### PR TITLE
Enable plugin's settings sharing through Settings Sync

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -125,6 +125,7 @@
                 <li><i>Feature:</i> Added navigation to <code>items.xml</code> Type attributes from generated classes
                 (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/120" target="_blank" rel="nofollow">#120</a>,
                  <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/71" target="_blank" rel="nofollow">#71</a>)</li>
+                <li><i>Feature:</i> Enabled [y] plugin settings sharing through <a href="https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#IDE_settings_sync">Settings Sync</a> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/163" target="_blank" rel="nofollow">#163</a>)</li>
                 <li><i>Feature:</i> Added navigation to <code>items.xml</code> Enum values declaration from generated classes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/115" target="_blank" rel="nofollow">#115</a>)</li>
                 <li><i>Feature:</i> Added navigation to <code>beans.xml</code> Enum values declaration from generated classes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/111" target="_blank" rel="nofollow">#111</a>)</li>
                 <li><i>Feature:</i> Added navigation to <code>beans.xml</code> Bean property declaration from generated classes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/112" target="_blank" rel="nofollow">#112</a>)</li>

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsComponent.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisApplicationSettingsComponent.java
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.settings;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.SettingsCategory;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
@@ -33,7 +34,9 @@ import static com.intellij.idea.plugin.hybris.common.HybrisConstants.STORAGE_HYB
  *
  * @author Alexander Bartash <AlexanderBartash@gmail.com>
  */
-@State(name = "HybrisApplicationSettings", storages = {@Storage(STORAGE_HYBRIS_INTEGRATION_SETTINGS)})
+@State(name = "[y] Global Settings",
+       category = SettingsCategory.PLUGINS,
+       storages = {@Storage(value = STORAGE_HYBRIS_INTEGRATION_SETTINGS)})
 public class HybrisApplicationSettingsComponent implements PersistentStateComponent<HybrisApplicationSettings> {
 
     protected final HybrisApplicationSettings hybrisApplicationSettings = new HybrisApplicationSettings();

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/system/bean/view/BSViewSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/system/bean/view/BSViewSettings.kt
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.toolwindow.system.bean.view
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.SettingsCategory
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.project.Project
@@ -27,7 +28,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.Topic
 import com.intellij.util.xmlb.XmlSerializerUtil
 
-@State(name = "HybrisBSView")
+@State(name = "[y] Bean System View settings", category = SettingsCategory.PLUGINS)
 @Storage(HybrisConstants.STORAGE_HYBRIS_BS_VIEW)
 class BSViewSettings(private val myProject: Project) : PersistentStateComponent<BSViewSettings.Settings> {
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/system/type/view/TSViewSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/system/type/view/TSViewSettings.kt
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.toolwindow.system.type.view
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.SettingsCategory
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.project.Project
@@ -27,7 +28,7 @@ import com.intellij.util.messages.MessageBus
 import com.intellij.util.messages.Topic
 import com.intellij.util.xmlb.XmlSerializerUtil
 
-@State(name = "HybrisTSView")
+@State(name = "[y] Type System View settings", category = SettingsCategory.PLUGINS)
 @Storage(HybrisConstants.STORAGE_HYBRIS_TS_VIEW)
 class TSViewSettings(myProject: Project) : PersistentStateComponent<TSViewSettings.Settings> {
 


### PR DESCRIPTION
Enabled settings sharing according to https://plugins.jetbrains.com/docs/intellij/persisting-state-of-components.html#sharing-settings-between-ide-installations

<img width="641" alt="Screenshot 2023-01-14 at 23 43 02" src="https://user-images.githubusercontent.com/2292510/212500455-26bfe6de-5888-438a-8e48-fa408ab443a1.png">
<img width="510" alt="Screenshot 2023-01-14 at 23 40 07" src="https://user-images.githubusercontent.com/2292510/212500460-545fcbe8-a8e1-448e-89f5-e0e52dc88de0.png">


Signed-off-by: Mykhailo Lytvyn