### PR TITLE
Minor fix for ordering elements in `*.iml` files - more predicted, so…

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
@@ -48,7 +48,7 @@ public abstract class AbstractHybrisModuleDescriptor implements HybrisModuleDesc
     @NotNull
     protected final HybrisProjectDescriptor rootProjectDescriptor;
     @NotNull
-    protected final Set<HybrisModuleDescriptor> dependenciesTree = new HashSet<>(0);
+    protected final Set<HybrisModuleDescriptor> dependenciesTree = new LinkedHashSet<>(0);
     @NotNull
     protected Set<String> springFileSet = new LinkedHashSet<>();
 

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/SelectHybrisModulesToImportStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/SelectHybrisModulesToImportStep.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -157,6 +158,7 @@ public class SelectHybrisModulesToImportStep extends AbstractSelectModulesToImpo
         final List<HybrisModuleDescriptor> filteredModuleToImport = moduleToImport
             .stream()
             .filter(e->!modulesOnBlackList.contains(e.getRelativePath()))
+            .sorted(Comparator.nullsLast(Comparator.comparing(HybrisModuleDescriptor::getName)))
             .collect(Collectors.toList());
         try {
             this.getContext().setList(filteredModuleToImport);


### PR DESCRIPTION
…rted or ordered elements allows compare and commit `*.iml` easier.

Signed-off-by: Viktors Jengovatovs <viktors.jengovatovs@pearlconsulting.no>

Signed-off-by: Your Real Name your.email@email.com
