### PR TITLE
VirtualFile is null for BeansUtils

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/system/bean/BeansUtils.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/BeansUtils.kt
@@ -31,7 +31,7 @@ object BeansUtils {
     fun isGeneratedFile(psiClass: PsiClass): Boolean {
         val virtualFile = psiClass.containingFile.virtualFile
 
-        if (virtualFile.extension == null) return false
+        if (virtualFile == null || virtualFile.extension == null) return false
 
         return (virtualFile.extension == "class" && virtualFile.path.contains(HybrisConstants.JAR_MODELS))
                 || (virtualFile.extension == "java" && virtualFile.path.contains("${HybrisConstants.PLATFORM_BOOTSTRAP_DIRECTORY}/${HybrisConstants.GEN_SRC_DIRECTORY}"))


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "com.intellij.openapi.vfs.VirtualFile.getExtension()" because "virtualFile" is null
	at com.intellij.idea.plugin.hybris.system.bean.BeansUtils.isGeneratedFile(BeansUtils.kt:34)
	at com.intellij.idea.plugin.hybris.system.bean.BeansUtils.isEnumFile(BeansUtils.kt:28)
	at com.intellij.idea.plugin.hybris.system.bean.codeInsight.daemon.DtoBeanLineMarkerProvider.canProcess(DtoBeanLineMarkerProvider.kt:36)
	at com.intellij.idea.plugin.hybris.codeInsight.daemon.AbstractHybrisClassLineMarkerProvider.canProcess(AbstractHybrisClassLineMarkerProvider.kt:40)
	at com.intellij.idea.plugin.hybris.codeInsight.daemon.AbstractHybrisLineMarkerProvider.collectSlowLineMarkers(AbstractHybrisLineMarkerProvider.kt:37)
	at com.intellij.codeInsight.daemon.impl.LineMarkersPass.queryProviders(LineMarkersPass.java:223)
```