### PR TITLE
Exception on Copy to console if triggered on file without extension

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -147,6 +147,7 @@
                 <li><i>Bug Fix:</i> Generate Business Process Diagram action is not available (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/96" target="_blank" rel="nofollow">#96</a>)</li>
                 <li><i>Bug Fix:</i> Platform module should not be identified as Gradle project (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/141" target="_blank" rel="nofollow">#141</a>)</li>
                 <li><i>Bug Fix:</i> Consoles are not disposable (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/142" target="_blank" rel="nofollow">#142</a>)</li>
+                <li><i>Bug Fix:</i> Exception on Copy to console if triggered on file without extension (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/157" target="_blank" rel="nofollow">#157</a>)</li>
                 <li><i>Bug Fix:</i> Default values for Type System modifiers</li>
                 <li><i>Deprecation:</i> Decreased usage of the Deprecated API
                 (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/107" target="_blank" rel="nofollow">#107</a>,

--- a/src/com/intellij/idea/plugin/hybris/actions/CopyFileToHybrisConsoleUtils.java
+++ b/src/com/intellij/idea/plugin/hybris/actions/CopyFileToHybrisConsoleUtils.java
@@ -96,7 +96,9 @@ public final class CopyFileToHybrisConsoleUtils {
             if (virtualFile.isDirectory()) {
                 return Collections.emptyList();
             }
-            extensions.add(virtualFile.getExtension());
+            if (virtualFile.getExtension() != null) {
+                extensions.add(virtualFile.getExtension());
+            }
         }
         return extensions;
     }


### PR DESCRIPTION
```
CopyFlexibleSearchFileAction#update@ProjectViewPopup (com.intellij.idea.plugin.hybris.flexibleSearch.file.actions.CopyFlexibleSearchFileAction), actionId=com.intellij.idea.plugin.hybris.flexibleSearch.file.actions.CopyFlexibleSearchFileAction, text='Copy to Flexible Search Console'

java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because the return value of "java.util.List.get(int)" is null
	at com.intellij.idea.plugin.hybris.actions.CopyFileToHybrisConsoleUtils.isRequiredSingleFileExtension(CopyFileToHybrisConsoleUtils.java:85)
	at com.intellij.idea.plugin.hybris.flexibleSearch.file.actions.CopyFlexibleSearchFileAction.update(CopyFlexibleSearchFileAction.java:39)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.lambda$performDumbAwareUpdate$0(ActionUtil.java:153)
```

Signed-off-by: Mykhailo Lytvyn