### PR TITLE
Re-enable gensrc under platform.bootstrap

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -349,7 +349,6 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
         }
 
         excludeDirectory(contentEntry, new File(platformBootstrapDirectory, PLATFORM_MODEL_CLASSES_DIRECTORY));
-        excludeDirectory(contentEntry, new File(platformBootstrapDirectory, GEN_SRC_DIRECTORY));
 
         File tomcat6 = new File(rootDirectory, PLATFORM_TOMCAT_6_DIRECTORY);
         if (tomcat6.exists()) {


### PR DESCRIPTION
- original change broke support for navigation to Enum declaration

Signed-off-by: Mykhailo Lytvyn <>