### PR TITLE
`ImpEx`: alignment strategy is not file specific and fails in multithreading environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Flaky ProcessCanceledException during TS/BS files modification [#412](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/412)
 - Incorrect resolution of the relation attributes in the `ImpEx` header line [#440](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/440)
 - Improved code completion for ImpEx sub-types [#447](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/447)
+- `ImpEx` alignment strategy is not file specific and fails in multithreading environment [#454](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/454)
 - Inject `FlexibleSearch` language only into `query` column of the `SearchRestriction` in `ImpEx` files [#441](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/441)
 
 ### Deprecated

--- a/src/com/intellij/idea/plugin/hybris/impex/formatting/ImpexBlock.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/formatting/ImpexBlock.java
@@ -41,25 +41,26 @@ public class ImpexBlock extends AbstractBlock {
 
     private final SpacingBuilder spacingBuilder;
     private final CodeStyleSettings codeStyleSettings;
+    private final AlignmentStrategy alignmentStrategy;
 
     public ImpexBlock(
         @NotNull final ASTNode node,
         @Nullable final Wrap wrap,
         @Nullable final Alignment alignment,
         @NotNull final SpacingBuilder spacingBuilder,
-        @NotNull final CodeStyleSettings codeStyleSettings
-    ) {
+        @NotNull final CodeStyleSettings codeStyleSettings,
+        @NotNull final AlignmentStrategy alignmentStrategy) {
         super(node, wrap, alignment);
 
         this.spacingBuilder = spacingBuilder;
         this.codeStyleSettings = codeStyleSettings;
+        this.alignmentStrategy = alignmentStrategy;
     }
 
     @Override
     protected List<Block> buildChildren() {
         final List<Block> blocks = new ArrayList<Block>();
 
-        final AlignmentStrategy alignmentStrategy = getAlignmentStrategy();
         alignmentStrategy.processNode(myNode);
 
         ASTNode currentNode = myNode.getFirstChildNode();
@@ -73,7 +74,8 @@ public class ImpexBlock extends AbstractBlock {
                     null,
                     alignmentStrategy.getAlignment(currentNode),
                     spacingBuilder,
-                    codeStyleSettings
+                    codeStyleSettings,
+                    alignmentStrategy
                 );
 
                 blocks.add(block);
@@ -83,20 +85,6 @@ public class ImpexBlock extends AbstractBlock {
         }
 
         return blocks;
-    }
-
-    @NotNull
-    private AlignmentStrategy getAlignmentStrategy() {
-        final ImpexCodeStyleSettings impexCodeStyleSettings = this.codeStyleSettings.getCustomSettings(
-            ImpexCodeStyleSettings.class
-        );
-
-        if (impexCodeStyleSettings.TABLIFY) {
-
-            return ApplicationManager.getApplication().getService(TableAlignmentStrategy.class);
-        }
-
-        return ApplicationManager.getApplication().getService(ColumnsAlignmentStrategy.class);
     }
 
     private boolean isNotWhitespaceOrNewLine(final ASTNode currentNode) {

--- a/src/com/intellij/idea/plugin/hybris/impex/formatting/ImpexFormattingModelBuilder.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/formatting/ImpexFormattingModelBuilder.java
@@ -36,28 +36,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public class ImpexFormattingModelBuilder implements FormattingModelBuilder {
 
-    @Override
-    public @NotNull FormattingModel createModel(@NotNull FormattingContext formattingContext) {
-        return createModelInternally(formattingContext.getPsiElement(), formattingContext.getCodeStyleSettings());
-    }
-
-    @NotNull
-    private FormattingModel createModelInternally(final PsiElement element, final CodeStyleSettings settings) {
-        final Block impexBlock = new ImpexBlock(
-            element.getNode(),
-            null,
-            Alignment.createAlignment(),
-            createSpaceBuilder(settings),
-            settings
-        );
-
-        return FormattingModelProvider.createFormattingModelForPsiFile(
-            element.getContainingFile(),
-            impexBlock,
-            settings
-        );
-    }
-
     private static SpacingBuilder createSpaceBuilder(final CodeStyleSettings settings) {
         final ImpexCodeStyleSettings impexSettings = settings.getCustomSettings(ImpexCodeStyleSettings.class);
 
@@ -128,6 +106,37 @@ public class ImpexFormattingModelBuilder implements FormattingModelBuilder {
             .before(ImpexTypes.ALTERNATIVE_PATTERN)
             .spaceIf(impexSettings.SPACE_BEFORE_ALTERNATIVE_PATTERN)
             ;
+    }
+
+    @Override
+    public @NotNull FormattingModel createModel(@NotNull FormattingContext formattingContext) {
+        return createModelInternally(formattingContext.getPsiElement(), formattingContext.getCodeStyleSettings());
+    }
+
+    @NotNull
+    private FormattingModel createModelInternally(final PsiElement element, final CodeStyleSettings settings) {
+        final Block impexBlock = new ImpexBlock(
+            element.getNode(),
+            null,
+            Alignment.createAlignment(),
+            createSpaceBuilder(settings),
+            settings,
+            getAlignmentStrategy(settings)
+        );
+
+        return FormattingModelProvider.createFormattingModelForPsiFile(
+            element.getContainingFile(),
+            impexBlock,
+            settings
+        );
+    }
+
+    @NotNull
+    private AlignmentStrategy getAlignmentStrategy(final CodeStyleSettings settings) {
+        final ImpexCodeStyleSettings impexCodeStyleSettings = settings.getCustomSettings(ImpexCodeStyleSettings.class);
+        return impexCodeStyleSettings.TABLIFY
+            ? new TableAlignmentStrategy()
+            : new ColumnsAlignmentStrategy();
     }
 
     @Nullable


### PR DESCRIPTION
```
java.lang.IndexOutOfBoundsException: Index 8 out of bounds for length 8
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:361)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at com.intellij.idea.plugin.hybris.impex.formatting.ColumnsAlignmentStrategy.getAlignment(ColumnsAlignmentStrategy.java:62)
	at com.intellij.idea.plugin.hybris.impex.formatting.ImpexBlock.buildChildren(ImpexBlock.java:74)
	at com.intellij.psi.formatter.common.AbstractBlock.getSubBlocks(AbstractBlock.java:48)
	at com.intellij.formatting.InitialInfoBuilder.buildFrom(InitialInfoBuilder.java:137)
	at com.intellij.formatting.InitialInfoBuilder.doIteration(InitialInfoBuilder.java:212)
	at com.intellij.formatting.InitialInfoBuilder.iteration(InitialInfoBuilder.java:109)
	at com.intellij.formatting.engine.WrapBlocksState.doIteration(WrapBlocksState.java:47)
	at com.intellij.formatting.engine.State.iteration(State.java:25)
	at com.intellij.formatting.engine.StateProcessor.iteration(StateProcessor.java:26)
	at com.intellij.formatting.FormatProcessor.iteration(FormatProcessor.java:108)
	at com.intellij.formatting.FormatterImpl$MyFormattingTask.iteration(FormatterImpl.java:690)
	at com.intellij.formatting.FormatterImpl.execute(FormatterImpl.java:268)
	at com.intellij.formatting.FormatterImpl.format(FormatterImpl.java:235)
	at com.intellij.psi.impl.source.codeStyle.CodeFormatterFacade.processRange(CodeFormatterFacade.java:114)
	at com.intellij.psi.impl.source.codeStyle.CodeFormatterFacade.processElement(CodeFormatterFacade.java:65)
	at com.intellij.formatting.service.CoreFormattingService.formatElement(CoreFormattingService.java:44)
	at com.intellij.formatting.service.FormattingServiceUtil.formatElement(FormattingServiceUtil.java:67)
	at com.intellij.psi.impl.source.codeStyle.CodeStyleManagerImpl.reformat(CodeStyleManagerImpl.java:79)
	at com.intellij.codeInspection.incorrectFormatting.FormattingChangesKt.detectFormattingChanges(FormattingChanges.kt:68)
	at com.intellij.formatting.visualLayer.VisualFormattingLayerServiceImpl.collectVisualFormattingLayerElements$lambda$9(VisualFormattingLayerServiceImpl.kt:58)
	at com.intellij.application.options.CodeStyle.doWithTemporarySettings(CodeStyle.java:314)
	at com.intellij.formatting.visualLayer.VisualFormattingLayerServiceImpl.collectVisualFormattingLayerElements(VisualFormattingLayerServiceImpl.kt:56)
	at com.intellij.formatting.visualLayer.VisualFormattingLayerHighlightingPass.doCollectInformation(VisualFormattingLayerHighlightingPass.kt:28)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:57)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:391)
	at com.intellij.platform.diagnostic.telemetry.impl.TraceKt.runWithSpanIgnoreThrows(trace.kt:82)
	at com.intellij.platform.diagnostic.telemetry.impl.TraceUtil.runWithSpanThrows(TraceUtil.java:24)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:387)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1149)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:378)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:608)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:683)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:639)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:607)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:61)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:377)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:353)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:196)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:211)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:351)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:181)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

```