### PR TITLE
Platform module should not be identified as Gradle project

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -121,6 +121,13 @@
                 <li><i>Feature:</i> Show label for dynamic attribute during Impex code completion (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/110" target="_blank" rel="nofollow">#110</a>)</li>
                 <li><i>Feature:</i> Inspection for <code>beans.xml</code> rely on whole Bean System, not only current file (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/88" target="_blank" rel="nofollow">#88</a>)</li>
                 <li><i>Feature:</i> Regrouped [y] Application settings into separate sections (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/130" target="_blank" rel="nofollow">#130</a>)</li>
+                <li><i>Bug Fix:</i> [y] Tool Window Logo too dark for New UI (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/95" target="_blank" rel="nofollow">#95</a>)</li>
+                <li><i>Bug Fix:</i> [y] Tool Window is not available after project import (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/125" target="_blank" rel="nofollow">#125</a>)</li>
+                <li><i>Bug Fix:</i> Impex config processor inspection does not work (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/100" target="_blank" rel="nofollow">#100</a>)</li>
+                <li><i>Bug Fix:</i> Focus is not propagated properly on Copy Impex/FlexibleSearch to Console action (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/124" target="_blank" rel="nofollow">#124</a>)</li>
+                <li><i>Bug Fix:</i> Generate Business Process Diagram action is not available (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/96" target="_blank" rel="nofollow">#96</a>)</li>
+                <li><i>Bug Fix:</i> Platform module should not be identified as Gradle project (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/141" target="_blank" rel="nofollow">#141</a>)</li>
+                <li><i>Bug Fix:</i> Default values for Type System modifiers</li>
                 <li><i>Deprecation:</i> Decreased usage of the Deprecated API
                 (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/107" target="_blank" rel="nofollow">#107</a>,
                  <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/106" target="_blank" rel="nofollow">#106</a>,
@@ -135,12 +142,6 @@
                  <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/138" target="_blank" rel="nofollow">#138</a>,
                  <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/139" target="_blank" rel="nofollow">#139</a>,
                  <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/140" target="_blank" rel="nofollow">#140</a>)</li>
-                <li><i>Bug Fix:</i> [y] Tool Window Logo too dark for New UI (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/95" target="_blank" rel="nofollow">#95</a>)</li>
-                <li><i>Bug Fix:</i> [y] Tool Window is not available after project import (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/125" target="_blank" rel="nofollow">#125</a>)</li>
-                <li><i>Bug Fix:</i> Impex config processor inspection does not work (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/100" target="_blank" rel="nofollow">#100</a>)</li>
-                <li><i>Bug Fix:</i> Focus is not propagated properly on Copy Impex/FlexibleSearch to Console action (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/124" target="_blank" rel="nofollow">#124</a>)</li>
-                <li><i>Bug Fix:</i> Generate Business Process Diagram action is not available (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/96" target="_blank" rel="nofollow">#96</a>)</li>
-                <li><i>Bug Fix:</i> Default values for Type System modifiers</li>
                 <li>
                     <strong>Ultimate only</strong>
                     <ul>

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -224,6 +224,7 @@ object HybrisConstants {
     @JvmField val RESERVED_TYPE_CODES_FILE = FileUtilRt.toSystemDependentName("resources/core/unittest/reservedTypecodes.txt")
     @JvmField val HYBRIS_SERVER_SHELL_SCRIPT_NAME = FileUtilRt.toSystemDependentName("bin/platform/hybrisserver.sh")
 
+    @JvmField val PLATFORM_MODULE = FileUtilRt.toSystemDependentName("hybris/bin/platform")
     @JvmField val PLATFORM_MODULE_PREFIX = FileUtilRt.toSystemDependentName("/bin/platform/")
     @JvmField val PLATFORM_EXT_MODULE_PREFIX = FileUtilRt.toSystemDependentName("bin/platform/ext/")
     @JvmField val PLATFORM_OOTB_MODULE_PREFIX = FileUtilRt.toSystemDependentName("bin/ext-")

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -539,10 +539,9 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
         }
 
         if (!acceptOnlyHybrisModules) {
-            if (hybrisProjectService.isGradleModule(rootProjectDirectory) && !FileUtil.filesEqual(
-                rootProjectDirectory,
-                rootDirectory
-            )) {
+            if (hybrisProjectService.isGradleModule(rootProjectDirectory)
+                && !rootProjectDirectory.getAbsolutePath().endsWith(HybrisConstants.PLATFORM_MODULE)
+                && !FileUtil.filesEqual(rootProjectDirectory, rootDirectory)) {
                 LOG.info("Detected gradle module " + rootProjectDirectory.getAbsolutePath());
                 moduleRootMap.get(NON_HYBRIS).add(rootProjectDirectory);
                 return;

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/PlatformHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/PlatformHybrisModuleDescriptor.java
@@ -113,8 +113,7 @@ public class PlatformHybrisModuleDescriptor extends AbstractHybrisModuleDescript
         final Collection<File> libraryDirectories = getLibraryDirectories();
         final File bootStrapSrc = new File(getRootDirectory(), HybrisConstants.PL_BOOTSTRAP_GEN_SRC_DIRECTORY);
 
-        final LibraryTable.ModifiableModel libraryTableModifiableModel = modifiableModelsProvider
-            .getModifiableProjectLibrariesModel();
+        final LibraryTable.ModifiableModel libraryTableModifiableModel = modifiableModelsProvider.getModifiableProjectLibrariesModel();
 
         Library library = libraryTableModifiableModel.getLibraryByName(HybrisConstants.PLATFORM_LIBRARY_GROUP);
         if (null == library) {
@@ -181,7 +180,6 @@ public class PlatformHybrisModuleDescriptor extends AbstractHybrisModuleDescript
         }
 
         addLibraryDirectories(libraryDirectories, new File(getRootDirectory(), HybrisConstants.PL_BOOTSTRAP_LIB_DIRECTORY));
-
         addLibraryDirectories(libraryDirectories, new File(getRootDirectory(), HybrisConstants.PL_TOMCAT_BIN_DIRECTORY));
         addLibraryDirectories(libraryDirectories, new File(getRootDirectory(), HybrisConstants.PL_TOMCAT_6_BIN_DIRECTORY));
         addLibraryDirectories(libraryDirectories, new File(getRootDirectory(), HybrisConstants.PL_TOMCAT_LIB_DIRECTORY));


### PR DESCRIPTION
In latest versions of the SAP Commerce it is possible to generate Gradle project for `hybris/bin/platform` via `ant gradle`, we have to ignore it as structure & configuration provided with that Gradle project is not compatible with the Plugin project structure

Signed-off-by: Mykhailo Lytvyn