### PR TITLE
FlexibleSearch code completion should not be case-sensitive for attributes

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -148,6 +148,7 @@
                 <li><i>Feature:</i> Added <code>extensioninfo.xml</coed> DOM model and custom Icon (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/147" target="_blank" rel="nofollow">#147</a>)</li>
                 <li><i>Feature:</i> Added <code>process.xml</code> DOM model and custom Icon (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/148" target="_blank" rel="nofollow">#148</a>)</li>
                 <li><i>Feature:</i> Decreases cognitive complexity for Code Completion and custom Icons (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/152" target="_blank" rel="nofollow">#152</a>)</li>
+                <li><i>Bug Fix:</i> FlexibleSearch code completion should not be case-sensitive for attributes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/167" target="_blank" rel="nofollow">#167</a>)</li>
                 <li><i>Bug Fix:</i> [y] Tool Window Logo too dark for New UI (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/95" target="_blank" rel="nofollow">#95</a>)</li>
                 <li><i>Bug Fix:</i> [y] Tool Window is not available after project import (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/125" target="_blank" rel="nofollow">#125</a>)</li>
                 <li><i>Bug Fix:</i> Impex config processor inspection does not work (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/100" target="_blank" rel="nofollow">#100</a>)</li>

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/completion/provider/FSFieldsCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/completion/provider/FSFieldsCompletionProvider.kt
@@ -90,6 +90,7 @@ class FSFieldsCompletionProvider : CompletionProvider<CompletionParameters>() {
         project: Project,
         result: CompletionResultSet
     ) {
+        val resultCaseInsensitive = result.caseInsensitive()
         val querySpecification = PsiTreeUtil.getTopmostParentOfType(psiElementUnderCaret, FlexibleSearchQuerySpecification::class.java)
 
         PsiTreeUtil.findChildrenOfType(querySpecification, FlexibleSearchTableReference::class.java)
@@ -98,7 +99,7 @@ class FSFieldsCompletionProvider : CompletionProvider<CompletionParameters>() {
                 val element = PsiTreeUtil.getNextSiblingOfType(it, FlexibleSearchCorrelationName::class.java)
                 element != null && element.text == tableNameId.text
             }
-            ?.let { fillDomAttributesCompletions(project, it.text, result) }
+            ?.let { fillDomAttributesCompletions(project, it.text, resultCaseInsensitive) }
     }
 
     private fun fillDomAttributesCompletions(
@@ -114,6 +115,7 @@ class FSFieldsCompletionProvider : CompletionProvider<CompletionParameters>() {
         metaItem.allAttributes
             .map {
                 LookupElementBuilder.create(it.name)
+//                    .withCaseSensitivity(false)
                     .withStrikeoutness(it.isDeprecated)
                     .withTypeText(it.flattenType, true)
                     .withIcon(HybrisIcons.ATTRIBUTE)
@@ -123,6 +125,7 @@ class FSFieldsCompletionProvider : CompletionProvider<CompletionParameters>() {
         metaItem.allRelationEnds
             .map {
                 LookupElementBuilder.create(it.qualifier)
+//                    .withCaseSensitivity(false)
                     .withStrikeoutness(it.isDeprecated)
                     .withTypeText(it.flattenType)
                     .withIcon(

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/references/ColumnReferenceMixin.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/references/ColumnReferenceMixin.kt
@@ -59,16 +59,15 @@ internal class TSAttributeReference(owner: FlexibleSearchColumnReference) : TSRe
             return ResolveResult.EMPTY_ARRAY
         }
 
-        val metaItemService = TSMetaItemService.getInstance(project)
-        val attributes = metaItemService
-                .findAttributesByName(metaItem.get(), refName, true)
-                .mapNotNull { it.retrieveDom() }
-                .map { AttributeResolveResult(it) }
+        val attributes = metaItem.get().allAttributes
+            .filter { refName.equals(it.name, true) }
+            .mapNotNull { it.retrieveDom() }
+            .map { AttributeResolveResult(it) }
 
-        val relations = metaItemService
-                .findRelationEndsByQualifier(metaItem.get(), refName, true)
-                .mapNotNull { it.retrieveDom() }
-                .map { RelationElementResolveResult(it) }
+        val relations = metaItem.get().allRelationEnds
+            .filter { refName.equals(it.name, true) }
+            .mapNotNull { it.retrieveDom() }
+            .map { RelationElementResolveResult(it) }
 
         return (attributes + relations).toTypedArray() 
     }

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/references/TSMixins.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/references/TSMixins.kt
@@ -1,5 +1,6 @@
 package com.intellij.idea.plugin.hybris.flexibleSearch.references
 
+import com.intellij.codeInsight.highlighting.HighlightedReference
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.idea.plugin.hybris.flexibleSearch.psi.FlexibleSearchTableName
 import com.intellij.idea.plugin.hybris.psi.reference.TSReferenceBase
@@ -32,7 +33,7 @@ abstract class TypeNameMixin(astNode: ASTNode) : ASTWrapperPsiElement(astNode), 
     }
 }
 
-class TSItemRef(owner: FlexibleSearchTableName) : TSReferenceBase<FlexibleSearchTableName>(owner) {
+class TSItemRef(owner: FlexibleSearchTableName) : TSReferenceBase<FlexibleSearchTableName>(owner), HighlightedReference {
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val lookingForName = element.text.replace("!", "")

--- a/src/com/intellij/idea/plugin/hybris/psi/reference/TSItemReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/psi/reference/TSItemReference.kt
@@ -18,6 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.psi.reference
 
+import com.intellij.codeInsight.highlighting.HighlightedReference
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.impex.psi.references.result.EnumResolveResult
 import com.intellij.idea.plugin.hybris.impex.psi.references.result.ItemResolveResult
@@ -35,7 +36,7 @@ import com.intellij.psi.ResolveResult
  *
  * see, standard-editors-spring.xml
  */
-class TSItemReference(element: PsiElement) : TSReferenceBase<PsiElement>(element), PsiPolyVariantReference {
+class TSItemReference(element: PsiElement) : TSReferenceBase<PsiElement>(element), PsiPolyVariantReference, HighlightedReference {
 
     override fun calculateDefaultRangeInElement(): TextRange {
         val text = element.text.trim()

--- a/src/com/intellij/idea/plugin/hybris/psi/reference/provider/TSItemReferenceProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/psi/reference/provider/TSItemReferenceProvider.kt
@@ -26,9 +26,9 @@ import com.intellij.util.ProcessingContext
 class TSItemReferenceProvider : PsiReferenceProvider() {
 
     override fun getReferencesByElement(
-        element: PsiElement,
-        context: ProcessingContext
-    ) = arrayOf(TSItemReference(element))
+        element: PsiElement, context: ProcessingContext
+    ) = if (element.text.contains(".")) emptyArray()
+    else arrayOf(TSItemReference(element))
 
     companion object {
         val instance: PsiReferenceProvider = ApplicationManager.getApplication().getService(TSItemReferenceProvider::class.java)


### PR DESCRIPTION

<img width="877" alt="Screenshot 2023-01-15 at 19 31 55" src="https://user-images.githubusercontent.com/2292510/212560270-356d26b7-fa54-44a1-9090-4d32dfc34184.png">


Signed-off-by: Mykhailo Lytvyn