### PR TITLE
Scala src directories (scalasrc & scalatestsrc) support

### DIFF
--- a/common/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.java
+++ b/common/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.java
@@ -105,10 +105,13 @@ public interface HybrisConstants {
     String QUERY_STORAGE_FOLDER_PATH = EXCLUDE_IDEA_DIRECTORY + File.separator + "consolestorage";
 
     String SRC_DIRECTORY = "src";
+    String SCALA_SRC_DIRECTORY = "scalasrc";
+    List<String> SRC_DIR_NAMES = Arrays.asList(SRC_DIRECTORY, SCALA_SRC_DIRECTORY);
     String GEN_SRC_DIRECTORY = "gensrc";
     String TEST_SRC_DIRECTORY = "testsrc";
     String GROOVY_TEST_SRC_DIRECTORY = "groovytestsrc";
-    List<String> TEST_SRC_DIR_NAMES = Arrays.asList(TEST_SRC_DIRECTORY, GROOVY_TEST_SRC_DIRECTORY);
+    String SCALA_TEST_SRC_DIRECTORY = "scalatestsrc";
+    List<String> TEST_SRC_DIR_NAMES = Arrays.asList(TEST_SRC_DIRECTORY, GROOVY_TEST_SRC_DIRECTORY, SCALA_TEST_SRC_DIRECTORY);
     String HMC_MODULE_DIRECTORY = "hmc";
     String HAC_MODULE_DIRECTORY = "hac";
     String HAC_MODULE_EXTENSION_NAME = "hac";

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -481,6 +481,6 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     }
 
     private boolean srcDirectoriesExists(final File webModuleDirectory) {
-        return TEST_SRC_DIR_NAMES.stream().map(s -> new File(webModuleDirectory, s).exists()).findAny().isPresent();
+        return TEST_SRC_DIR_NAMES.stream().anyMatch(s -> new File(webModuleDirectory, s).exists());
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -64,7 +64,7 @@ import static com.intellij.idea.plugin.hybris.common.HybrisConstants.PLATFORM_TO
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.PLATFORM_TOMCAT_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.RESOURCES_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.SETTINGS_DIRECTORY;
-import static com.intellij.idea.plugin.hybris.common.HybrisConstants.SRC_DIRECTORY;
+import static com.intellij.idea.plugin.hybris.common.HybrisConstants.SRC_DIR_NAMES;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.TEST_CLASSES_DIRECTORY;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.TEST_SRC_DIR_NAMES;
 import static com.intellij.idea.plugin.hybris.common.HybrisConstants.WEB_INF_CLASSES_DIRECTORY;
@@ -140,12 +140,14 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
         Validate.notNull(moduleDescriptor);
         Validate.notNull(contentEntry);
 
-        addSourceFolderIfNotIgnored(
-            contentEntry,
-            new File(moduleDescriptor.getRootDirectory(), SRC_DIRECTORY),
-            JavaSourceRootType.SOURCE,
-            dirsToIgnore
-        );
+        for (String srcDirName : SRC_DIR_NAMES) {
+            addSourceFolderIfNotIgnored(
+                contentEntry,
+                new File(moduleDescriptor.getRootDirectory(), srcDirName),
+                JavaSourceRootType.SOURCE,
+                dirsToIgnore
+            );
+        }
 
         addSourceFolderIfNotIgnored(
             contentEntry,
@@ -233,11 +235,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             return;
         }
 
-        final File additionalSrcDirectory = new File(additionalModuleDirectory, SRC_DIRECTORY);
-        contentEntry.addSourceFolder(
-            VfsUtil.pathToUrl(additionalSrcDirectory.getAbsolutePath()),
-            JavaSourceRootType.SOURCE
-        );
+        for (String srcDirName : SRC_DIR_NAMES) {
+            final File additionalSrcDirectory = new File(additionalModuleDirectory, srcDirName);
+            contentEntry.addSourceFolder(
+                VfsUtil.pathToUrl(additionalSrcDirectory.getAbsolutePath()),
+                JavaSourceRootType.SOURCE
+            );
+        }
 
         final File additionalResourcesDirectory = new File(additionalModuleDirectory, RESOURCES_DIRECTORY);
         contentEntry.addSourceFolder(
@@ -299,11 +303,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             moduleDescriptor.getRootDirectory(), BACK_OFFICE_MODULE_DIRECTORY
         );
 
-        final File backOfficeSrcDirectory = new File(backOfficeModuleDirectory, SRC_DIRECTORY);
-        contentEntry.addSourceFolder(
-            VfsUtil.pathToUrl(backOfficeSrcDirectory.getAbsolutePath()),
-            JavaSourceRootType.SOURCE
-        );
+        for (String srcDirName : SRC_DIR_NAMES) {
+            final File backOfficeSrcDirectory = new File(backOfficeModuleDirectory, srcDirName);
+            contentEntry.addSourceFolder(
+                VfsUtil.pathToUrl(backOfficeSrcDirectory.getAbsolutePath()),
+                JavaSourceRootType.SOURCE
+            );
+        }
 
         if (moduleDescriptor instanceof CustomHybrisModuleDescriptor || !moduleDescriptor.getRootProjectDescriptor()
                                                                                          .isExcludeTestSources()) {
@@ -360,11 +366,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     ) {
         Validate.notNull(moduleDescriptor);
 
-        final File webSrcDirectory = new File(webModuleDirectory, SRC_DIRECTORY);
-        contentEntry.addSourceFolder(
-            VfsUtil.pathToUrl(webSrcDirectory.getAbsolutePath()),
-            JavaSourceRootType.SOURCE
-        );
+        for (String srcDirName : SRC_DIR_NAMES) {
+            final File webSrcDirectory = new File(webModuleDirectory, srcDirName);
+            contentEntry.addSourceFolder(
+                VfsUtil.pathToUrl(webSrcDirectory.getAbsolutePath()),
+                JavaSourceRootType.SOURCE
+            );
+        }
 
         final File webGenSrcDirectory = new File(webModuleDirectory, GEN_SRC_DIRECTORY);
         contentEntry.addSourceFolder(
@@ -466,9 +474,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             excludeDirectory(contentEntry, new File(rootDirectory, WEB_INF_CLASSES_DIRECTORY));
         } else if (
             !moduleDescriptor.getRootProjectDescriptor().isImportOotbModulesInReadOnlyMode() &&
-            new File(webModuleDirectory, SRC_DIRECTORY).exists()
+            srcDirectoriesExists(webModuleDirectory)
         ) {
             excludeDirectory(contentEntry, new File(rootDirectory, WEB_INF_CLASSES_DIRECTORY));
         }
+    }
+
+    private boolean srcDirectoriesExists(final File webModuleDirectory) {
+        return TEST_SRC_DIR_NAMES.stream().map(s -> new File(webModuleDirectory, s).exists()).findAny().isPresent();
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/RegularHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/RegularHybrisModuleDescriptor.java
@@ -219,11 +219,13 @@ public abstract class RegularHybrisModuleDescriptor extends AbstractHybrisModule
                     false, true
                 ));
 
