### PR TITLE
Do not index node_modules directories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     idea
     kotlin("jvm")
-    id("org.jetbrains.intellij") version "1.3.0"
+    id("org.jetbrains.intellij") version "1.5.2"
 }
 
 sourceSets.main {

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -89,6 +89,11 @@ hybris.import.settings.exclude.resources.popup.edit.title=Edit
 hybris.import.settings.exclude.resources.popup.edit.text=Edit Extension name
 hybris.import.settings.exclude.resources.popup.add.title=Add
 hybris.import.settings.exclude.resources.popup.add.text=Add Extension name
+hybris.import.settings.excludedFromIndex.directory.name=Excluded from index
+hybris.import.settings.excludedFromIndex.directory.popup.edit.title=Edit
+hybris.import.settings.excludedFromIndex.directory.popup.edit.text=Edit directory name
+hybris.import.settings.excludedFromIndex.directory.popup.add.title=Add
+hybris.import.settings.excludedFromIndex.directory.popup.add.text=Add directory name
 
 hybris.toolwindow.solr.ip=Solr IP address
 hybris.toolwindow.solr.label=Remote SOLR Instance

--- a/src/com/intellij/idea/plugin/hybris/indexing/HybrisDirectoryIndexExcludePolicy.kt
+++ b/src/com/intellij/idea/plugin/hybris/indexing/HybrisDirectoryIndexExcludePolicy.kt
@@ -18,6 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.indexing
 
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootModel
 import com.intellij.openapi.roots.impl.DirectoryIndexExcludePolicy
@@ -28,10 +29,6 @@ import com.intellij.openapi.vfs.pointers.VirtualFilePointer
 import com.intellij.openapi.vfs.pointers.VirtualFilePointerManager
 
 class HybrisDirectoryIndexExcludePolicy(val project: Project) : DirectoryIndexExcludePolicy {
-
-    companion object {
-        private val EXCLUDED_FOLDER_PATHS = setOf("smartedit-custom-build", "smartedit-build", "apps/**/node_modules", "common/temp/node_modules")
-    }
 
     override fun getExcludeRootsForModule(rootModel: ModuleRootModel): Array<VirtualFilePointer> {
         val contentRoots = rootModel.contentRoots
@@ -44,11 +41,17 @@ class HybrisDirectoryIndexExcludePolicy(val project: Project) : DirectoryIndexEx
 
     private fun getExcludedFoldersFromIndex(contentRoot: VirtualFile): List<VirtualFilePointer> {
         val excludedFoldersFromIndex = mutableListOf<VirtualFilePointer>()
-        EXCLUDED_FOLDER_PATHS.forEach { excludedFolderPath ->
+        getExcludedFromIndexList().forEach { excludedFolderPath ->
             VfsUtilCore.visitChildrenRecursively(contentRoot, HybrisExcludeFromIndexFileVisitor(project,
                     excludedFolderPath, excludedFoldersFromIndex, VirtualFileVisitor.SKIP_ROOT))
         }
         return excludedFoldersFromIndex
+    }
+
+    private fun getExcludedFromIndexList(): List<String> {
+        return HybrisApplicationSettingsComponent.getInstance()
+                .state
+                .excludedFromIndexList
     }
 
     class HybrisExcludeFromIndexFileVisitor(

--- a/src/com/intellij/idea/plugin/hybris/indexing/HybrisDirectoryIndexExcludePolicy.kt
+++ b/src/com/intellij/idea/plugin/hybris/indexing/HybrisDirectoryIndexExcludePolicy.kt
@@ -30,7 +30,9 @@ import com.intellij.openapi.vfs.pointers.VirtualFilePointerManager
 class HybrisDirectoryIndexExcludePolicy(val project : Project) : DirectoryIndexExcludePolicy {
 
     companion object {
-        private val EXCLUDED_FOLDER_PATHS = setOf("smartedit-custom-build", "smartedit-build")
+        private val EXCLUDED_FOLDER_PATHS = setOf("smartedit-custom-build", "smartedit-build", "node_modules")
+        private val EXCLUDED_FOLDER_PATHS_BY_KEY = mapOf(
+                "smartedit" to setOf("common/temp"))
     }
 
     override fun getExcludeRootsForModule(rootModel: ModuleRootModel): Array<VirtualFilePointer> {
@@ -44,6 +46,14 @@ class HybrisDirectoryIndexExcludePolicy(val project : Project) : DirectoryIndexE
 
     private fun getExcludedFoldersFromIndex(contentRoot : VirtualFile) : List<VirtualFilePointer>  {
         val excludedFoldersFromIndex = mutableListOf<VirtualFilePointer>()
+        EXCLUDED_FOLDER_PATHS_BY_KEY.forEach { excludedFolderPathMap ->
+            if (contentRoot.parent.name == excludedFolderPathMap.key) {
+                EXCLUDED_FOLDER_PATHS_BY_KEY[excludedFolderPathMap.key]?.forEach { excludedFolderPath ->
+                    VfsUtilCore.visitChildrenRecursively(contentRoot, HybrisExcludeFromIndexVirtualFileVisitor(project,
+                            excludedFolderPath, excludedFoldersFromIndex, VirtualFileVisitor.SKIP_ROOT))
+                }
+            }
+        }
         EXCLUDED_FOLDER_PATHS.forEach { excludedFolderPath ->
             VfsUtilCore.visitChildrenRecursively(contentRoot, HybrisExcludeFromIndexVirtualFileVisitor(project,
                 excludedFolderPath, excludedFoldersFromIndex, VirtualFileVisitor.SKIP_ROOT))

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettings.java
@@ -60,6 +60,13 @@ public class HybrisApplicationSettings {
         "npmancillary"
     );
 
+    public static final List<String> DEFAULT_EXCLUDED_FROM_INDEX = Lists.newArrayList(
+        "smartedit-custom-build",
+        "smartedit-build",
+        "apps/**/node_modules",
+        "common/temp/node_modules"
+    );
+
     @PropertyName("foldingEnabled")
     private boolean foldingEnabled = true;
 
@@ -141,6 +148,9 @@ public class HybrisApplicationSettings {
     @PropertyName("warnIfGeneratedItemsAreOutOfDate")
     private boolean warnIfGeneratedItemsAreOutOfDate = true;
 
+    @PropertyName("excludedFromIndexList")
+    private List<String> excludedFromIndexList = DEFAULT_EXCLUDED_FROM_INDEX;
+
 
     public HybrisApplicationSettings() {
     }
@@ -167,6 +177,14 @@ public class HybrisApplicationSettings {
 
     public void setJunkDirectoryList(final List<String> junkDirectoryList) {
         this.junkDirectoryList = junkDirectoryList;
+    }
+
+    public List<String> getExcludedFromIndexList() {
+        return excludedFromIndexList;
+    }
+
+    public void setExcludedFromIndexList(final List<String> excludedFromIndexList) {
+        this.excludedFromIndexList = excludedFromIndexList;
     }
 
     public boolean isGroupModules() {
@@ -391,6 +409,7 @@ public class HybrisApplicationSettings {
             .append(excludeTestSources)
             .append(extensionsResourcesToExcludeList)
             .append(warnIfGeneratedItemsAreOutOfDate)
+            .append(excludedFromIndexList)
             .toHashCode();
     }
 
@@ -434,6 +453,7 @@ public class HybrisApplicationSettings {
             .append(excludeTestSources, other.excludeTestSources)
             .append(extensionsResourcesToExcludeList, other.extensionsResourcesToExcludeList)
             .append(warnIfGeneratedItemsAreOutOfDate, other.warnIfGeneratedItemsAreOutOfDate)
+            .append(excludedFromIndexList, other.excludedFromIndexList)
             .isEquals();
     }
 
@@ -467,6 +487,7 @@ public class HybrisApplicationSettings {
         sb.append(", developmentMode='").append(developmentMode).append('\'');
         sb.append(", excludeTestSources='").append(excludeTestSources).append('\'');
         sb.append(", warnIfGeneratedItemsAreOutOfDate='").append(warnIfGeneratedItemsAreOutOfDate).append('\'');
+        sb.append(", excludedFromIndexList='").append(excludedFromIndexList).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="15" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="919" height="656"/>
+      <xy x="20" y="20" width="919" height="659"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -111,7 +111,7 @@
           <grid row="9" column="0" row-span="1" col-span="5" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
-      <grid id="410c1" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="410c1" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="13" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -123,7 +123,7 @@
         <children>
           <component id="5df70" class="javax.swing.JLabel" binding="projectTreeViewSettingsLabel" custom-create="true">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="4" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value=""/>
@@ -131,7 +131,7 @@
           </component>
           <component id="ce3de" class="javax.swing.JCheckBox" binding="hideEmptyMiddleFoldersCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.project.view.tree.hide.empty.middle.folders"/>
@@ -139,7 +139,7 @@
           </component>
           <component id="e0198" class="javax.swing.JCheckBox" binding="defaultPlatformInReadOnly">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.import.settings.import.ootb.modules.read.only.label"/>
@@ -148,7 +148,7 @@
           </component>
           <component id="c48aa" class="javax.swing.JCheckBox" binding="followSymlink">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="true"/>
@@ -157,7 +157,7 @@
           </component>
           <component id="a14f2" class="javax.swing.JCheckBox" binding="scanThroughExternalModule">
             <constraints>
-              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -166,7 +166,7 @@
           </component>
           <component id="7c462" class="javax.swing.JCheckBox" binding="excludeTestSources">
             <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -175,7 +175,7 @@
           </component>
           <component id="aeae3" class="javax.swing.JCheckBox" binding="warnIfGeneratedItemsAreOutOfDateCheckBox">
             <constraints>
-              <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.ts.items.validation.settings.enabled"/>
@@ -183,7 +183,7 @@
           </component>
           <component id="ed275" class="javax.swing.JCheckBox" binding="withMavenJavadocs">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -192,7 +192,7 @@
           </component>
           <component id="8d1e4" class="javax.swing.JCheckBox" binding="withMavenSources">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <selected value="false"/>
@@ -201,12 +201,20 @@
           </component>
           <component id="7d4ec" class="javax.swing.JCheckBox" binding="withStandardProvidedSources" default-binding="true">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.project.attach.standard.sources"/>
             </properties>
           </component>
+          <grid id="d6c63" binding="excludedFromIndexPanel" custom-create="true" layout-manager="BorderLayout" hgap="0" vgap="0">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="1" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children/>
+          </grid>
         </children>
       </grid>
       <vspacer id="d2065">

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsForm.java
@@ -65,10 +65,12 @@ public class HybrisApplicationSettingsForm {
     private JPanel extensionsResourcesToExclude;
     private JCheckBox warnIfGeneratedItemsAreOutOfDateCheckBox;
     private JCheckBox withStandardProvidedSources;
+    private JPanel excludedFromIndexPanel;
 
     private MyListPanel junkListPanel;
     private MyListPanel tsdListPanel;
     private MyListPanel extensionsResourcesToExcludeListPanel;
+    private MyListPanel excludedFromIndexListPanel;
 
     public void setData(final HybrisApplicationSettings data) {
         enableFoldingCheckBox.setSelected(data.isFoldingEnabled());
@@ -92,6 +94,7 @@ public class HybrisApplicationSettingsForm {
         scanThroughExternalModule.setSelected(data.isScanThroughExternalModule());
         excludeTestSources.setSelected(data.isExcludeTestSources());
         warnIfGeneratedItemsAreOutOfDateCheckBox.setSelected(data.isWarnIfGeneratedItemsAreOutOfDate());
+        excludedFromIndexListPanel.setMyList(data.getExcludedFromIndexList());
     }
 
     public void getData(final HybrisApplicationSettings data) {
@@ -116,6 +119,7 @@ public class HybrisApplicationSettingsForm {
         data.setScanThroughExternalModule(scanThroughExternalModule.isSelected());
         data.setExcludeTestSources(excludeTestSources.isSelected());
         data.setWarnIfGeneratedItemsAreOutOfDate(warnIfGeneratedItemsAreOutOfDateCheckBox.isSelected());
+        data.setExcludedFromIndexList(excludedFromIndexListPanel.getMyList());
     }
 
     public boolean isModified(final HybrisApplicationSettings data) {
@@ -126,6 +130,9 @@ public class HybrisApplicationSettingsForm {
             return true;
         }
         if (!junkListPanel.getMyList().equals(data.getJunkDirectoryList())) {
+            return true;
+        }
+        if (!excludedFromIndexListPanel.getMyList().equals(data.getExcludedFromIndexList())) {
             return true;
         }
         if (!tsdListPanel.getMyList().equals(data.getTsdStopTypeList())) {
@@ -202,6 +209,8 @@ public class HybrisApplicationSettingsForm {
         typeSystemDiagramStopWords = tsdListPanel;
         extensionsResourcesToExcludeListPanel = new MyListPanel("hybris.import.settings.exclude.resources.name", "hybris.import.settings.exclude.resources.popup.add.title", "hybris.import.settings.exclude.resources.popup.add.text", "hybris.import.settings.exclude.resources.popup.edit.title", "hybris.import.settings.exclude.resources.popup.edit.text", new ArrayList<String>());
         extensionsResourcesToExclude = extensionsResourcesToExcludeListPanel;
+        excludedFromIndexListPanel = new MyListPanel("hybris.import.settings.excludedFromIndex.directory.name", "hybris.import.settings.excludedFromIndex.directory.popup.add.title", "hybris.import.settings.excludedFromIndex.directory.popup.add.text", "hybris.import.settings.excludedFromIndex.directory.popup.edit.title", "hybris.import.settings.excludedFromIndex.directory.popup.edit.text", new ArrayList<String>());
+        excludedFromIndexPanel = excludedFromIndexListPanel;
 
         projectTreeViewSettingsLabel = new JBLabel();
         projectTreeViewSettingsLabel.setBorder(IdeBorderFactory.createTitledBorder(HybrisI18NBundleUtils.message(


### PR DESCRIPTION
Gradle version changed from 1.3.0 to 1.5.2 - fixed bug with com.jetbrains\jbre\jbr_jcef-11_0_14_1-windows-x64-b2043.17

Added node_modules and smartedittools/common/temp to exclusions

Signed-off-by: Vladyslav Yanytskyi vladyslav_yanytskyi@epam.com
