### PR TITLE
Inspection rule: validate that `lang` modifier is used only for localized attributes

### DIFF
--- a/resources/META-INF/plugin-inspections.xml
+++ b/resources/META-INF/plugin-inspections.xml
@@ -48,6 +48,10 @@
                          groupName="[y] Impex" level="ERROR" language="Impex" enabledByDefault="true"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexLanguageIsNotSupportedInspection"/>
 
+        <localInspection groupPath="SAP Commerce" shortName="ImpexLanguageModifierIsNotAllowedInspection" displayName="[y] Lang modifier is not allowed for non-localized attributes"
+                         groupName="[y] Impex" level="ERROR" language="Impex" enabledByDefault="true"
+                         implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexLanguageModifierIsNotAllowedInspection"/>
+
         <localInspection groupPath="SAP Commerce" shortName="ImpexNoUniqueValueInspection" displayName="[y] No unique value in column"
                          groupName="[y] Impex" level="WEAK WARNING" language="Impex" enabledByDefault="true"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexNoUniqueValueInspection"/>

--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -107,7 +107,8 @@
                 <li><i>Feature:</i> <strong>Impex</strong> enhancements
                     <ul>
                         <li>Added code completion of all available languages for <code>lang</code> column attribute (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/416" target="_blank" rel="nofollow">#416</a>)</li>
-                        <li>Inspection rule: validate that <code>lang</code> column attribute value is present in the <code>lang.packs</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417" target="_blank" rel="nofollow">#417</a>)</li>
+                        <li>Inspection rule: validate that <code>lang</code> modifier value is present in the <code>lang.packs</code> (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417" target="_blank" rel="nofollow">#417</a>)</li>
+                        <li>Inspection rule: validate that <code>lang</code> modifier is used only for localized attributes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418" target="_blank" rel="nofollow">#418</a>)</li>
                     </ul>
                 </li>
                 <li><i>Feature:</i> Added Node.js version 18 to the CCv2 js-storefront manifest file (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/413" target="_blank" rel="nofollow">#413</a>)</li>

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -259,6 +259,7 @@ hybris.inspections.impex.ImpexUnknownConfigPropertyInspection.key=[y] Unknown co
 hybris.inspections.impex.ImpexUnknownMacrosInspection.key=[y] Unknown macro ''{0}''
 hybris.inspections.impex.ImpexUnknownAttributeModifierInspection.key=[y] Unknown Attribute modifier ''{0}''
 hybris.inspections.impex.ImpexUnknownTypeModifierInspection.key=[y] Unknown Type modifier ''{0}''
+hybris.inspections.impex.ImpexLanguageModifierIsNotAllowedInspection.key=[y] Lang modifier is not allowed for non-localized attribute ''{0}''
 
 hybris.inspections.ts.AttributeHandlerMustBeSetForDynamicAttribute.key=[y] Attribute handler must be defined for Dynamic Attribute
 hybris.inspections.ts.DeploymentTypeCodeMustBeUnique.key=[y] Deployment type code must be unique
@@ -337,6 +338,9 @@ hybris.inspections.fix.xml.DeleteAttribute=Delete attribute {0}
 hybris.inspections.fix.xml.DeleteSubTag=Delete sub-tag {0}
 hybris.inspections.fix.xml.DeleteTag=Delete tag
 hybris.inspections.fix.psi.NavigateToAnchor=Navigate to existing declaration
+
+hybris.inspections.fix.impex.DeleteModifier=Delete modifier
+hybris.inspections.fix.impex.DeleteModifier.text=Delete modifier ''{0}''
 
 hybris.inspections.fxs.unresolved.attribute.key=[y] Unresolved attribute ''{0}''
 hybris.inspections.fxs.unresolved.type.key=[y] Unresolved type ''{0}''

--- a/resources/inspectionDescriptions/ImpexLanguageModifierIsNotAllowedInspection.html
+++ b/resources/inspectionDescriptions/ImpexLanguageModifierIsNotAllowedInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+  ~ Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html>
+<body>
+<code>lang</code> modifier is allowed only for localized attributes.
+</body>
+</html>

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/impex/ImpexDeleteModifierFix.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/impex/ImpexDeleteModifierFix.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.fix.impex
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAttribute
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexTypes
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.TokenType
+import com.intellij.psi.util.elementType
+
+class ImpexDeleteModifierFix(
+    modifier: ImpexAttribute,
+    private val name: String = message("hybris.inspections.fix.impex.DeleteModifier.text", modifier.anyAttributeName.text)
+) : LocalQuickFixOnPsiElement(modifier) {
+
+    override fun getFamilyName() = message("hybris.inspections.fix.impex.DeleteModifier")
+    override fun getText() = name
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val prevSiblingsToDelete = mutableSetOf<PsiElement>()
+        var prevSibling = startElement.prevSibling
+
+        while (prevSibling != null) {
+            prevSibling = if (prevSibling.elementType == ImpexTypes.ATTRIBUTE_SEPARATOR || prevSibling.elementType == TokenType.WHITE_SPACE) {
+                prevSiblingsToDelete.add(prevSibling)
+                prevSibling.prevSibling
+            } else {
+                null
+            }
+        }
+
+        prevSiblingsToDelete.forEach { it.delete() }
+
+        startElement.delete()
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddAttributeQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddAttributeQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -24,18 +24,22 @@ import com.intellij.codeInspection.ProblemDescriptorBase;
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.xml.XmlAttribute;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.PsiNavigateUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class XmlDeleteSubTagQuickFix implements LocalQuickFix {
+public class XmlAddAttributeQuickFix implements LocalQuickFix {
 
     private final String myFixName;
-    private final String myTagName;
+    private final String myAttributeName;
 
-    public XmlDeleteSubTagQuickFix(final @NotNull String tagName) {
-        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.DeleteSubTag", tagName);
-        myTagName = tagName;
+    public XmlAddAttributeQuickFix(
+        final String attributeName
+    ) {
+
+        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.AddAttribute", attributeName);
+        myAttributeName = attributeName;
     }
 
     @NotNull
@@ -50,13 +54,14 @@ public class XmlDeleteSubTagQuickFix implements LocalQuickFix {
 
         if (currentElement instanceof XmlTag) {
             final XmlTag currentTag = (XmlTag) currentElement;
-            final XmlTag subTag = currentTag.findFirstSubTag(myTagName);
-            if (subTag != null) {
-                subTag.delete();
-                if (descriptor instanceof ProblemDescriptorBase) {
-                    PsiNavigateUtil.navigate(currentTag);
-                }
-            }
+            final XmlAttribute xmlAttribute = currentTag.setAttribute(myAttributeName, "");
+            navigateIfNotPreviewMode(descriptor, xmlAttribute.getValueElement());
+        }
+    }
+
+    private void navigateIfNotPreviewMode(final ProblemDescriptor descriptor, final PsiElement psiElement) {
+        if (descriptor instanceof ProblemDescriptorBase) {
+            PsiNavigateUtil.navigate(psiElement);
         }
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddTagQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddTagQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddUpdateAttributeQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlAddUpdateAttributeQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteAttributeQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteAttributeQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteSubTagQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteSubTagQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -24,26 +24,18 @@ import com.intellij.codeInspection.ProblemDescriptorBase;
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
-import com.intellij.psi.xml.XmlAttribute;
-import com.intellij.psi.xml.XmlElement;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.PsiNavigateUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class XmlUpdateAttributeQuickFix implements LocalQuickFix {
+public class XmlDeleteSubTagQuickFix implements LocalQuickFix {
 
     private final String myFixName;
-    private final String myAttributeName;
-    private final String myAttributeValue;
+    private final String myTagName;
 
-    public XmlUpdateAttributeQuickFix(
-        final String attributeName,
-        final String attributeValue
-    ) {
-
-        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.UpdateAttribute", attributeName, attributeValue);
-        myAttributeName = attributeName;
-        myAttributeValue = attributeValue;
+    public XmlDeleteSubTagQuickFix(final @NotNull String tagName) {
+        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.DeleteSubTag", tagName);
+        myTagName = tagName;
     }
 
     @NotNull
@@ -58,22 +50,13 @@ public class XmlUpdateAttributeQuickFix implements LocalQuickFix {
 
         if (currentElement instanceof XmlTag) {
             final XmlTag currentTag = (XmlTag) currentElement;
-            final XmlAttribute xmlAttribute = currentTag.setAttribute(myAttributeName, myAttributeValue);
-            navigateIfNotPreviewMode(descriptor, xmlAttribute);
-        } else if (currentElement instanceof XmlAttribute) {
-            final XmlAttribute xmlAttribute = (XmlAttribute) currentElement;
-            xmlAttribute.setValue(myAttributeValue);
-            navigateIfNotPreviewMode(descriptor, xmlAttribute);
-        } else if (currentElement instanceof XmlElement && currentElement.getParent() instanceof XmlAttribute) {
-            final XmlAttribute xmlAttribute = (XmlAttribute) currentElement.getParent();
-            xmlAttribute.setValue(myAttributeValue);
-            navigateIfNotPreviewMode(descriptor, xmlAttribute);
-        }
-    }
-
-    private void navigateIfNotPreviewMode(final ProblemDescriptor descriptor, final XmlAttribute xmlAttribute) {
-        if (descriptor instanceof ProblemDescriptorBase) {
-            PsiNavigateUtil.navigate(xmlAttribute);
+            final XmlTag subTag = currentTag.findFirstSubTag(myTagName);
+            if (subTag != null) {
+                subTag.delete();
+                if (descriptor instanceof ProblemDescriptorBase) {
+                    PsiNavigateUtil.navigate(currentTag);
+                }
+            }
         }
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteTagQuickFix.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlDeleteTagQuickFix.kt
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.codeInspection.fix
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml
 
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlUpdateAttributeQuickFix.java
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/fix/xml/XmlUpdateAttributeQuickFix.java
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.intellij.idea.plugin.hybris.codeInspection.fix;
+package com.intellij.idea.plugin.hybris.codeInspection.fix.xml;
 
 import com.intellij.codeInspection.LocalQuickFix;
 import com.intellij.codeInspection.ProblemDescriptor;
@@ -25,21 +25,25 @@ import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.xml.XmlAttribute;
+import com.intellij.psi.xml.XmlElement;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.PsiNavigateUtil;
 import org.jetbrains.annotations.NotNull;
 
-public class XmlAddAttributeQuickFix implements LocalQuickFix {
+public class XmlUpdateAttributeQuickFix implements LocalQuickFix {
 
     private final String myFixName;
     private final String myAttributeName;
+    private final String myAttributeValue;
 
-    public XmlAddAttributeQuickFix(
-        final String attributeName
+    public XmlUpdateAttributeQuickFix(
+        final String attributeName,
+        final String attributeValue
     ) {
 
-        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.AddAttribute", attributeName);
+        myFixName = HybrisI18NBundleUtils.message("hybris.inspections.fix.xml.UpdateAttribute", attributeName, attributeValue);
         myAttributeName = attributeName;
+        myAttributeValue = attributeValue;
     }
 
     @NotNull
@@ -54,14 +58,22 @@ public class XmlAddAttributeQuickFix implements LocalQuickFix {
 
         if (currentElement instanceof XmlTag) {
             final XmlTag currentTag = (XmlTag) currentElement;
-            final XmlAttribute xmlAttribute = currentTag.setAttribute(myAttributeName, "");
-            navigateIfNotPreviewMode(descriptor, xmlAttribute.getValueElement());
+            final XmlAttribute xmlAttribute = currentTag.setAttribute(myAttributeName, myAttributeValue);
+            navigateIfNotPreviewMode(descriptor, xmlAttribute);
+        } else if (currentElement instanceof XmlAttribute) {
+            final XmlAttribute xmlAttribute = (XmlAttribute) currentElement;
+            xmlAttribute.setValue(myAttributeValue);
+            navigateIfNotPreviewMode(descriptor, xmlAttribute);
+        } else if (currentElement instanceof XmlElement && currentElement.getParent() instanceof XmlAttribute) {
+            final XmlAttribute xmlAttribute = (XmlAttribute) currentElement.getParent();
+            xmlAttribute.setValue(myAttributeValue);
+            navigateIfNotPreviewMode(descriptor, xmlAttribute);
         }
     }
 
-    private void navigateIfNotPreviewMode(final ProblemDescriptor descriptor, final PsiElement psiElement) {
+    private void navigateIfNotPreviewMode(final ProblemDescriptor descriptor, final XmlAttribute xmlAttribute) {
         if (descriptor instanceof ProblemDescriptorBase) {
-            PsiNavigateUtil.navigate(psiElement);
+            PsiNavigateUtil.navigate(xmlAttribute);
         }
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/beanSystem/BSDuplicateBeanPropertyDefinition.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/beanSystem/BSDuplicateBeanPropertyDefinition.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.beanSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.system.bean.meta.BSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.bean.model.Bean
 import com.intellij.idea.plugin.hybris.system.bean.model.Beans

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/extensioninfo/EiDuplicateExtensionDefinition.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/extensioninfo/EiDuplicateExtensionDefinition.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.extensioninfo
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.system.extensioninfo.model.ExtensionInfo
 import com.intellij.idea.plugin.hybris.system.extensioninfo.model.RequiresExtension

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/extensioninfo/EiUnknownExtensionDefinition.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/extensioninfo/EiUnknownExtensionDefinition.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.extensioninfo
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.idea.plugin.hybris.system.extensioninfo.model.ExtensionInfo

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageModifierIsNotAllowedInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageModifierIsNotAllowedInspection.kt
@@ -1,0 +1,62 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.rule.impex
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.idea.plugin.hybris.codeInspection.fix.impex.ImpexDeleteModifierFix
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAnyAttributeName
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAttribute
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexFullHeaderParameter
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexVisitor
+import com.intellij.idea.plugin.hybris.system.type.psi.reference.result.AttributeResolveResult
+import com.intellij.psi.PsiPolyVariantReference
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
+
+class ImpexLanguageModifierIsNotAllowedInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.ERROR
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : ImpexVisitor() {
+
+        override fun visitAnyAttributeName(psi: ImpexAnyAttributeName) {
+            if (psi.text != AttributeModifier.LANG.modifierName) return
+
+            val attribute = psi.getParentOfType<ImpexAttribute>(false) ?: return
+            val meta = psi.getParentOfType<ImpexFullHeaderParameter>(false)
+                ?.anyHeaderParameterName
+                ?.reference
+                ?.let { it as PsiPolyVariantReference }
+                ?.multiResolve(false)
+                ?.firstOrNull()
+                ?.let { it as? AttributeResolveResult }
+                ?.meta
+                ?.takeUnless { it.isLocalized }
+                ?: return
+
+            holder.registerProblem(
+                psi,
+                message("hybris.inspections.impex.ImpexLanguageModifierIsNotAllowedInspection.key", meta.name),
+                ImpexDeleteModifierFix(attribute)
+            )
+        }
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/localextensions/LeUnknownExtensionDefinition.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/localextensions/LeUnknownExtensionDefinition.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.localextensions
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.idea.plugin.hybris.system.localextensions.model.Extension

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSAttributeHandlerMustBeSetForDynamicAttribute.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSAttributeHandlerMustBeSetForDynamicAttribute.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlAddAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlAddAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.Project

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSCmpPersistanceTypeIsDeprecated.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSCmpPersistanceTypeIsDeprecated.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.Project

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSCollectionsAreOnlyForDynamicAndJalo.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSCollectionsAreOnlyForDynamicAndJalo.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.annotation.HighlightSeverity

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableMustExistForItemExtendingGenericItem.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableMustExistForItemExtendingGenericItem.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlAddTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlAddTagQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.ItemType

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableMustNotBeRedeclaredInChildTypes.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableMustNotBeRedeclaredInChildTypes.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteSubTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteSubTagQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.ItemType
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableNameLengthShouldBeValid.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableNameLengthShouldBeValid.kt
@@ -17,7 +17,7 @@
  */
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.impex.utils.ProjectPropertiesUtils

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTagMustNotBeDeclaredForO2MRelation.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTagMustNotBeDeclaredForO2MRelation.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Cardinality
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.Relation

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeMustBeGreaterThanTenThousand.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeMustBeGreaterThanTenThousand.kt
@@ -17,7 +17,7 @@
  */
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeMustBeUnique.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeMustBeUnique.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForB2BCommerceExtension.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForB2BCommerceExtension.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForCommonsExtension.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForCommonsExtension.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForLegacyXPrintExtension.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForLegacyXPrintExtension.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForPrintExtension.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForPrintExtension.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForProcessingExtension.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodeReservedForProcessingExtension.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodesMustBeGreaterThanTenThousandForRelations.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTypeCodesMustBeGreaterThanTenThousandForRelations.kt
@@ -18,7 +18,7 @@
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.model.Deployment
 import com.intellij.idea.plugin.hybris.system.type.model.Items

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSJaloClassIsNotAllowedWhenAddingFieldsToExistingClass.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSJaloClassIsNotAllowedWhenAddingFieldsToExistingClass.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.ItemType
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.all

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSJaloPersistanceTypeIsDeprecated.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSJaloPersistanceTypeIsDeprecated.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.Project

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSListsInRelationShouldBeAvoided.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSListsInRelationShouldBeAvoided.kt
@@ -18,8 +18,8 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.project.Project

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSOnlyOneSideN2mRelationMustBeNotNavigable.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSOnlyOneSideN2mRelationMustBeNotNavigable.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Cardinality
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.RelationElement

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSOrderingOfRelationShouldBeAvoided.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSOrderingOfRelationShouldBeAvoided.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Cardinality
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.RelationElement

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierAndModifiersMustNotBeDeclaredForNavigableFalse.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierAndModifiersMustNotBeDeclaredForNavigableFalse.kt
@@ -18,8 +18,8 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteTagQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteTagQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Cardinality
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.RelationElement

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierMustExistForNavigablePartInN2MRelation.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierMustExistForNavigablePartInN2MRelation.kt
@@ -18,8 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlAddAttributeQuickFix
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlAddAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Cardinality
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.RelationElement

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierMustStartWithLowercaseLetter.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSQualifierMustStartWithLowercaseLetter.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Attribute
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.all

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSTypeNameMustNotStartWithGenerated.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSTypeNameMustNotStartWithGenerated.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.ItemType
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.all

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSTypeNameMustStartWithUppercaseLetter.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSTypeNameMustStartWithUppercaseLetter.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.ItemType
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.all

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSUseOfUnoptimizedAttributesIsNotRecommended.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSUseOfUnoptimizedAttributesIsNotRecommended.kt
@@ -18,7 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.codeInspection.rule.typeSystem
 
-import com.intellij.idea.plugin.hybris.codeInspection.fix.XmlDeleteAttributeQuickFix
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlDeleteAttributeQuickFix
 import com.intellij.idea.plugin.hybris.system.type.model.Items
 import com.intellij.idea.plugin.hybris.system.type.model.Modifiers
 import com.intellij.idea.plugin.hybris.system.type.model.modifiers


### PR DESCRIPTION
<img width="659" alt="Screenshot 2023-05-21 at 10 29 20" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/f342c897-d46b-4959-bf23-2253a3820bdf">
<img width="263" alt="Screenshot 2023-05-21 at 10 29 11" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/48f28d8d-c10f-40ba-a3c0-be86dd00a416">
