### PR TITLE
Added possibility to copy FlexibleSearch from the Java 15 text block

### DIFF
--- a/resources/META-INF/plugin-release-info.xml
+++ b/resources/META-INF/plugin-release-info.xml
@@ -120,6 +120,11 @@
                         <li>Inspection rule: validate that <code>lang</code> modifier is used only for localized attributes (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418" target="_blank" rel="nofollow">#418</a>)</li>
                     </ul>
                 </li>
+                <li><i>Feature:</i> <strong>FlexibleSearch</strong> enhancements
+                    <ul>
+                        <li>Added possibility to copy FlexibleSearch from the Java 15 text block (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/428" target="_blank" rel="nofollow">#428</a>)</li>
+                    </ul>
+                </li>
                 <li><i>Feature:</i> Added Node.js version 18 to the CCv2 js-storefront manifest file (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/413" target="_blank" rel="nofollow">#413</a>)</li>
                 <li><i>Fix:</i> Check additional active plugin for java EE (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/406" target="_blank" rel="nofollow">#406</a>)</li>
                 <li><i>Fix:</i> IDEA 2023.2: the expensive method should not be called inside the Highlighting Pass (<a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/411" target="_blank" rel="nofollow">#411</a>)</li>


### PR DESCRIPTION
<img width="451" alt="Screenshot 2023-05-22 at 14 06 51" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/d654a873-d2a7-46c3-b591-0bbf987bd480">
<img width="677" alt="Screenshot 2023-05-22 at 14 06 58" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/1d7725c1-52a4-42c4-bb7f-60167b8b8d6c">
