### PR TITLE
Enabled IDEA capability to Open new Project as SAP Commerce Project

### DIFF
--- a/resources/META-INF/optional-java-dependencies.xml
+++ b/resources/META-INF/optional-java-dependencies.xml
@@ -26,7 +26,8 @@
 
         <projectImportProvider implementation="com.intellij.idea.plugin.hybris.project.HybrisProjectImportProvider"/>
         <projectImportBuilder implementation="com.intellij.idea.plugin.hybris.project.DefaultHybrisProjectImportBuilder"/>
-<!--        <projectOpenProcessor implementation="com.intellij.idea.plugin.hybris.project.HybrisProjectOpenProcessor"/>-->
+        <projectImportBuilder implementation="com.intellij.idea.plugin.hybris.project.OpenHybrisProjectImportBuilder"/>
+        <projectOpenProcessor implementation="com.intellij.idea.plugin.hybris.project.HybrisProjectOpenProcessor"/>
         <writingAccessProvider implementation="com.intellij.idea.plugin.hybris.project.providers.HybrisWritingAccessProvider" />
 
         <applicationService serviceInterface="com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptorFactory"

--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -93,6 +93,7 @@
         <![CDATA[
             <h3>2022.3.1</h3>
             <ul>
+                <li><i>Feature:</i> Enabled IDEA capability to open new Project as SAP Commerce Project (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/132" target="_blank" rel="nofollow">#132</a>)</li>
                 <li><i>Feature:</i> Introduced the Bean System Management - the powerful tool to observe SAP Commerce bean system (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/76" target="_blank" rel="nofollow">#76</a>)</li>
                 <li><i>Feature:</i> Introduced new Debugger Java Type Renderers for Model classes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/123" target="_blank" rel="nofollow">#123</a>)</li>
                 <li><i>Feature:</i> Introduced automatic Plugin Update Checker (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/127" target="_blank" rel="nofollow">#127</a>)</li>

--- a/src/com/intellij/idea/plugin/hybris/impex/view/ImpexHeaderParameterElement.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/view/ImpexHeaderParameterElement.java
@@ -42,7 +42,7 @@ public class ImpexHeaderParameterElement extends PsiTreeElementBase<ImpexFullHea
     @NotNull
     @Override
     public Collection<StructureViewTreeElement> getChildrenBase() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Nullable

--- a/src/com/intellij/idea/plugin/hybris/project/DefaultHybrisProjectImportBuilder.java
+++ b/src/com/intellij/idea/plugin/hybris/project/DefaultHybrisProjectImportBuilder.java
@@ -210,9 +210,7 @@ public class DefaultHybrisProjectImportBuilder extends AbstractHybrisProjectImpo
         if (yToolWindow == null) return;
 
         ApplicationManager.getApplication().invokeLater(() -> {
-            if (!refresh) {
-                yToolWindow.setAvailable(true);
-            }
+            yToolWindow.setAvailable(true);
             yToolWindow.activate(null, true);
         });
     }

--- a/src/com/intellij/idea/plugin/hybris/project/OpenHybrisProjectImportBuilder.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/OpenHybrisProjectImportBuilder.kt
@@ -1,0 +1,49 @@
+/*
+ * This file is part of "hybris integration" plugin for Intellij IDEA.
+ * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.project
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.module.ModifiableModuleModel
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ui.configuration.IdeaProjectSettingsService
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider
+import com.intellij.openapi.startup.StartupManager
+import com.intellij.packaging.artifacts.ModifiableArtifactModel
+
+class OpenHybrisProjectImportBuilder : DefaultHybrisProjectImportBuilder() {
+
+    override fun commit(
+        project: Project,
+        model: ModifiableModuleModel?,
+        modulesProvider: ModulesProvider?,
+        artifactModel: ModifiableArtifactModel?
+    ): MutableList<Module>? {
+        if (isOpenProjectSettingsAfter) {
+            StartupManager.getInstance(project).runAfterOpened {
+                // ensure the dialog is shown after all startup activities are done
+                ApplicationManager.getApplication().invokeLater({
+                    IdeaProjectSettingsService.getInstance(project).openProjectSettings()
+                }, ModalityState.NON_MODAL, project.disposed)
+            }
+        }
+        return super.commit(project, model, modulesProvider, artifactModel)
+    }
+
+}

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisModuleDescriptorFactory.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisModuleDescriptorFactory.java
@@ -49,15 +49,15 @@ public class DefaultHybrisModuleDescriptorFactory implements HybrisModuleDescrip
         final HybrisProjectService hybrisProjectService = ApplicationManager.getApplication().getService(HybrisProjectService.class);
 
         String path = file.getAbsolutePath();
-        File resolvedFile;
+        final File resolvedFile;
         try {
             resolvedFile = file.getCanonicalFile();
         } catch (IOException e) {
             throw new HybrisConfigurationException(e);
         }
-        String newPath = resolvedFile.getAbsolutePath();
+        final String newPath = resolvedFile.getAbsolutePath();
         if (!path.equals(newPath)) {
-            path = path + "(" + newPath + ")";
+            path = path + '(' + newPath + ')';
         }
         if (hybrisProjectService.isConfigModule(resolvedFile)) {
             LOG.info("Creating Config module for " + path);

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/AbstractSelectModulesToImportStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/AbstractSelectModulesToImportStep.java
@@ -69,7 +69,7 @@ public abstract class AbstractSelectModulesToImportStep extends SelectImportedPr
     }
 
     protected List<HybrisModuleDescriptor> getAdditionalFixedElements() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @NotNull
@@ -133,7 +133,6 @@ public abstract class AbstractSelectModulesToImportStep extends SelectImportedPr
 
     protected abstract void setList(final List<HybrisModuleDescriptor> allElements);
 
-
     protected boolean validateCommon() throws ConfigurationException {
         final Set<HybrisModuleDescriptor> moduleDuplicates = this.calculateSelectedModuleDuplicates();
         final Collection<String> moduleDuplicateNames = new HashSet<>(moduleDuplicates.size());
@@ -173,15 +172,12 @@ public abstract class AbstractSelectModulesToImportStep extends SelectImportedPr
         final int spaceWidth = fm.charWidth(' ');
         final int spaceCount = (COLUMN_WIDTH - currentWidth) / spaceWidth;
 
-        for (int index = 0; index < spaceCount; index++) {
-            builder.append(' ');
-        }
-
-        builder.append(" (");
-        builder.append(moduleDescriptor.getRelativePath());
-        builder.append(')');
-
-        return builder.toString();
+        return builder
+            .append(" ".repeat(Math.max(0, spaceCount)))
+            .append(" (")
+            .append(moduleDescriptor.getRelativePath())
+            .append(')')
+            .toString();
     }
 
 }

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.intellij.idea.plugin.hybris.project.wizard.HybrisWorkspaceRootStep">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="20" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="20" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="773" height="781"/>
@@ -13,7 +13,7 @@
       <grid id="a2f68" binding="directoryOverridePanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -84,7 +84,7 @@
       </component>
       <component id="7981a" class="javax.swing.JTextField" binding="projectNameTextField">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -113,7 +113,7 @@
       </component>
       <component id="491f3" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="storeModuleFilesInChooser">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="true"/>
@@ -122,7 +122,7 @@
       </component>
       <component id="d289f" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="sourceCodeFilesInChooser">
         <constraints>
-          <grid row="3" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <editable value="true"/>
@@ -195,7 +195,7 @@
       </component>
       <component id="6ca24" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="hybrisDistributionDirectoryFilesInChooser">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
@@ -251,10 +251,10 @@
           <text resource-bundle="i18n/HybrisBundle" key="hybris.import.wizard.config.directory.override.label"/>
         </properties>
       </component>
-      <grid id="2ac58" binding="configOverridePanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="2ac58" binding="configOverridePanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -263,7 +263,7 @@
         <children>
           <component id="1eef3" class="javax.swing.JLabel">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="4" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="4" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="i18n/HybrisBundle" key="hybris.import.wizard.config.directory.override.separator.label"/>
@@ -280,7 +280,7 @@
           </component>
           <component id="74a52" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="configOverrideFilesInChooser">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <toolTipText value=""/>
@@ -288,7 +288,7 @@
           </component>
           <component id="6e223" class="javax.swing.JSeparator">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
@@ -306,7 +306,7 @@
       <grid id="40f51" binding="dbDriverDirOverridePanel" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="14" column="0" row-span="1" col-span="3" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <visible value="true"/>
@@ -351,7 +351,7 @@
       </grid>
       <vspacer id="286f1">
         <constraints>
-          <grid row="19" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="19" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="5e798" class="javax.swing.JLabel" binding="dbDriversDirOverrideLabel">

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/HybrisWorkspaceRootStep.java
@@ -65,7 +65,7 @@ import static java.util.Collections.sort;
 /**
  * @author Vlad Bozhenok <VladBozhenok@gmail.com>
  */
-public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements NonGuiSupport {
+public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements OpenSupport, RefreshSupport {
 
     private static final Logger LOG = Logger.getInstance(HybrisWorkspaceRootStep.class);
 
@@ -595,7 +595,13 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
     }
 
     @Override
-    public void nonGuiModeImport(final HybrisProjectSettings settings) throws ConfigurationException {
+    public void open(@Nullable final HybrisProjectSettings settings) throws ConfigurationException {
+        updateStep();
+        updateDataModel();
+    }
+
+    @Override
+    public void refresh(final HybrisProjectSettings settings) throws ConfigurationException {
 
         this.getContext().cleanup();
 
@@ -648,13 +654,11 @@ public class HybrisWorkspaceRootStep extends ProjectImportWizardStep implements 
         if (hybrisDirectory == null) {
             // refreshing a project which was never imported by this plugin
             ProgressManager.getInstance().run(new SearchHybrisDistributionDirectoryTaskModalWindow(
-                toFile(this.getBuilder().getFileToImport()), parameter -> {
-                hybrisProjectDescriptor.setHybrisDistributionDirectory(toFile(parameter));
-            }
+                toFile(this.getBuilder().getFileToImport()), parameter -> hybrisProjectDescriptor.setHybrisDistributionDirectory(toFile(parameter))
             ));
         }
 
-        LOG.info("refreshing a project with the following settings: "+this.getContext().getHybrisProjectDescriptor().toString());
+        LOG.info("refreshing a project with the following settings: " + this.getContext().getHybrisProjectDescriptor());
     }
 
     private void createUIComponents() {

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/InformationStep.form
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/InformationStep.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="580" height="3041"/>
+      <xy x="20" y="20" width="580" height="474"/>
     </constraints>
     <properties/>
     <border type="none"/>

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/OpenSupport.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/OpenSupport.kt
@@ -1,0 +1,26 @@
+/*
+ * This file is part of "hybris integration" plugin for Intellij IDEA.
+ * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.project.wizard
+
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettings
+import com.intellij.openapi.options.ConfigurationException
+
+interface OpenSupport {
+    @Throws(ConfigurationException::class)
+    fun open(settings: HybrisProjectSettings?)
+}

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/RefreshSupport.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/RefreshSupport.java
@@ -24,8 +24,8 @@ import com.intellij.openapi.options.ConfigurationException;
 /**
  * Created by Martin Zdarsky-Jones (martin.zdarsky@hybris.com) on 14/2/17.
  */
-public interface NonGuiSupport {
+public interface RefreshSupport {
 
-    void nonGuiModeImport(final HybrisProjectSettings settings) throws ConfigurationException;
+    void refresh(HybrisProjectSettings settings) throws ConfigurationException;
 
 }

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/SelectOtherModulesToImportStep.java
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/SelectOtherModulesToImportStep.java
@@ -70,6 +70,7 @@ public class SelectOtherModulesToImportStep extends AbstractSelectModulesToImpor
         return null;
     }
 
+    @Override
     protected void setList(final List<HybrisModuleDescriptor> otherElements) {
         final Stream<HybrisModuleDescriptor> hybrisModuleStream = getContext().getHybrisModulesToImport().stream();
         final List<HybrisModuleDescriptor> allModules =

--- a/src/com/intellij/idea/plugin/hybris/settings/forms/HybrisProjectSettingsForm.form
+++ b/src/com/intellij/idea/plugin/hybris/settings/forms/HybrisProjectSettingsForm.form
@@ -19,28 +19,10 @@
       </component>
       <component id="ce3de" class="javax.swing.JCheckBox" binding="createBackwardCyclicDependenciesForAddons">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="i18n/HybrisBundle" key="hybris.import.wizard.hybris.addon.circular.dependency.label"/>
-        </properties>
-      </component>
-      <component id="c48aa" class="javax.swing.JCheckBox" binding="followSymlink">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <selected value="true"/>
-          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.followSymlink"/>
-        </properties>
-      </component>
-      <component id="a14f2" class="javax.swing.JCheckBox" binding="scanThroughExternalModule">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <selected value="false"/>
-          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.scannExternalModules"/>
         </properties>
       </component>
       <component id="7c462" class="javax.swing.JCheckBox" binding="excludeTestSources">
@@ -57,6 +39,24 @@
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="c48aa" class="javax.swing.JCheckBox" binding="followSymlink">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <selected value="true"/>
+          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.followSymlink"/>
+        </properties>
+      </component>
+      <component id="a14f2" class="javax.swing.JCheckBox" binding="scanThroughExternalModule">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <selected value="false"/>
+          <text resource-bundle="i18n/HybrisBundle" key="hybris.project.import.scannExternalModules"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>


### PR DESCRIPTION
From now on it should be possible to open new project as SAP Commerce one.

Project settings will be opened to post-configure JDK (as for now no support for automatic JDK identification per [y] version).

By default only extensions defined via `localextensions.xml` with dependencies will be imported, no extra projects.

<img width="769" alt="Screenshot 2023-01-06 at 23 47 36" src="https://user-images.githubusercontent.com/2292510/211116085-0959b817-0677-45f9-a238-2e144d054e8f.png">

p.s. may consider possibility to change set of the project which will be part of the Refresh action via Project Settings.

Signed-off-by: Mykhailo Lytvyn