### PR TITLE
`ImpEx`: inspection rule - validate that inline type for reference parameter extends its type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Inject FlexibleSearch language into `SearchRestriction :: query` respecting `restrictedType` [#434](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/434)
 - Inject complete `User Rights` block on code completion for `$START_USERRIGHTS` [#446](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/446)
 - Inject space after mode keyword [#448](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/448)
+- Inspection rule: validate that inline type for reference parameter extends its type [#458](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/458)
 - Inspection rule: validate that `lang` modifier value is present in the `lang.packs` [#417](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417)
 - Inspection rule: validate that `lang` modifier is used only for localized attributes [#418](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418)
 

--- a/resources/META-INF/plugin-inspections.xml
+++ b/resources/META-INF/plugin-inspections.xml
@@ -72,6 +72,10 @@
                          groupName="[y] ImpEx" level="WEAK WARNING" language="ImpEx" enabledByDefault="true"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexConfigProcessorInspection"/>
 
+        <localInspection groupPath="SAP Commerce" shortName="ImpexFunctionReferenceTypeMismatchInspection" displayName="[y] Mismatch reference attribute inline type"
+                         groupName="[y] ImpEx" level="ERROR" language="ImpEx" enabledByDefault="true"
+                         implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexFunctionReferenceTypeMismatchInspection"/>
+
         <localInspection groupPath="SAP Commerce" shortName="ImpexUniqueAttributeWithoutIndex" displayName="[y] Unique attribute without an index"
                          groupName="[y] ImpEx" level="WEAK WARNING" language="ImpEx" enabledByDefault="true"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.impex.ImpexUniqueAttributeWithoutIndexInspection"/>

--- a/resources/inspectionDescriptions/ImpexFunctionReferenceTypeMismatchInspection.html
+++ b/resources/inspectionDescriptions/ImpexFunctionReferenceTypeMismatchInspection.html
@@ -1,0 +1,26 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+  ~ Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html lang="en">
+<body>
+This type does not match type of the attribute or is not its sub-type.
+See:
+<a href="https://help.sap.com/docs/SAP_COMMERCE/d0224eca81e249cb821f2cdf45a82ace/1c8f5bebdc6e434782ff0cfdb0ca1847.html?locale=en-US">ImpEx
+    Header</a>
+</body>
+</html>

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexFunctionReferenceTypeMismatchInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexFunctionReferenceTypeMismatchInspection.kt
@@ -1,0 +1,100 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.rule.impex
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexMacroUsageDec
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexParameter
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexTypes.DOCUMENT_ID
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexVisitor
+import com.intellij.idea.plugin.hybris.impex.psi.references.ImpexFunctionTSItemReference
+import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
+import com.intellij.idea.plugin.hybris.system.type.meta.model.*
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+
+class ImpexFunctionReferenceTypeMismatchInspection : LocalInspectionTool() {
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.ERROR
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = ImpexHeaderLineVisitor(holder)
+
+    private class ImpexHeaderLineVisitor(private val problemsHolder: ProblemsHolder) : ImpexVisitor() {
+
+        override fun visitParameter(parameter: ImpexParameter) {
+            if (parameter.firstChild is ImpexMacroUsageDec || (parameter.firstChild as? LeafPsiElement)?.elementType == DOCUMENT_ID) return
+
+            val typeReference = parameter.references
+                .find { it is ImpexFunctionTSItemReference }
+                ?.let { it as? ImpexFunctionTSItemReference }
+                ?.takeIf { it.multiResolve(false).isNotEmpty() }
+                ?: return
+
+            val expectedItemType = parameter.referenceItemTypeName ?: return
+            val inlineType = typeReference.value
+            val metaModelAccess = TSMetaModelAccess.getInstance(parameter.project)
+            val referenceMeta = metaModelAccess.findMetaClassifierByName(expectedItemType)
+                ?: return
+
+            when (referenceMeta) {
+                is TSGlobalMetaItem -> {
+                    metaModelAccess.getAll<TSGlobalMetaItem>(TSMetaType.META_ITEM)
+                        .any { meta ->
+                            meta.allExtends.find { it.name == inlineType } != null
+                                // or itself, it will be highlighted as unnecessary via Inspection
+                                || meta.name == inlineType
+                        }
+                        .takeUnless { it }
+                        ?.let {
+                            problemsHolder.registerProblemForReference(
+                                typeReference,
+                                ProblemHighlightType.ERROR,
+                                message("hybris.inspections.impex.ImpexMismatchFunctionTypeInspection.key",
+                                    inlineType,
+                                    expectedItemType,
+                                    parameter.referenceName ?: "?"
+                                ),
+                            )
+                        }
+                }
+
+                is TSGlobalMetaEnum -> registerProblemTypeMismatch(typeReference, inlineType, "Enum")
+                is TSGlobalMetaCollection -> registerProblemTypeMismatch(typeReference, inlineType, "Collection")
+                is TSGlobalMetaMap -> registerProblemTypeMismatch(typeReference, inlineType, "Map")
+                is TSGlobalMetaRelation -> registerProblemTypeMismatch(typeReference, inlineType, "Relation")
+                is TSGlobalMetaAtomic -> registerProblemTypeMismatch(typeReference, inlineType, "Atomic")
+            }
+        }
+
+        private fun registerProblemTypeMismatch(
+            typeReference: ImpexFunctionTSItemReference,
+            inlineType: String,
+            type: String
+        ) {
+            problemsHolder.registerProblemForReference(
+                typeReference,
+                ProblemHighlightType.ERROR,
+                message("hybris.inspections.impex.ImpexMismatchFunctionTypeInspection.onlyItemType.key", inlineType, type),
+            )
+        }
+
+    }
+}


### PR DESCRIPTION
<img width="1027" alt="Screenshot 2023-05-28 at 12 48 06" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/14e557ae-0c2c-4d20-94cc-5ca0a900ae5b">
<img width="604" alt="Screenshot 2023-05-28 at 12 47 59" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/253dcb56-5d43-48e0-902a-8914580bbfb6">
