### PR TITLE
Inspection rule: validate that `lang` column attribute value is present in the `lang.packs`

### DIFF
--- a/resources/META-INF/plugin-inspections.xml
+++ b/resources/META-INF/plugin-inspections.xml
@@ -44,6 +44,10 @@
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.cockpitng.CngContextParentIsNotValid"/>
 
         <!-- Impex -->
+        <localInspection groupPath="SAP Commerce" shortName="ImpexLanguageIsNotSupportedInspection" displayName="[y] Language is not supported"
+                         groupName="[y] Impex" level="ERROR" language="Impex" enabledByDefault="true"
+                         implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexLanguageIsNotSupportedInspection"/>
+
         <localInspection groupPath="SAP Commerce" shortName="ImpexNoUniqueValueInspection" displayName="[y] No unique value in column"
                          groupName="[y] Impex" level="WEAK WARNING" language="Impex" enabledByDefault="true"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexNoUniqueValueInspection"/>

--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -107,6 +107,7 @@
                 <li><i>Feature:</i> <strong>Impex</strong> enhancements
                     <ul>
                         <li>Added code completion of all available languages for <code>lang</code> column attribute (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/416" target="_blank" rel="nofollow">#416</a>)</li>
+                        <li>Inspection rule: validate that <code>lang</code> column attribute value is present in the <code>lang.packs</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417" target="_blank" rel="nofollow">#417</a>)</li>
                     </ul>
                 </li>
                 <li><i>Feature:</i> Added Node.js version 18 to the CCv2 js-storefront manifest file (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/413" target="_blank" rel="nofollow">#413</a>)</li>

--- a/resources/inspectionDescriptions/ImpexLanguageIsNotSupportedInspection.html
+++ b/resources/inspectionDescriptions/ImpexLanguageIsNotSupportedInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+  ~ Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html>
+<body>
+Only languages specified in the <code>lang.packs</code> can be used for localized attributes.
+</body>
+</html>

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageIsNotSupportedInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageIsNotSupportedInspection.kt
@@ -1,0 +1,57 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.rule.impex
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAnyAttributeName
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAnyAttributeValue
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexVisitor
+import com.intellij.idea.plugin.hybris.properties.PropertiesService
+import com.intellij.psi.util.PsiTreeUtil
+
+class ImpexLanguageIsNotSupportedInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.ERROR
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : ImpexVisitor() {
+
+        override fun visitAnyAttributeValue(psi: ImpexAnyAttributeValue) {
+            PsiTreeUtil.getPrevSiblingOfType(psi, ImpexAnyAttributeName::class.java)
+                ?.takeIf { AttributeModifier.LANG.modifierName == it.text }
+                ?: return
+
+            val language = psi.text
+            val supportedLanguages = PropertiesService.getInstance(psi.project).getLanguages()
+
+            if (supportedLanguages.contains(language)) return
+
+            holder.registerProblem(
+                psi,
+                message(
+                    "hybris.inspections.language.unsupported",
+                    language,
+                    supportedLanguages.joinToString()
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
<img width="126" alt="Screenshot 2023-05-21 at 09 29 15" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/6643a0e0-e384-4f07-b133-8b339988d703">
<img width="861" alt="Screenshot 2023-05-21 at 09 29 33" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/9f2b2932-ab5e-42b1-abe8-8dda3d77ec6f">
