### PR TITLE
Added possibility to Unify table alias separator for `FlexibleSearch` with a single click

### DIFF
--- a/resources/META-INF/lang/optional-flexibleSearch.xml
+++ b/resources/META-INF/lang/optional-flexibleSearch.xml
@@ -46,7 +46,8 @@
         <renamePsiElementProcessor implementation="com.intellij.idea.plugin.hybris.flexibleSearch.refactoring.rename.processor.FlexibleSearchRenameProcessor"/>
 
         <highlightUsagesHandlerFactory implementation="com.intellij.idea.plugin.hybris.flexibleSearch.highlighting.FlexibleSearchHighlightUsagesHandlerFactory"/>
-        <editorNotificationProvider id="fxsEditorNotificationProvider" implementation="com.intellij.idea.plugin.hybris.flexibleSearch.ui.FlexibleSearchEditorNotificationProvider"/>
+        <editorNotificationProvider id="fxsReservedWordsCaseEditorNotificationProvider" implementation="com.intellij.idea.plugin.hybris.flexibleSearch.ui.FxSReservedWordsCaseEditorNotificationProvider"/>
+        <editorNotificationProvider id="fxsTableAliasSeparatorEditorNotificationProvider" implementation="com.intellij.idea.plugin.hybris.flexibleSearch.ui.FxSTableAliasSeparatorEditorNotificationProvider"/>
 
         <languageInjector implementation="com.intellij.idea.plugin.hybris.flexibleSearch.injection.FlexibleSearchInjector"/>
 

