### PR TITLE
Added code completion and navigation for Cockpitng 'advanced-search -> field -> name'

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -160,6 +160,7 @@
                         <li><code>list-view -> qualifier</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/175" target="_blank" rel="nofollow">#175</a>)</li>
                         <li><code>explorer-tree -> type-node -> code</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/176" target="_blank" rel="nofollow">#176</a>)</li>
                         <li><code>editorArea -> attribute -> qualifier</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/177" target="_blank" rel="nofollow">#177</a>)</li>
+                        <li><code>advanced-search -> field -> name</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/178" target="_blank" rel="nofollow">#178</a>)</li>
                     </ul>
                 </li>
                 <li><i>Bug Fix:</i> FlexibleSearch code completion should not be case-sensitive for attributes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/167" target="_blank" rel="nofollow">#167</a>)</li>

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/codeInsight/completion/CngCompletionContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/codeInsight/completion/CngCompletionContributor.kt
@@ -57,5 +57,10 @@ class CngCompletionContributor : CompletionContributor() {
             PlatformPatterns.psiElement().inside(CngPatterns.EDITOR_ATTRIBUTE),
             CngItemAttributeCodeCompletionProvider.instance
         )
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement().inside(CngPatterns.ADVANCED_SEARCH_FIELD_NAME),
+            CngItemAttributeCodeCompletionProvider.instance
+        )
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
@@ -80,6 +80,15 @@ object CngPatterns {
         .inside(XmlPatterns.xmlTag().withLocalName(CONTEXT))
         .inFile(cngFile)
 
+    val ADVANCED_SEARCH_FIELD_NAME = attributeValue(
+        "name",
+        "field",
+        "advanced-search",
+        CngConfigDomFileDescription.NAMESPACE_COCKPITNG_CONFIG_ADVANCED_SEARCH
+    )
+        .inside(XmlPatterns.xmlTag().withLocalName(CONTEXT))
+        .inFile(cngFile)
+
     private fun attributeValue(
         attribute: String,
         tag: String,

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
@@ -50,5 +50,9 @@ class CngReferenceContributor : PsiReferenceContributor() {
             CngPatterns.EDITOR_ATTRIBUTE,
             TSAttributeReferenceProvider.instance
         )
+        registrar.registerReferenceProvider(
+            CngPatterns.ADVANCED_SEARCH_FIELD_NAME,
+            TSAttributeReferenceProvider.instance
+        )
     }
 }


### PR DESCRIPTION

<img width="1049" alt="Screenshot 2023-01-18 at 22 28 24" src="https://user-images.githubusercontent.com/2292510/213299882-42b11098-afac-4993-a7d5-deb9be83d398.png">
<img width="898" alt="Screenshot 2023-01-18 at 22 27 58" src="https://user-images.githubusercontent.com/2292510/213299892-723017c5-1d2f-49fb-97b3-1bd987a5a25e.png">


Signed-off-by: Mykhailo Lytvyn