-                libs.add(new DefaultJavaLibraryDescriptor(
-                    new File(this.getRootDirectory(), HybrisConstants.JAVA_COMPILER_OUTPUT_PATH),
-                    new File(this.getRootDirectory(), HybrisConstants.SRC_DIRECTORY),
-                    true, true
-                ));
+                for (String srcDirName : HybrisConstants.SRC_DIR_NAMES) {
+                    libs.add(new DefaultJavaLibraryDescriptor(
+                        new File(this.getRootDirectory(), HybrisConstants.JAVA_COMPILER_OUTPUT_PATH),
+                        new File(this.getRootDirectory(), srcDirName),
+                        true, true
+                    ));
+                }
 
                 libs.add(new DefaultJavaLibraryDescriptor(
                     new File(this.getRootDirectory(), HybrisConstants.RESOURCES_DIRECTORY),
@@ -337,9 +339,11 @@ public abstract class RegularHybrisModuleDescriptor extends AbstractHybrisModule
         if (serverJars == null || serverJars.length == 0) {
             return;
         }
-        final File srcDir = new File(this.getRootDirectory(), HybrisConstants.SRC_DIRECTORY);
-        for (File serverJar: serverJars) {
-            libs.add(new DefaultJavaLibraryDescriptor(serverJar, srcDir.isDirectory() ? srcDir : null, true, true));
+        for (String srcDirName : HybrisConstants.SRC_DIR_NAMES) {
+            final File srcDir = new File(this.getRootDirectory(), srcDirName);
+            for (File serverJar : serverJars) {
+                libs.add(new DefaultJavaLibraryDescriptor(serverJar, srcDir.isDirectory() ? srcDir : null, true, true));
+            }
         }
     }
 


### PR DESCRIPTION
OOTB plugin marks as sources only `src` and `gensrc` directories and `testsrc` and `groovytestsrc` as test sources. If a project uses scala then you need to mark separately located scala source directories manually every time you refresh a project. This pull request contains changes that add `scalasrc` and `scalatestsrc` as source and test source directories to a module structure during import and refresh of a project.