### PR TITLE
IIP-19 / investigation / fix. 'ant gradle' behaviour'

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -541,6 +541,15 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
             return;
         }
 
+        if (hybrisProjectService.isPlatformModule(rootProjectDirectory)) {
+            LOG.info("Detected platform module " + rootProjectDirectory.getAbsolutePath());
+            moduleRootMap.get(HYBRIS).add(rootProjectDirectory);
+
+            // scan for ext directories
+            scanSubrirectories(moduleRootMap, acceptOnlyHybrisModules, rootProjectDirectory.toPath(), progressListenerProcessor);
+            return;
+        }
+
         if (!acceptOnlyHybrisModules) {
             if (hybrisProjectService.isGradleModule(rootProjectDirectory) && !FileUtil.filesEqual(
                 rootProjectDirectory,
@@ -560,10 +569,7 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
                 return;
             }
 
-            if (hybrisProjectService.isPlatformModule(rootProjectDirectory)) {
-                LOG.info("Detected platform module " + rootProjectDirectory.getAbsolutePath());
-                moduleRootMap.get(HYBRIS).add(rootProjectDirectory);
-            } else if (hybrisProjectService.isEclipseModule(rootProjectDirectory) && !FileUtil.filesEqual(
+            if (hybrisProjectService.isEclipseModule(rootProjectDirectory) && !FileUtil.filesEqual(
                 rootProjectDirectory,
                 rootDirectory
             )) {


### PR DESCRIPTION
Signed-off-by: Rustam Burmenskyi rustam_burmenskyi@epam.com

In the newer versions of sap commerce the command 'ant gradle' can be executed within the platform directory.
That will generate the files build.gradle and settings.gradle. within the platform directory.
Those can be used to import the project as a Gradle project for IntelliJ.

Since then the platform directory was detected as a Gradle project and the subdirectories were not scanned for additional modules.