### PR TITLE
Added code completion and navigation for Cockpitng 'explorer-tree -> type-node -> code'

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -158,6 +158,7 @@
                         <li><code>actions -> action-id</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/172" target="_blank" rel="nofollow">#172</a>)</li>
                         <li><code>widgets -> widgetDefinitionId</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/173" target="_blank" rel="nofollow">#173</a>)</li>
                         <li><code>list-view -> qualifier</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/175" target="_blank" rel="nofollow">#175</a>)</li>
+                        <li><code>explorer-tree -> type-node -> code</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/176" target="_blank" rel="nofollow">#176</a>)</li>
                     </ul>
                 </li>
                 <li><i>Bug Fix:</i> FlexibleSearch code completion should not be case-sensitive for attributes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/167" target="_blank" rel="nofollow">#167</a>)</li>

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/codeInsight/completion/CngCompletionContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/codeInsight/completion/CngCompletionContributor.kt
@@ -39,6 +39,11 @@ class CngCompletionContributor : CompletionContributor() {
         )
         extend(
             CompletionType.BASIC,
+            PlatformPatterns.psiElement().inside(CngPatterns.TREE_NODE_TYPE_CODE),
+            ItemTypeCodeCompletionProvider.instance
+        )
+        extend(
+            CompletionType.BASIC,
             PlatformPatterns.psiElement().inside(CngPatterns.CONTEXT_PARENT),
             ItemTypeCodeCompletionProvider.instance
         )

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
@@ -70,4 +70,20 @@ object CngPatterns {
         .inside(XmlPatterns.xmlTag().withLocalName(CONTEXT))
         .inFile(cngFile)
 
+    val TREE_NODE_TYPE_CODE = XmlPatterns.xmlAttributeValue()
+        .withParent(
+            XmlPatterns.xmlAttribute().withLocalName("code")
+                .withParent(
+                    XmlPatterns.xmlTag().withLocalName("type-node")
+                        .inside(
+                            XmlPatterns.xmlTag()
+                                .withNamespace("http://www.hybris.com/cockpitng/config/explorertree")
+                                .withLocalName("explorer-tree")
+                        )
+                )
+        )
+        .andNot(XmlPatterns.xmlAttributeValue().withValue(StandardPatterns.string().contains(".")))
+        .inside(XmlPatterns.xmlTag().withLocalName(CONTEXT))
+        .inFile(cngFile)
+
 }

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
@@ -26,13 +26,16 @@ import com.intellij.psi.PsiReferenceRegistrar
 class CngReferenceContributor : PsiReferenceContributor() {
 
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        // classes resolved by JavaXmlClassListReferenceContributor
         registrar.registerReferenceProvider(
             CngPatterns.CONTEXT_TYPE,
             TSItemReferenceProvider.instance
         )
         registrar.registerReferenceProvider(
             CngPatterns.FLOW_STEP_CONTENT_PROPERTY_TYPE,
+            TSItemReferenceProvider.instance
+        )
+        registrar.registerReferenceProvider(
+            CngPatterns.TREE_NODE_TYPE_CODE,
             TSItemReferenceProvider.instance
         )
         registrar.registerReferenceProvider(


### PR DESCRIPTION

<img width="794" alt="Screenshot 2023-01-18 at 20 47 51" src="https://user-images.githubusercontent.com/2292510/213280434-212e33e5-32fe-43d3-89d2-7e519502a636.png">
<img width="1049" alt="Screenshot 2023-01-18 at 20 48 24" src="https://user-images.githubusercontent.com/2292510/213280459-4f19cbe2-9e77-4e23-abcc-1b1ef3ffb1ec.png">


Signed-off-by: Mykhailo Lytvyn