--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -111,6 +111,7 @@
                         <li>Respect value of the `show language` flag (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/382" target="_blank" rel="nofollow">#382</a>)</li>
                     </ul>
                 </li>
+                <li><i>Feature:</i> Added possibility to Unify table alias separator for FlexibleSearch with a single click (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/389" target="_blank" rel="nofollow">#389</a>)</li>
                 <li><i>Feature:</i> Added <code>Go to Declaration</code> action for Type System preview Tree (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/384" target="_blank" rel="nofollow">#384</a>)</li>
                 <li><i>Feature:</i> Added <code>Go to Declaration</code> action for Type System preview Tables (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/385" target="_blank" rel="nofollow">#385</a>)</li>
                 <li><i>Feature:</i> Added <code>Go to Declaration</code> action for Bean System preview Tree (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/386" target="_blank" rel="nofollow">#386</a>)</li>
@@ -144,7 +145,7 @@
                     <ul>
                         <li>Rewritten from the Scratch</li>
                         <li>Folding support</li>
-                        <li>Brand new possibility to Unify case of the reserved words, change to upper or lowercase with single click</li>
+                        <li>Brand new possibility to Unify case of the reserved words, change to upper or lowercase with a single click</li>
                         <li>Added support of the multiline comment block <code>/**/</code></li>
                         <li>Added find usages for table & column aliases</li>
                         <li>Added support of the localized attributes</li>

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -550,6 +550,10 @@ hybris.fxs.notification.provider.keywords.case.LOWERCASE=Lowercase
 hybris.fxs.notification.provider.keywords.action.unify=Unify
 hybris.fxs.notification.provider.keywords.action.settings=Settings
 
+hybris.fxs.notification.provider.tableAliasSeparator.text=Tabe Alias Separator mismatches with predefined ''{0}'' setting
+hybris.fxs.notification.provider.tableAliasSeparator.action.unify=Unify
+hybris.fxs.notification.provider.tableAliasSeparator.action.settings=Settings
+
 hybris.fxs.actions.open_settings=Open FlexibleSearch Settings
 hybris.fxs.actions.open_settings.description=Opens FlexibleSearch settings dialog
 

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/FlexibleSearchElementFactory.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/FlexibleSearchElementFactory.kt
@@ -23,10 +23,15 @@ import com.intellij.idea.plugin.hybris.flexibleSearch.file.FlexibleSearchFileTyp
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
+import com.intellij.psi.util.PsiTreeUtil
 
 object FlexibleSearchElementFactory {
 
     fun createIdentifier(project: Project, name: String): PsiElement = createFile(project, name).firstChild
+
+    fun createColumnSeparator(project: Project, separator: String): PsiElement? = createFile(project, "SELECT {alias${separator}name}")
+        .let { PsiTreeUtil.findChildOfType(it, FlexibleSearchColumnSeparator::class.java) }
+        ?.firstChild
 
     fun createFile(project: Project, text: String): FlexibleSearchFile = PsiFileFactory.getInstance(project)
         .createFileFromText("dummy.fxs", FlexibleSearchFileType.instance, text) as FlexibleSearchFile

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/settings/FlexibleSearchSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/settings/FlexibleSearchSettings.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.components.BaseState
 
 data class FlexibleSearchSettings(
     var verifyCaseForReservedWords: Boolean = true,
+    var verifyUsedTableAliasSeparator: Boolean = true,
     var defaultCaseForReservedWords: ReservedWordsCase = ReservedWordsCase.UPPERCASE,
 
     var completion: FlexibleSearchCompletionSettings = FlexibleSearchCompletionSettings(),

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/settings/FlexibleSearchSettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/settings/FlexibleSearchSettingsConfigurableProvider.kt
@@ -19,7 +19,7 @@
 package com.intellij.idea.plugin.hybris.flexibleSearch.settings
 
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
-import com.intellij.idea.plugin.hybris.flexibleSearch.ui.FlexibleSearchEditorNotificationProvider
+import com.intellij.idea.plugin.hybris.flexibleSearch.ui.FxSReservedWordsCaseEditorNotificationProvider
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.idea.plugin.hybris.settings.ReservedWordsCase
 import com.intellij.openapi.options.BoundSearchableConfigurable
@@ -53,12 +53,17 @@ class FlexibleSearchSettingsConfigurableProvider(val project: Project) : Configu
         override fun apply() {
             super.apply()
 
-            EditorNotificationProvider.EP_NAME.findExtension(FlexibleSearchEditorNotificationProvider::class.java, project)
+            EditorNotificationProvider.EP_NAME.findExtension(FxSReservedWordsCaseEditorNotificationProvider::class.java, project)
                 ?.let { EditorNotifications.getInstance(project).updateNotifications(it) }
         }
 
         override fun createPanel() = panel {
             group("Language") {
+                row {
+                    checkBox("Verify used table alias separator")
+                        .bindSelected(state::verifyUsedTableAliasSeparator)
+                        .comment("Usage of the default table alias separator will be verified when the file is being opened for the first time")
+                }
                 row {
                     verifyCaseCheckBox =
                         checkBox("Verify case of the reserved words")

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/ui/AbstractFxSEditorNotificationProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/ui/AbstractFxSEditorNotificationProvider.kt
@@ -1,0 +1,63 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.flexibleSearch.ui
+
+import com.intellij.idea.plugin.hybris.flexibleSearch.file.FlexibleSearchFileType
+import com.intellij.idea.plugin.hybris.flexibleSearch.settings.FlexibleSearchSettings
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotificationProvider
+import java.util.function.Function
+import javax.swing.JComponent
+
+abstract class AbstractFxSEditorNotificationProvider : EditorNotificationProvider, DumbAware {
+
+    override fun collectNotificationData(project: Project, file: VirtualFile): Function<in FileEditor, out JComponent?>? {
+        val settings = HybrisProjectSettingsComponent.getInstance(project)
+        if (!settings.isHybrisProject()) return null
+        if (!FileTypeRegistry.getInstance().isFileOfType(file, FlexibleSearchFileType.instance)) return null
+        val fxsSettings = settings.state.flexibleSearchSettings
+        if (!shouldCollect(fxsSettings)) return null
+
+        val psiFile = PsiManager.getInstance(project).findFile(file) ?: return null
+
+        if (collect(fxsSettings, psiFile).isEmpty()) return null
+
+        return panelFunction(fxsSettings, project, psiFile, file)
+    }
+
+    protected abstract fun shouldCollect(fxsSettings: FlexibleSearchSettings): Boolean
+
+    protected abstract fun panelFunction(
+        fxsSettings: FlexibleSearchSettings,
+        project: Project,
+        psiFile: PsiFile,
+        file: VirtualFile
+    ): Function<FileEditor, EditorNotificationPanel>
+
+    protected abstract fun collect(fxsSettings: FlexibleSearchSettings, psiFile: PsiFile): MutableCollection<LeafPsiElement>
+
+}

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/ui/FxSTableAliasSeparatorEditorNotificationProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/ui/FxSTableAliasSeparatorEditorNotificationProvider.kt
@@ -1,0 +1,102 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.flexibleSearch.ui
+
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.flexibleSearch.psi.FlexibleSearchElementFactory
+import com.intellij.idea.plugin.hybris.flexibleSearch.psi.FlexibleSearchTypes.*
+import com.intellij.idea.plugin.hybris.flexibleSearch.settings.FlexibleSearchSettings
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.search.PsiElementProcessor
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotifications
+import java.util.function.Function
+
+class FxSTableAliasSeparatorEditorNotificationProvider : AbstractFxSEditorNotificationProvider() {
+
+    override fun shouldCollect(fxsSettings: FlexibleSearchSettings) = fxsSettings.verifyUsedTableAliasSeparator
+
+    override fun panelFunction(
+        fxsSettings: FlexibleSearchSettings,
+        project: Project,
+        psiFile: PsiFile,
+        file: VirtualFile
+    ): Function<FileEditor, EditorNotificationPanel> {
+        return Function { fileEditor ->
+            val panel = EditorNotificationPanel(fileEditor, EditorNotificationPanel.Status.Info)
+            panel.icon(HybrisIcons.HYBRIS)
+            panel.text = message(
+                "hybris.fxs.notification.provider.tableAliasSeparator.text",
+                when (val separator = fxsSettings.completion.defaultTableAliasSeparator) {
+                    "." -> message("hybris.settings.project.fxs.code.completion.separator.dot")
+                    ":" -> message("hybris.settings.project.fxs.code.completion.separator.colon")
+                    else -> separator
+                }
+            )
+            panel.createActionLabel(message("hybris.fxs.notification.provider.tableAliasSeparator.action.unify")) {
+                WriteCommandAction.runWriteCommandAction(project) {
+                    FlexibleSearchElementFactory.createColumnSeparator(project, fxsSettings.completion.defaultTableAliasSeparator)
+                        ?.let { newSeparatorLeaf ->
+                            collect(fxsSettings, psiFile)
+                                .distinct()
+                                .reversed()
+                                .forEach { it.replace(newSeparatorLeaf) }
+                        }
+                }
+
+                EditorNotifications.getInstance(project).updateNotifications(file)
+            }
+            panel.createActionLabel(message("hybris.fxs.notification.provider.tableAliasSeparator.action.settings"), "hybris.fxs.openSettings")
+            panel
+        }
+    }
+
+    override fun collect(
+        fxsSettings: FlexibleSearchSettings,
+        psiFile: PsiFile
+    ): MutableCollection<LeafPsiElement> {
+        val searchForElementType = when (fxsSettings.completion.defaultTableAliasSeparator) {
+            "." -> COLON
+            ":" -> DOT
+            else -> return mutableListOf()
+        }
+
+        val processor = Collector(searchForElementType)
+        PsiTreeUtil.processElements(psiFile, LeafPsiElement::class.java, processor)
+        return processor.collection
+    }
+
+    class Collector(private val searchForElementType: IElementType) : PsiElementProcessor.CollectElements<LeafPsiElement>() {
+        override fun execute(element: LeafPsiElement): Boolean {
+            if (element.elementType == searchForElementType && element.parent.parent.elementType == COLUMN_REF_Y_EXPRESSION) {
+                return super.execute(element)
+            }
+            return true
+        }
+    }
+
+}

--- a/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettingsConfigurableProvider.kt
@@ -52,7 +52,6 @@ class ImpexSettingsConfigurableProvider(val project: Project) : ConfigurableProv
                     checkBox("Use smart folding")
                         .bindSelected(state.folding::useSmartFolding)
                         .enabledIf(foldingEnableCheckBox.selected)
-                        .component
                 }
             }
         }


### PR DESCRIPTION
<img width="707" alt="Screenshot 2023-05-08 at 18 01 15" src="https://user-images.githubusercontent.com/2292510/236875744-48f21508-7286-4ce8-802d-979f306051b6.png">
<img width="591" alt="Screenshot 2023-05-08 at 18 01 33" src="https://user-images.githubusercontent.com/2292510/236875752-2ee4136e-37fa-47b7-b77c-f7bbedd95977.png">
