### PR TITLE
IIP-17/ Feature. Download and attach maven artifacts' javadocs and sources to related …

### DIFF
--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -165,6 +165,8 @@ hybris.stats.permission.checkbox=I agree to send statistics for the plugin devel
 
 hybris.project.view.tree.settings=Project Tree Settings
 hybris.project.view.tree.hide.empty.middle.folders=Hide Empty Middle Folders
+hybris.project.maven.download.sources.folders=Download and attach Maven artifacts sources
+hybris.project.maven.download.javadocs.folders=Download and attach Maven artifacts javadocs
 
 hybris.inspection.tsv.key=hybris TSV Inspections
 

--- a/src/com/intellij/idea/plugin/hybris/common/LibraryDescriptorType.java
+++ b/src/com/intellij/idea/plugin/hybris/common/LibraryDescriptorType.java
@@ -1,0 +1,23 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.common;
+
+public enum LibraryDescriptorType {
+    UNKNOWN, LIB, WEB_INF_LIB
+}

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/JavadocModuleConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/JavadocModuleConfigurator.java
@@ -19,6 +19,7 @@
 package com.intellij.idea.plugin.hybris.project.configurators;
 
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,6 +30,7 @@ public interface JavadocModuleConfigurator {
 
     void configure(
         @NotNull ModifiableRootModel modifiableRootModel,
-        @NotNull HybrisModuleDescriptor moduleDescriptor
+        @NotNull HybrisModuleDescriptor moduleDescriptor,
+        final @NotNull ProgressIndicator indicator
     );
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/LibRootsConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/LibRootsConfigurator.java
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.project.configurators;
 
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
 import com.intellij.openapi.externalSystem.service.project.IdeModifiableModelsProvider;
+import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,7 +35,8 @@ public interface LibRootsConfigurator {
     void configure(
         @NotNull ModifiableRootModel modifiableRootModel,
         @NotNull HybrisModuleDescriptor moduleDescriptor,
-        @NotNull IdeModifiableModelsProvider modifiableModelsProvider
+        @NotNull IdeModifiableModelsProvider modifiableModelsProvider,
+        @NotNull ProgressIndicator indicator
     );
 
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultSpringConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultSpringConfigurator.java
@@ -43,11 +43,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.intellij.openapi.util.io.FileUtilRt.toSystemDependentName;
@@ -119,7 +122,10 @@ public class DefaultSpringConfigurator implements SpringConfigurator {
             return;
         }
 
-        for (HybrisModuleDescriptor dependsOnModule : moduleDescriptor.getDependenciesTree()) {
+        final Set<HybrisModuleDescriptor> dependenciesTree = moduleDescriptor.getDependenciesTree();
+        final List<HybrisModuleDescriptor> sortedDependenciesTree = dependenciesTree.stream().sorted().collect(
+            Collectors.toList());
+        for (HybrisModuleDescriptor dependsOnModule : sortedDependenciesTree) {
             final SpringFileSet parentFileSet = getSpringFileSet(modifiableFacetModelMap, dependsOnModule.getName());
             if (parentFileSet == null) {
                 continue;

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/MavenUtils.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/MavenUtils.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.project.configurators.impl;
+
+import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.idea.maven.model.MavenArtifact;
+import org.jetbrains.idea.maven.model.MavenExplicitProfiles;
+import org.jetbrains.idea.maven.model.MavenId;
+import org.jetbrains.idea.maven.project.MavenArtifactDownloader;
+import org.jetbrains.idea.maven.project.MavenEmbeddersManager;
+import org.jetbrains.idea.maven.project.MavenGeneralSettings;
+import org.jetbrains.idea.maven.project.MavenProjectReader;
+import org.jetbrains.idea.maven.project.MavenProjectReaderProjectLocator;
+import org.jetbrains.idea.maven.project.MavenProjectReaderResult;
+import org.jetbrains.idea.maven.project.MavenProjectsManager;
+import org.jetbrains.idea.maven.project.MavenProjectsTree;
+import org.jetbrains.idea.maven.project.MavenWorkspaceSettings;
+import org.jetbrains.idea.maven.project.MavenWorkspaceSettingsComponent;
+import org.jetbrains.idea.maven.server.MavenEmbedderWrapper;
+import org.jetbrains.idea.maven.utils.MavenArtifactUtil;
+import org.jetbrains.idea.maven.utils.MavenProcessCanceledException;
+import org.jetbrains.idea.maven.utils.MavenProgressIndicator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public interface MavenUtils {
+
+    Logger LOG = LoggerFactory.getLogger(MavenUtils.class);
+
+    @NotNull
+     static List<String> resolveMavenJavadocs(
+        final @NotNull ModifiableRootModel modifiableRootModel,
+        final @NotNull HybrisModuleDescriptor moduleDescriptor,
+        final @NotNull ProgressIndicator progressIndicator
+    ) {
+        final HybrisApplicationSettings appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
+        if (appSettings.isWithMavenJavadocs()) {
+            return resolveMavenDependencies(modifiableRootModel, moduleDescriptor, progressIndicator, false, true);
+        }
+        return Collections.emptyList();
+    }
+
+     static List<String> resolveMavenSources(
+        final @NotNull ModifiableRootModel modifiableRootModel,
+        final @NotNull HybrisModuleDescriptor moduleDescriptor,
+        final @NotNull ProgressIndicator progressIndicator
+    ) {
+        final HybrisApplicationSettings appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
+        if (appSettings.isWithMavenSources()) {
+            return resolveMavenDependencies(modifiableRootModel, moduleDescriptor, progressIndicator, true, false);
+        }
+        return Collections.emptyList();
+    }
+
+    @NotNull
+    private static List<String> resolveMavenDependencies(
+        final @NotNull ModifiableRootModel modifiableRootModel,
+        final @NotNull HybrisModuleDescriptor moduleDescriptor,
+        final @NotNull ProgressIndicator progressIndicator, final boolean downloadSources, final boolean downloadDocs
+    ) {
+        final List<String> resultPathList = new ArrayList<>();
+
+        final File moduleDir = moduleDescriptor.getRootDirectory();
+        final File mavenDescriptorFile = new File(moduleDir, "external-dependencies.xml");
+        if (mavenDescriptorFile.exists()) {
+            final MavenProjectReader mavenProjectReader = new MavenProjectReader(modifiableRootModel.getProject());
+            final VirtualFile vfsMavenDescriptor = VfsUtil.findFileByIoFile(mavenDescriptorFile, false);
+
+            final @NotNull Project project = modifiableRootModel.getProject();
+            final MavenWorkspaceSettings settings = MavenWorkspaceSettingsComponent.getInstance(project).getSettings();
+
+            final String moduleDirPath = moduleDir.getAbsolutePath();
+            final MavenEmbeddersManager embeddersManager = new MavenEmbeddersManager(project);
+            final MavenEmbedderWrapper embedder = embeddersManager.getEmbedder(
+                MavenEmbeddersManager.FOR_DEPENDENCIES_RESOLVE,
+                moduleDirPath,
+                moduleDirPath
+            );
+            final MavenGeneralSettings generalSettings = settings.generalSettings;
+            generalSettings.setNonRecursive(true);
+
+            final MavenProjectsTree mavenProjectsTree = new MavenProjectsTree(project);
+            final MavenProjectReaderProjectLocator myProjectLocator = mavenProjectsTree.getProjectLocator();
+
+            try {
+                final Collection<MavenProjectReaderResult> mavenProjects = mavenProjectReader.resolveProject(
+                    generalSettings,
+                    embedder,
+                    Collections.singleton(vfsMavenDescriptor),
+                    MavenExplicitProfiles.NONE,
+                    myProjectLocator
+                );
+
+                for (MavenProjectReaderResult mavenProjectReaderResult : mavenProjects) {
+                    final MavenProjectsManager manager = MavenProjectsManager.getInstance(project);
+
+                    final MavenProgressIndicator indicator = new MavenProgressIndicator(manager::getSyncConsole);
+                    indicator.setIndicator(progressIndicator);
+                    final List<MavenArtifact> dependencies = mavenProjectReaderResult.mavenModel.getDependencies();
+
+                    mavenProjectsTree.resetManagedFilesAndProfiles(
+                        Collections.singletonList(vfsMavenDescriptor),
+                        MavenExplicitProfiles.NONE
+                    );
+                    mavenProjectsTree.updateAll(false, generalSettings, indicator);
+
+                    mavenProjectsTree.getProjects().get(0).getDependencies().addAll(dependencies);
+                    final MavenArtifactDownloader.DownloadResult downloadResult = MavenArtifactDownloader.download(
+                        project,
+                        mavenProjectsTree,
+                        mavenProjectsTree.getProjects(),
+                        dependencies,
+                        downloadSources,
+                        downloadDocs,
+                        embedder,
+                        indicator
+                    );
+                    if (downloadDocs) {
+                        for (final MavenId resolvedDoc : downloadResult.resolvedDocs) {
+                            final File libFile = getArtifactLib(manager, resolvedDoc);
+                            final String resultJarPath = libFile.getAbsolutePath().replace(".jar", "-javadoc.jar");
+                            resultPathList.add(resultJarPath);
+                        }
+                    }
+                    if (downloadSources) {
+                        for (final MavenId resolvedDoc : downloadResult.resolvedSources) {
+                            final File libFile = getArtifactLib(manager, resolvedDoc);
+                            final String resultJarPath = libFile.getAbsolutePath().replace(".jar", "-sources.jar");
+                            resultPathList.add(resultJarPath);
+                        }
+                    }
+                }
+
+            } catch (MavenProcessCanceledException e) {
+                LOG.error("Unable to generate pseudo-maven dependencies", e);
+            }
+            resultPathList.sort(String::compareTo);
+        }
+        return resultPathList;
+    }
+
+    @NotNull
+    static File getArtifactLib(final MavenProjectsManager manager, final MavenId resolvedDoc) {
+        return MavenArtifactUtil
+            .getArtifactFile(
+                manager.getLocalRepository(),
+                resolvedDoc.getGroupId(),
+                resolvedDoc.getArtifactId(),
+                resolvedDoc.getVersion(),
+                "jar"
+            );
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -47,9 +48,9 @@ public abstract class AbstractHybrisModuleDescriptor implements HybrisModuleDesc
     @NotNull
     protected final HybrisProjectDescriptor rootProjectDescriptor;
     @NotNull
-    protected final Set<HybrisModuleDescriptor> dependenciesTree = new HashSet<HybrisModuleDescriptor>(0);
+    protected final Set<HybrisModuleDescriptor> dependenciesTree = new HashSet<>(0);
     @NotNull
-    protected Set<String> springFileSet = new HashSet<String>();
+    protected Set<String> springFileSet = new LinkedHashSet<>();
 
     private boolean inLocalExtensions;
     private IMPORT_STATUS importStatus = IMPORT_STATUS.UNUSED;

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -110,6 +110,8 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     protected File externalConfigDirectory;
     @Nullable
     protected File externalDbDriversDirectory;
+    private boolean withMavenSources;
+    private boolean withMavenJavadocs;
     @Nullable
     protected String javadocUrl;
     @Nullable
@@ -900,6 +902,26 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     @Override
     public void setExternalDbDriversDirectory(@Nullable final File externalDbDriversDirectory) {
         this.externalDbDriversDirectory = externalDbDriversDirectory;
+    }
+
+    @Override
+    public boolean isWithMavenSources() {
+        return withMavenSources;
+    }
+
+    @Override
+    public void setWithMavenSources(final boolean withMavenSources) {
+        this.withMavenSources = withMavenSources;
+    }
+
+    @Override
+    public boolean isWithMavenJavadocs() {
+        return withMavenJavadocs;
+    }
+
+    @Override
+    public void setWithMavenJavadocs(final boolean withMavenJavadocs) {
+        this.withMavenJavadocs = withMavenJavadocs;
     }
 
     @Nullable

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultJavaLibraryDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultJavaLibraryDescriptor.java
@@ -18,6 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.project.descriptors;
 
+import com.intellij.idea.plugin.hybris.common.LibraryDescriptorType;
 import com.intellij.openapi.roots.DependencyScope;
 import com.intellij.openapi.util.io.FileUtil;
 import org.apache.commons.lang3.Validate;
@@ -40,6 +41,8 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
     private final File sourcesFile;
     private final boolean isExported;
     private final boolean isDirectoryWithClasses;
+    private final LibraryDescriptorType descriptorType;
+
     @NotNull
     private final DependencyScope scope;
 
@@ -54,6 +57,22 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
         this.isExported = isExported;
         this.isDirectoryWithClasses = false;
         this.scope = DependencyScope.COMPILE;
+        this.descriptorType = LibraryDescriptorType.UNKNOWN;
+    }
+
+    public DefaultJavaLibraryDescriptor(
+        @NotNull final File libraryFile,
+        final boolean isExported,
+        final LibraryDescriptorType descriptorType
+    ) {
+        Validate.notNull(libraryFile);
+
+        this.libraryFile = libraryFile;
+        this.sourcesFile = null;
+        this.isExported = isExported;
+        this.isDirectoryWithClasses = false;
+        this.scope = DependencyScope.COMPILE;
+        this.descriptorType = descriptorType;
     }
 
     public DefaultJavaLibraryDescriptor(
@@ -69,6 +88,7 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
         this.isExported = isExported;
         this.isDirectoryWithClasses = false;
         this.scope = DependencyScope.COMPILE;
+        descriptorType = LibraryDescriptorType.UNKNOWN;
     }
 
     public DefaultJavaLibraryDescriptor(
@@ -83,6 +103,7 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
         this.isExported = isExported;
         this.isDirectoryWithClasses = isDirectoryWithClasses;
         this.scope = DependencyScope.COMPILE;
+        descriptorType = LibraryDescriptorType.UNKNOWN;
     }
 
     public DefaultJavaLibraryDescriptor(
@@ -98,6 +119,7 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
         this.isExported = isExported;
         this.isDirectoryWithClasses = isDirectoryWithClasses;
         this.scope = DependencyScope.COMPILE;
+        descriptorType = LibraryDescriptorType.UNKNOWN;
     }
 
     @NotNull
@@ -136,6 +158,10 @@ public class DefaultJavaLibraryDescriptor implements JavaLibraryDescriptor {
     @Override
     public int compareTo(@NotNull final JavaLibraryDescriptor o) {
         return FileUtil.compareFiles(this.libraryFile, o.getLibraryFile());
+    }
+
+    public LibraryDescriptorType getDescriptorType() {
+        return descriptorType;
     }
 
     @Override

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
@@ -135,4 +135,12 @@ public interface HybrisProjectDescriptor {
     String getHybrisVersion();
 
     Set<File> getDetectedVcs();
+
+    boolean isWithMavenSources();
+
+    void setWithMavenSources(boolean withMavenSources);
+
+    boolean isWithMavenJavadocs();
+
+    void setWithMavenJavadocs(boolean withMavenJavadocs);
 }

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/RegularHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/RegularHybrisModuleDescriptor.java
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.project.descriptors;
 
 import com.google.common.collect.Sets;
 import com.intellij.idea.plugin.hybris.common.HybrisConstants;
+import com.intellij.idea.plugin.hybris.common.LibraryDescriptorType;
 import com.intellij.idea.plugin.hybris.common.services.CommonIdeaService;
 import com.intellij.idea.plugin.hybris.project.exceptions.HybrisConfigurationException;
 import com.intellij.idea.plugin.hybris.project.settings.jaxb.extensioninfo.ExtensionInfo;
@@ -265,7 +266,8 @@ public abstract class RegularHybrisModuleDescriptor extends AbstractHybrisModule
 
         libs.add(new DefaultJavaLibraryDescriptor(
             new File(this.getRootDirectory(), HybrisConstants.LIB_DIRECTORY),
-            true
+            true,
+            LibraryDescriptorType.LIB
         ));
 
         libs.add(new DefaultJavaLibraryDescriptor(

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -77,7 +77,6 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.JavaSdkVersion;
-import com.intellij.openapi.projectRoots.JdkVersionUtil;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.LanguageLevelProjectExtension;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -227,7 +226,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
             modifiableRootModel.inheritSdk();
 
             indicator.setText2(HybrisI18NBundleUtils.message("hybris.project.import.module.libs"));
-            libRootsConfigurator.configure(modifiableRootModel, moduleDescriptor, modifiableModelsProvider);
+            libRootsConfigurator.configure(modifiableRootModel, moduleDescriptor, modifiableModelsProvider, indicator);
             indicator.setText2(HybrisI18NBundleUtils.message("hybris.project.import.module.content"));
 
             if (shouldBeTreatedAsReadOnly(moduleDescriptor)) {
@@ -238,7 +237,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
             indicator.setText2(HybrisI18NBundleUtils.message("hybris.project.import.module.outputpath"));
             compilerOutputPathsConfigurator.configure(modifiableRootModel, moduleDescriptor);
             indicator.setText2(HybrisI18NBundleUtils.message("hybris.project.import.module.javadoc"));
-            javadocModuleConfigurator.configure(modifiableRootModel, moduleDescriptor);
+            javadocModuleConfigurator.configure(modifiableRootModel, moduleDescriptor,indicator);
             indicator.setText2(HybrisI18NBundleUtils.message("hybris.project.import.module.groups"));
             groupModuleConfigurator.configure(rootProjectModifiableModel, javaModule, moduleDescriptor);
 

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -431,6 +431,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
             appSettings.setExternalDbDriversDirectory("");
         }
 
+        appSettings.setWithMavenSources(hybrisProjectDescriptor.isWithMavenSources());
+        appSettings.setWithMavenJavadocs(hybrisProjectDescriptor.isWithMavenJavadocs());
+
         hybrisProjectSettings.setCreateBackwardCyclicDependenciesForAddOns(hybrisProjectDescriptor.isCreateBackwardCyclicDependenciesForAddOn());
         final File sourceCodeFile = hybrisProjectDescriptor.getSourceCodeFile();
 

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.intellij.idea.plugin.hybris.project.wizard.HybrisWorkspaceRootStep">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="17" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="19" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="773" height="744"/>
+      <xy x="20" y="20" width="773" height="771"/>
     </constraints>
     <properties>
       <enabled value="false"/>
@@ -351,7 +351,7 @@
       </grid>
       <vspacer id="286f1">
         <constraints>
-          <grid row="16" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="18" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="5e798" class="javax.swing.JLabel" binding="dbDriversDirOverrideLabel">
@@ -416,6 +416,38 @@
         </constraints>
         <properties>
           <text resource-bundle="i18n/HybrisBundle" key="hybris.import.wizard.exclude.test.sources.label"/>
+        </properties>
+      </component>
+      <component id="b043e" class="javax.swing.JCheckBox" binding="withMavenSources">
+        <constraints>
+          <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="7f7a9" class="javax.swing.JCheckBox" binding="withMavenJavadocs">
+        <constraints>
+          <grid row="17" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
+      <component id="34f32" class="javax.swing.JLabel" binding="withMavenSourcesLabel">
+        <constraints>
+          <grid row="16" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.maven.download.sources.folders"/>
+        </properties>
+      </component>
+      <component id="a16ac" class="javax.swing.JLabel" binding="withMavenJavadocsLabel">
+        <constraints>
+          <grid row="17" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.maven.download.javadocs.folders"/>
         </properties>
       </component>
     </children>

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
@@ -104,7 +104,12 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
     private JCheckBox scanThroughExternalModuleCheckbox;
     private JCheckBox excludeTestSourcesCheckBox;
     private JLabel excludeTestSourcesLabel;
+    private JCheckBox withMavenSources;
+    private JCheckBox withMavenJavadocs;
+    private JLabel withMavenJavadocsLabel;
+    private JLabel withMavenSourcesLabel;
     private String hybrisVersion;
+
     public HybrisWorkspaceRootStep(final WizardContext context) {
         super(context);
 
@@ -308,6 +313,8 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
         this.getContext().getHybrisProjectDescriptor().setCreateBackwardCyclicDependenciesForAddOns(
             this.circularDependencyCheckBox.isSelected()
         );
+        this.getContext().getHybrisProjectDescriptor().setWithMavenSources(withMavenSources.isSelected());
+        this.getContext().getHybrisProjectDescriptor().setWithMavenJavadocs(withMavenJavadocs.isSelected());
 
         this.getContext().getHybrisProjectDescriptor().setJavadocUrl(
             this.javadocUrlTextField.getText()
@@ -315,7 +322,9 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
 
         this.getContext().getHybrisProjectDescriptor().setHybrisVersion(hybrisVersion);
 
-        LOG.info("importing a project with the following settings: "+this.getContext().getHybrisProjectDescriptor().toString());
+        LOG.info("importing a project with the following settings: " + this.getContext()
+                                                                           .getHybrisProjectDescriptor()
+                                                                           .toString());
 
         this.getContext().setRootProjectDirectory(toFile(this.getContext().getFileToImport()));
     }

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
@@ -106,6 +106,12 @@ public class HybrisApplicationSettings {
     @PropertyName("followSymlink")
     private boolean followSymlink = true;
 
+    @PropertyName("withMavenSources")
+    private boolean withMavenSources = true;
+
+    @PropertyName("withMavenJavadocs")
+    private boolean withMavenJavadocs = true;
+
     @PropertyName("allowedSendingPlainStatistics")
     private boolean allowedSendingPlainStatistics = false;
 
@@ -249,6 +255,22 @@ public class HybrisApplicationSettings {
         this.followSymlink = followSymlink;
     }
 
+    public boolean isWithMavenSources() {
+        return withMavenSources;
+    }
+
+    public void setWithMavenSources(final boolean withMavenSources) {
+        this.withMavenSources = withMavenSources;
+    }
+
+    public boolean isWithMavenJavadocs() {
+        return withMavenJavadocs;
+    }
+
+    public void setWithMavenJavadocs(final boolean withMavenJavadocs) {
+        this.withMavenJavadocs = withMavenJavadocs;
+    }
+
     public boolean isAllowedSendingPlainStatistics() {
         return allowedSendingPlainStatistics;
     }
@@ -346,6 +368,8 @@ public class HybrisApplicationSettings {
             .append(hideEmptyMiddleFolders)
             .append(defaultPlatformInReadOnly)
             .append(followSymlink)
+            .append(withMavenSources)
+            .append(withMavenJavadocs)
             .append(scanThroughExternalModule)
             .append(allowedSendingPlainStatistics)
             .append(disallowedSendingStatistics)
@@ -386,6 +410,8 @@ public class HybrisApplicationSettings {
             .append(hideEmptyMiddleFolders, other.hideEmptyMiddleFolders)
             .append(defaultPlatformInReadOnly, other.defaultPlatformInReadOnly)
             .append(followSymlink, other.followSymlink)
+            .append(withMavenSources, other.withMavenSources)
+            .append(withMavenJavadocs, other.withMavenJavadocs)
             .append(scanThroughExternalModule, other.scanThroughExternalModule)
             .append(allowedSendingPlainStatistics, other.allowedSendingPlainStatistics)
             .append(disallowedSendingStatistics, other.disallowedSendingStatistics)
@@ -417,6 +443,8 @@ public class HybrisApplicationSettings {
         sb.append(", hideEmptyMiddleFolders='").append(hideEmptyMiddleFolders).append('\'');
         sb.append(", defaultPlatformInReadOnly='").append(defaultPlatformInReadOnly).append('\'');
         sb.append(", followSymlink='").append(followSymlink).append('\'');
+        sb.append(", withMavenSources='").append(withMavenSources).append('\'');
+        sb.append(", withMavenJavadocs='").append(withMavenJavadocs).append('\'');
         sb.append(", scanThroughExternalModule='").append(scanThroughExternalModule).append('\'');
         sb.append(", allowedSendingPlainStatistics='").append(allowedSendingPlainStatistics).append('\'');
         sb.append(", disallowedSendingStatistics='").append(disallowedSendingStatistics).append('\'');

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.HashSet;
 import java.util.List;
 
 public class HybrisApplicationSettings {
@@ -107,10 +106,10 @@ public class HybrisApplicationSettings {
     private boolean followSymlink = true;
 
     @PropertyName("withMavenSources")
-    private boolean withMavenSources = true;
+    private boolean withMavenSources;
 
     @PropertyName("withMavenJavadocs")
-    private boolean withMavenJavadocs = true;
+    private boolean withMavenJavadocs;
 
     @PropertyName("allowedSendingPlainStatistics")
     private boolean allowedSendingPlainStatistics = false;

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
@@ -111,7 +111,7 @@
           <grid row="9" column="0" row-span="1" col-span="5" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
-      <grid id="410c1" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="410c1" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="13" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -157,7 +157,7 @@
           </component>
           <component id="a14f2" class="javax.swing.JCheckBox" binding="scanThroughExternalModule">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -166,7 +166,7 @@
           </component>
           <component id="7c462" class="javax.swing.JCheckBox" binding="excludeTestSources">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -175,10 +175,28 @@
           </component>
           <component id="aeae3" class="javax.swing.JCheckBox" binding="warnIfGeneratedItemsAreOutOfDateCheckBox">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.ts.items.validation.settings.enabled"/>
+            </properties>
+          </component>
+          <component id="ed275" class="javax.swing.JCheckBox" binding="withMavenJavadocs">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text resource-bundle="i18n/HybrisBundle" key="hybris.project.maven.download.javadocs.folders"/>
+            </properties>
+          </component>
+          <component id="8d1e4" class="javax.swing.JCheckBox" binding="withMavenSources">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <selected value="false"/>
+              <text resource-bundle="i18n/HybrisBundle" key="hybris.project.maven.download.sources.folders"/>
             </properties>
           </component>
         </children>

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
@@ -57,6 +57,8 @@ public class HybrisApplicationSettingsForm {
     private JCheckBox defaultPlatformInReadOnly;
     private JTextField groupPlatformTextField;
     private JCheckBox followSymlink;
+    private JCheckBox withMavenSources;
+    private JCheckBox withMavenJavadocs;
     private JPanel typeSystemDiagramStopWords;
     private JCheckBox scanThroughExternalModule;
     private JCheckBox excludeTestSources;
@@ -83,6 +85,8 @@ public class HybrisApplicationSettingsForm {
         hideEmptyMiddleFoldersCheckBox.setSelected(data.isHideEmptyMiddleFolders());
         defaultPlatformInReadOnly.setSelected(data.isDefaultPlatformInReadOnly());
         followSymlink.setSelected(data.isFollowSymlink());
+        withMavenSources.setSelected(data.isWithMavenSources());
+        withMavenJavadocs.setSelected(data.isWithMavenJavadocs());
         scanThroughExternalModule.setSelected(data.isScanThroughExternalModule());
         excludeTestSources.setSelected(data.isExcludeTestSources());
         warnIfGeneratedItemsAreOutOfDateCheckBox.setSelected(data.isWarnIfGeneratedItemsAreOutOfDate());
@@ -104,6 +108,8 @@ public class HybrisApplicationSettingsForm {
         data.setHideEmptyMiddleFolders(hideEmptyMiddleFoldersCheckBox.isSelected());
         data.setDefaultPlatformInReadOnly(defaultPlatformInReadOnly.isSelected());
         data.setFollowSymlink(followSymlink.isSelected());
+        data.setWithMavenJavadocs(withMavenSources.isSelected());
+        data.setWithMavenJavadocs(withMavenJavadocs.isSelected());
         data.setScanThroughExternalModule(scanThroughExternalModule.isSelected());
         data.setExcludeTestSources(excludeTestSources.isSelected());
         data.setWarnIfGeneratedItemsAreOutOfDate(warnIfGeneratedItemsAreOutOfDateCheckBox.isSelected());
@@ -156,6 +162,12 @@ public class HybrisApplicationSettingsForm {
             return true;
         }
         if (followSymlink.isSelected() != data.isFollowSymlink()) {
+            return true;
+        }
+        if (withMavenSources.isSelected() != data.isWithMavenSources()) {
+            return true;
+        }
+        if (withMavenJavadocs.isSelected() != data.isWithMavenJavadocs()) {
             return true;
         }
         if (excludeTestSources.isSelected() != data.isExcludeTestSources()) {


### PR DESCRIPTION
…extensions.

Related artifacts list is based on `external-dependencies.xml` files, artifacts with "-javadoc.jar" or with "-sources.jar" suffixes.

Minor fix for ordering elements in `*.iml` files - more predicted, sorted or ordered elements allows compare and commit `*.iml` easier.

Signed-off-by: Viktors Jengovatovs <viktors.jengovatovs@pearlconsulting.no>

Signed-off-by: Your Real Name your.email@email.com
