### PR TITLE
Do not inject `FlexibleSearch` language into strings starting with `#%`  in `ImpEx` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - `ImpEx` alignment strategy is not file specific and fails in multithreading environment [#454](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/454)
 - `ImpEx` inline type reference is not correctly validated [#461](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/461)
 - Inject `FlexibleSearch` language only into `query` column of the `SearchRestriction` in `ImpEx` files [#441](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/441)
+- Do not inject `FlexibleSearch` language into strings starting with `#%`  in `ImpEx` files [#462](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/462)
 
 ### Deprecated
 - `TreeSpeedSearch` -> `TreeUIHelper` [#415](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/415)

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/injection/impl/FlexibleSearchToImpexInjectorProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/injection/impl/FlexibleSearchToImpexInjectorProvider.kt
@@ -47,6 +47,9 @@ class FlexibleSearchToImpexInjectorProvider : FlexibleSearchInjectorProvider() {
 
         val expression = StringUtil.unquoteString(host.getText()).lowercase(Locale.getDefault())
 
+        // do not inject executable statement
+        if (expression.startsWith("#%")) return
+
         val valueLine = host.valueGroup
             ?.valueLine
 


### PR DESCRIPTION
**Before**
<img width="776" alt="Screenshot 2023-05-28 at 14 57 06" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/e273e269-095b-4be5-9a9f-b155a6edbb53">


**After**
<img width="801" alt="Screenshot 2023-05-28 at 14 58 18" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/4c545334-32b2-41a1-9ddc-88bccb65e503">
