### PR TITLE
Inject FlexibleSearch language into `SearchRestriction :: query` respecting `restrictedType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added reference support for `lang` modifier value [#420](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/420)
 - Added `env.properties` support for project properties code completion [#419](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/419)
 - Inject FlexibleSearch language into suitable macro declaration values [#433](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/433)
+- Inject FlexibleSearch language into `SearchRestriction :: query` respecting `restrictedType` [#434](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/434)
 - Inspection rule: validate that `lang` modifier value is present in the `lang.packs` [#417](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417)
 - Inspection rule: validate that `lang` modifier is used only for localized attributes [#418](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418)
 

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexFullHeaderParameter.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexFullHeaderParameter.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -24,6 +20,7 @@ package com.intellij.idea.plugin.hybris.impex.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier;
 
 public interface ImpexFullHeaderParameter extends PsiElement {
 
@@ -40,5 +37,8 @@ public interface ImpexFullHeaderParameter extends PsiElement {
   ImpexHeaderLine getHeaderLine();
 
   int getColumnNumber();
+
+  @Nullable
+  ImpexAttribute getAttribute(@NotNull AttributeModifier attributeModifier);
 
 }

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexHeaderLine.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexHeaderLine.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -35,5 +31,8 @@ public interface ImpexHeaderLine extends PsiElement {
 
   @Nullable
   ImpexFullHeaderType getFullHeaderType();
+
+  @Nullable
+  ImpexFullHeaderParameter getFullHeaderParameter(@NotNull String parameterName);
 
 }

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexValueGroup.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/ImpexValueGroup.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -37,5 +33,8 @@ public interface ImpexValueGroup extends PsiElement {
 
   @Nullable
   ImpexValueLine getValueLine();
+
+  @Nullable
+  String computeValue();
 
 }

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexFullHeaderParameterImpl.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexFullHeaderParameterImpl.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -30,6 +26,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import static com.intellij.idea.plugin.hybris.impex.psi.ImpexTypes.*;
 import com.intellij.extapi.psi.ASTWrapperPsiElement;
 import com.intellij.idea.plugin.hybris.impex.psi.*;
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier;
 
 public class ImpexFullHeaderParameterImpl extends ASTWrapperPsiElement implements ImpexFullHeaderParameter {
 
@@ -74,6 +71,12 @@ public class ImpexFullHeaderParameterImpl extends ASTWrapperPsiElement implement
   @Override
   public int getColumnNumber() {
     return ImpexPsiUtil.getColumnNumber(this);
+  }
+
+  @Override
+  @Nullable
+  public ImpexAttribute getAttribute(@NotNull AttributeModifier attributeModifier) {
+    return ImpexPsiUtil.getAttribute(this, attributeModifier);
   }
 
 }

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexHeaderLineImpl.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexHeaderLineImpl.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -63,6 +59,12 @@ public class ImpexHeaderLineImpl extends ASTWrapperPsiElement implements ImpexHe
   @Nullable
   public ImpexFullHeaderType getFullHeaderType() {
     return findChildByClass(ImpexFullHeaderType.class);
+  }
+
+  @Override
+  @Nullable
+  public ImpexFullHeaderParameter getFullHeaderParameter(@NotNull String parameterName) {
+    return ImpexPsiUtil.getFullHeaderParameter(this, parameterName);
   }
 
 }

--- a/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexValueGroupImpl.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexValueGroupImpl.java
@@ -1,8 +1,4 @@
 /*
- * ----------------------------------------------------------------
- * --- WARNING: THIS FILE IS GENERATED AND WILL BE OVERWRITTEN! ---
- * ----------------------------------------------------------------
- *
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
  *
@@ -68,6 +64,12 @@ public class ImpexValueGroupImpl extends ASTWrapperPsiElement implements ImpexVa
   @Nullable
   public ImpexValueLine getValueLine() {
     return ImpexPsiUtil.getValueLine(this);
+  }
+
+  @Override
+  @Nullable
+  public String computeValue() {
+    return ImpexPsiUtil.computeValue(this);
   }
 
 }

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -211,6 +211,7 @@ object HybrisConstants {
     const val TS_TYPE_CRON_JOB = "CronJob"
     const val TS_TYPE_CATALOG_VERSION = "CatalogVersion"
     const val TS_TYPE_LINK = "Link"
+    const val TS_TYPE_SEARCH_RESTRICTION = "SearchRestriction"
     const val TS_TYPE_ENUMERATION_VALUE = "EnumerationValue"
     const val TS_META_TYPE_ATTRIBUTE_DESCRIPTOR = "AttributeDescriptor"
     const val TS_JAVA_LANG_PREFIX = "java.lang."

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/injection/FlexibleSearchInjectorProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/injection/FlexibleSearchInjectorProvider.kt
@@ -48,14 +48,16 @@ abstract class FlexibleSearchInjectorProvider {
         injectionPlacesRegistrar: InjectedLanguagePlaces,
         host: PsiElement,
         quoteLength: Int = 1,
+        prefix: String? = null,
+        suffix: String? = null,
         textRange: TextRange = TextRange.from(quoteLength, host.textLength - (quoteLength * 2))
     ) {
         try {
             injectionPlacesRegistrar.addPlace(
                 FlexibleSearchLanguage.INSTANCE,
                 textRange,
-                null,
-                null
+                prefix,
+                suffix
             )
         } catch (e: ProcessCanceledException) {
             // ignore

--- a/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
+++ b/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
@@ -88,8 +88,10 @@ root_macro_usage ::= MACRO_USAGE FIELD_VALUE_SEPARATOR*
 
 
 header_line ::= any_header_mode full_header_type ((PARAMETERS_SEPARATOR full_header_parameter) | PARAMETERS_SEPARATOR)*
-{pin = 1}
-
+{
+    pin = 1
+    methods=[getFullHeaderParameter]
+}
 
 comment ::= LINE_COMMENT
 {pin = 1}
@@ -137,7 +139,7 @@ value_line ::= (sub_type_name value_group*) | (value_group+) {
 value_group ::= FIELD_VALUE_SEPARATOR value?
 {
     pin=1
-    methods=[getFullHeaderParameter getColumnNumber getValueLine]
+    methods=[getFullHeaderParameter getColumnNumber getValueLine computeValue]
 }
 
 value ::= (((  FIELD_VALUE
@@ -188,7 +190,7 @@ full_header_parameter ::= any_header_parameter_name parameters? modifiers* param
 {
     pin=1
     recoverWhile=not_line_break_or_parameters_separator
-    methods=[getHeaderLine getColumnNumber]
+    methods=[getHeaderLine getColumnNumber getAttribute]
 }
 
 any_header_parameter_name ::= HEADER_PARAMETER_NAME | HEADER_SPECIAL_PARAMETER_NAME | macro_usage_dec | DOCUMENT_ID | FUNCTION

--- a/src/com/intellij/idea/plugin/hybris/psi/injector/LanguageInjectionUtil.kt
+++ b/src/com/intellij/idea/plugin/hybris/psi/injector/LanguageInjectionUtil.kt
@@ -22,6 +22,7 @@ import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexString
 import com.intellij.idea.plugin.hybris.system.businessProcess.BpDomFileDescription
 import com.intellij.idea.plugin.hybris.system.type.ScriptType
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.util.parentOfType
 import com.intellij.psi.xml.XmlFile
@@ -48,27 +49,13 @@ object LanguageInjectionUtil {
             }
             ?: return null
 
-        val scriptTypeColumn = header
-            .fullHeaderParameterList
-            .find { it.anyHeaderParameterName.textMatches("scriptType") }
+        val scriptTypeColumn = header.getFullHeaderParameter("scriptType")
             ?: return ScriptType.GROOVY
 
         return valueGroup.valueLine
             ?.getValueGroup(scriptTypeColumn.columnNumber)
-            ?.value
-            ?.text
-            ?.trim()
+            ?.computeValue()
             ?.let { ScriptType.byName(it) }
-            ?: scriptTypeColumn
-                .modifiersList
-                .flatMap { it.attributeList }
-                .find { it.anyAttributeName.textMatches("default") }
-                ?.anyAttributeValue
-                ?.stringList
-                ?.firstOrNull()
-                ?.text
-                ?.replace("\"", "")
-                ?.let { ScriptType.byName(it) }
     }
 
     fun tryInject(


### PR DESCRIPTION
`restrictionType` will be injected as fake psi elements before SearchRestriction query to ensure that FxS is valid.

generated fake prefix: `SELECT {pk} FROM {<restrictionType>} WHERE `

Documentation: https://help.sap.com/docs/SAP_COMMERCE/d0224eca81e249cb821f2cdf45a82ace/8c428f8286691014970ceee87aa01605.html?locale=en-US

<img width="2375" alt="Screenshot 2023-05-24 at 16 55 58" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/eb5467b1-d2a3-4924-9d46-791b7fe60a64">
