### PR TITLE
`FlexibleSearch`: resolve `Link` relation ends for relation references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Added possibility to copy FlexibleSearch from the Java 15 text block `"""SELECT * FROM {Product}"""` [#428](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/428)
 - Added FlexibleSearch language injection into Java 15 text block `"""SELECT * FROM {Product}"""` [#430](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/430)
 - Resolve [y] column by table name if alias is not provided (enabled by default) [#444](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/444)
+- Resolve `Link` relation ends for relation references [#464](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/464)
 - Remove spaces around `.` and `:` characters [#442](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/442)
 - Remove spaces before `,` character [#443](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/443)
 

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/reference/FxSYColumnReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/reference/FxSYColumnReference.kt
@@ -203,10 +203,7 @@ class FxSYColumnReference(owner: FlexibleSearchYColumnName) : PsiReferenceBase.P
                 return arrayOf(RelationEndResolveResult(meta.target))
             }
 
-            return metaService.findMetaItemByName(HybrisConstants.TS_TYPE_LINK)
-                ?.allAttributes
-                ?.find { refName.equals(it.name, true) }
-                ?.let { arrayOf(AttributeResolveResult(it)) }
+            return tryResolveByItemType(HybrisConstants.TS_TYPE_LINK, refName, metaService)
         }
 
         private fun tryResolveByEnumType(type: String, refName: String, metaService: TSMetaModelAccess): Array<ResolveResult>? = metaService.findMetaEnumByName(type)


### PR DESCRIPTION
**Before**
<img width="672" alt="Screenshot 2023-05-28 at 16 27 54" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/8f403712-18b7-41e9-9db5-a6f574ed142f">

**After**

<img width="693" alt="Screenshot 2023-05-28 at 16 29 39" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/c779a4a3-0504-43f7-b5b5-53bcb2c6e8ca">
