### PR TITLE
`ImpEx`: inspection rule - unique document id rule will report both DocId and reference qualifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Inspection rule: validate that inline type for reference parameter exists [#459](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/459)
 - Inspection rule: validate that `lang` modifier value is present in the `lang.packs` [#417](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417)
 - Inspection rule: validate that `lang` modifier is used only for localized attributes [#418](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418)
+- Inspection rule: unique document id rule will report both DocId and rreference qualifier [#463](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/463)
 
 ### `ImpEx` - `User Rights` 2.0
 - SAP Help Portal - [User Rights](https://help.sap.com/docs/SAP_COMMERCE/50c996852b32456c96d3161a95544cdb/e472718cafe840c39fbb5ceb00002e52.html?locale=en-US)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - Inspection rule: validate that inline type for reference parameter exists [#459](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/459)
 - Inspection rule: validate that `lang` modifier value is present in the `lang.packs` [#417](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/417)
 - Inspection rule: validate that `lang` modifier is used only for localized attributes [#418](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/418)
-- Inspection rule: unique document id rule will report both DocId and rreference qualifier [#463](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/463)
+- Inspection rule: unique document id rule will report both DocId and reference qualifier [#463](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/463)
 
 ### `ImpEx` - `User Rights` 2.0
 - SAP Help Portal - [User Rights](https://help.sap.com/docs/SAP_COMMERCE/50c996852b32456c96d3161a95544cdb/e472718cafe840c39fbb5ceb00002e52.html?locale=en-US)

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -252,7 +252,7 @@ hybris.editor.gutter.ts.interceptor.tooltip.text=Navigate to [y] Interceptor dec
 hybris.editor.gutter.ts.interceptor.no.matches=Interceptors are not registered
 
 hybris.inspections.impex.ImpexUniqueAttributeWithoutIndexInspection.key=[y] Attribute ''{0}'' does not have an index for ''{1}'' type
-hybris.inspections.impex.ImpexUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' already used
+hybris.inspections.impex.ImpexUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' already used for reference ''{0]''
 hybris.inspections.impex.ImpexConfigProcessorInspection.key=[y] Incorrect use of the ''{0}'' macros - not defined ConfigPropertyImportProcessor
 hybris.inspections.impex.ImpexUnknownConfigPropertyInspection.param.key=[y] Unknown config property ''{0}''
 hybris.inspections.impex.ImpexUnknownConfigPropertyInspection.key=[y] Unknown config property ''{0}''

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -252,7 +252,7 @@ hybris.editor.gutter.ts.interceptor.tooltip.text=Navigate to [y] Interceptor dec
 hybris.editor.gutter.ts.interceptor.no.matches=Interceptors are not registered
 
 hybris.inspections.impex.ImpexUniqueAttributeWithoutIndexInspection.key=[y] Attribute ''{0}'' does not have an index for ''{1}'' type
-hybris.inspections.impex.ImpexUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' already used for reference ''{0]''
+hybris.inspections.impex.ImpexUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' is already used for docId ''{1}''
 hybris.inspections.impex.ImpexConfigProcessorInspection.key=[y] Incorrect use of the ''{0}'' macros - not defined ConfigPropertyImportProcessor
 hybris.inspections.impex.ImpexUnknownConfigPropertyInspection.param.key=[y] Unknown config property ''{0}''
 hybris.inspections.impex.ImpexUnknownConfigPropertyInspection.key=[y] Unknown config property ''{0}''


### PR DESCRIPTION
**Before**
<img width="334" alt="Screenshot 2023-05-28 at 15 10 21" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/7f315625-0163-4dbf-8155-caa2599ee8e7">

**After**
<img width="514" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/b3fcf25d-a3fa-47b3-8a72-52e501100a8b">
