### PR TITLE
Automatically adjust Kotlin Compiler based on `kotlinnature` settings and project JDK

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -99,6 +99,7 @@
                 <li><i>Feature:</i> <strong>Kotlin</strong> language support (<a href="https://github.com/mlytvyn/kotlinnature">kotlinnature</a>)
                     <ul>
                         <li>Register Kotlin Facet for extensions with <code>kotlinsrc</code> / <code>kotlintestsrc</code> directories (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/407" target="_blank" rel="nofollow">#407</a>)</li>
+                        <li>Automatically adjust Kotlin Compiler based on <code>kotlinnature</code> settings and project JDK (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/409" target="_blank" rel="nofollow">#409</a>)</li>
                         <li>Show different icon for <code>kotlinnature</code> extension (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/408" target="_blank" rel="nofollow">#408</a>)</li>
                     </ul>
                 </li>

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/FacetConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/FacetConfigurator.java
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.project.configurators;
 
 import com.intellij.facet.ModifiableFacetModel;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
+import com.intellij.idea.plugin.hybris.project.descriptors.HybrisProjectDescriptor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
 public interface FacetConfigurator {
 
     void configure(
-        @NotNull ModifiableFacetModel modifiableFacetModel,
+        final @NotNull HybrisProjectDescriptor hybrisProjectDescriptor, @NotNull ModifiableFacetModel modifiableFacetModel,
         @NotNull HybrisModuleDescriptor moduleDescriptor,
         @NotNull Module javaModule,
         @NotNull ModifiableRootModel modifiableRootModel

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/KotlinCompilerConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/KotlinCompilerConfigurator.kt
@@ -6,4 +6,6 @@ import com.intellij.openapi.project.Project
 interface KotlinCompilerConfigurator {
 
     fun configure(descriptor: HybrisProjectDescriptor, project: Project, cache: HybrisConfiguratorCache)
+
+    fun configureAfterImport(project: Project)
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultPostImportConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultPostImportConfigurator.kt
@@ -74,6 +74,9 @@ class DefaultPostImportConfigurator(val project: Project) : PostImportConfigurat
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) return@invokeLater
 
+            configuratorFactory.kotlinCompilerConfigurator
+                ?.configureAfterImport(project)
+
             configuratorFactory.mavenConfigurator
                 ?.let {
                     try {

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/SpringFacetConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/SpringFacetConfigurator.java
@@ -23,6 +23,7 @@ import com.intellij.facet.ModifiableFacetModel;
 import com.intellij.idea.plugin.hybris.project.configurators.FacetConfigurator;
 import com.intellij.idea.plugin.hybris.project.descriptors.CCv2HybrisModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
+import com.intellij.idea.plugin.hybris.project.descriptors.HybrisProjectDescriptor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -45,7 +46,7 @@ public class SpringFacetConfigurator implements FacetConfigurator {
 
     @Override
     public void configure(
-        @NotNull final ModifiableFacetModel modifiableFacetModel,
+        final @NotNull HybrisProjectDescriptor hybrisProjectDescriptor, @NotNull final ModifiableFacetModel modifiableFacetModel,
         @NotNull final HybrisModuleDescriptor moduleDescriptor,
         @NotNull final Module javaModule,
         @NotNull final ModifiableRootModel modifiableRootModel

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/WebFacetConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/WebFacetConfigurator.java
@@ -26,6 +26,7 @@ import com.intellij.facet.ModifiableFacetModel;
 import com.intellij.idea.plugin.hybris.common.HybrisConstants;
 import com.intellij.idea.plugin.hybris.project.configurators.FacetConfigurator;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisModuleDescriptor;
+import com.intellij.idea.plugin.hybris.project.descriptors.HybrisProjectDescriptor;
 import com.intellij.javaee.DeploymentDescriptorsConstants;
 import com.intellij.javaee.web.facet.WebFacet;
 import com.intellij.openapi.application.WriteAction;
@@ -49,7 +50,7 @@ public class WebFacetConfigurator implements FacetConfigurator {
 
     @Override
     public void configure(
-        @NotNull final ModifiableFacetModel modifiableFacetModel,
+        final @NotNull HybrisProjectDescriptor hybrisProjectDescriptor, @NotNull final ModifiableFacetModel modifiableFacetModel,
         @NotNull final HybrisModuleDescriptor moduleDescriptor,
         @NotNull final Module javaModule,
         @NotNull final ModifiableRootModel modifiableRootModel

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/AbstractHybrisModuleDescriptor.java
@@ -208,9 +208,9 @@ public abstract class AbstractHybrisModuleDescriptor implements HybrisModuleDesc
     }
 
     @Override
-    public boolean isKotlinEnabled() {
-        return new File(this.getRootDirectory(), HybrisConstants.KOTLIN_SRC_DIRECTORY).exists()
-            || new File(this.getRootDirectory(), HybrisConstants.KOTLIN_TEST_SRC_DIRECTORY).exists();
+    public boolean hasKotlinSourceDirectories() {
+        return new File(getRootDirectory(), HybrisConstants.KOTLIN_SRC_DIRECTORY).exists()
+            || new File(getRootDirectory(), HybrisConstants.KOTLIN_TEST_SRC_DIRECTORY).exists();
     }
 
     @Override

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -123,6 +123,8 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     private ConfigHybrisModuleDescriptor configHybrisModuleDescriptor;
     @NotNull
     private PlatformHybrisModuleDescriptor platformHybrisModuleDescriptor;
+    @Nullable
+    private HybrisModuleDescriptor kotlinNatureModuleDescriptor;
     private final Set<File> vcs = new HashSet<>();
 
     private void processLocalExtensions() {
@@ -783,6 +785,9 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
             if (module instanceof PlatformHybrisModuleDescriptor) {
                 platformHybrisModuleDescriptor = (PlatformHybrisModuleDescriptor) module;
             }
+            if (HybrisConstants.EXTENSION_NAME_KOTLIN_NATURE.equals(module.getName())) {
+                kotlinNatureModuleDescriptor = module;
+            }
         });
     }
 
@@ -796,6 +801,12 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     @Override
     public PlatformHybrisModuleDescriptor getPlatformHybrisModuleDescriptor() {
         return platformHybrisModuleDescriptor;
+    }
+
+    @Nullable
+    @Override
+    public HybrisModuleDescriptor getKotlinNatureModuleDescriptor() {
+        return kotlinNatureModuleDescriptor;
     }
 
     @NotNull

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisModuleDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisModuleDescriptor.java
@@ -80,7 +80,10 @@ public interface HybrisModuleDescriptor extends Comparable<HybrisModuleDescripto
 
     boolean isAddOn();
 
-    boolean isKotlinEnabled();
+    /**
+     * This method will return true if module has `kotlinsrc` or `kotlintestsrc` directories
+     */
+    boolean hasKotlinSourceDirectories();
 
     @NotNull
     HybrisModuleDescriptorType getDescriptorType();

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
@@ -57,6 +57,8 @@ public interface HybrisProjectDescriptor {
     @NotNull
     PlatformHybrisModuleDescriptor getPlatformHybrisModuleDescriptor();
 
+    @Nullable HybrisModuleDescriptor getKotlinNatureModuleDescriptor();
+
     @NotNull
     Set<HybrisModuleDescriptor> getAlreadyOpenedModules();
 

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -139,9 +139,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         final HybrisConfiguratorCache cache = new HybrisConfiguratorCache();
         final List<HybrisModuleDescriptor> allModules = getHybrisModuleDescriptors();
 
-        final SpringConfigurator springConfigurator = configuratorFactory.getSpringConfigurator();
+        final var springConfigurator = configuratorFactory.getSpringConfigurator();
         final var groupModuleConfigurator = configuratorFactory.getGroupModuleConfigurator();
-        final VersionControlSystemConfigurator versionControlSystemConfigurator = configuratorFactory.getVersionControlSystemConfigurator();
+        final var versionControlSystemConfigurator = configuratorFactory.getVersionControlSystemConfigurator();
 
         this.initializeHybrisProjectSettings(project);
         this.updateProjectDictionary(project, hybrisProjectDescriptor.getModulesChosenForImport());
@@ -301,7 +301,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
 
         indicator.setText2(message("hybris.project.import.module.facet"));
         for (final FacetConfigurator facetConfigurator : configuratorFactory.getFacetConfigurators()) {
-            facetConfigurator.configure(modifiableFacetModel, moduleDescriptor, javaModule, modifiableRootModel);
+            facetConfigurator.configure(hybrisProjectDescriptor, modifiableFacetModel, moduleDescriptor, javaModule, modifiableRootModel);
         }
         return javaModule;
     }

--- a/src/com/intellij/idea/plugin/hybris/project/utils/PluginCommon.java
+++ b/src/com/intellij/idea/plugin/hybris/project/utils/PluginCommon.java
@@ -25,13 +25,16 @@ import com.intellij.openapi.extensions.PluginId;
 /**
  * Created by Martin Zdarsky-Jones (martin.zdarsky@hybris.com) on 20/3/17.
  */
-public class PluginCommon {
+public final class PluginCommon {
 
     public static final String ANT_SUPPORT_PLUGIN_ID = "AntSupport";
     public static final String JAVAEE_PLUGIN_ID = "com.intellij.javaee";
     public static final String SPRING_PLUGIN_ID = "com.intellij.spring";
     public static final String KOTLIN_PLUGIN_ID = "org.jetbrains.kotlin";
     public static final String SHOW_UNLINKED_GRADLE_POPUP = "show.inlinked.gradle.project.popup";
+
+    private PluginCommon() {
+    }
 
     public static boolean isPluginActive(final String id) {
         final IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId(id));

--- a/src/com/intellij/idea/plugin/hybris/startup/HybrisProjectStructureStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/HybrisProjectStructureStartupActivity.kt
@@ -50,7 +50,7 @@ class HybrisProjectStructureStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         if (project.isDisposed) return
 
-        val commonIdeaService = ApplicationManager.getApplication().getService(CommonIdeaService::class.java)
+        val commonIdeaService = CommonIdeaService.getInstance()
         val isHybrisProject = commonIdeaService.isHybrisProject(project)
 
         if (isHybrisProject) {
@@ -105,7 +105,7 @@ class HybrisProjectStructureStartupActivity : ProjectActivity {
     }
 
     private fun resetSpringGeneralSettings(project: Project) {
-        val commonIdeaService = ApplicationManager.getApplication().getService(CommonIdeaService::class.java)
+        val commonIdeaService = CommonIdeaService.getInstance()
 
         if (commonIdeaService.isHybrisProject(project) && PluginCommon.isPluginActive(PluginCommon.SPRING_PLUGIN_ID)) {
             val springGeneralSettings = SpringGeneralSettings.getInstance(project)

--- a/src/com/intellij/idea/plugin/hybris/startup/ImpexHeaderHighlighterStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/ImpexHeaderHighlighterStartupActivity.kt
@@ -31,7 +31,7 @@ import com.intellij.psi.PsiManager
 class ImpexHeaderHighlighterStartupActivity : ProjectActivity, Disposable {
 
     override suspend fun execute(project: Project) {
-        if (!ApplicationManager.getApplication().getService(CommonIdeaService::class.java).isHybrisProject(project)) {
+        if (!CommonIdeaService.getInstance().isHybrisProject(project)) {
             return
         }
 

--- a/src/com/intellij/idea/plugin/hybris/startup/ItemsXmlFileOpenStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/ItemsXmlFileOpenStartupActivity.kt
@@ -37,7 +37,7 @@ import com.intellij.psi.search.GlobalSearchScope
 class ItemsXmlFileOpenStartupActivity : ProjectActivity {
 
     override suspend fun execute(project: Project) {
-        if (!ApplicationManager.getApplication().getService(CommonIdeaService::class.java).isHybrisProject(project)) return
+        if (!CommonIdeaService.getInstance().isHybrisProject(project)) return
         if (!HybrisApplicationSettingsComponent.getInstance().state.warnIfGeneratedItemsAreOutOfDate) return
 
         val task = object : Task.Backgroundable(project, message("hybris.startupActivity.itemsXmlValidation.progress.title")) {

--- a/src/com/intellij/idea/plugin/hybris/startup/PreLoadSystemsStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/PreLoadSystemsStartupActivity.kt
@@ -29,7 +29,7 @@ import com.intellij.openapi.startup.ProjectActivity
 class PreLoadSystemsStartupActivity : ProjectActivity {
 
     override suspend fun execute(project: Project) {
-        if (!ApplicationManager.getApplication().getService(CommonIdeaService::class.java).isHybrisProject(project)) {
+        if (!CommonIdeaService.getInstance().isHybrisProject(project)) {
             return
         }
 


### PR DESCRIPTION
Reimport or refresh project with `kotlinnature` extension and Plugin will automatically adjust Kotlin Compiler according to `kotlinnature.compiler.version` and selected Project JDK version.

<img width="940" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/70404fe2-1e54-4e3e-a38b-7f73364c29c3">
