### PR TITLE
NPE in manifest files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [2023.2.1]
 
+### Fixes
+- NPE in manifest files [#469](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/469)
+
 ### Other
 - [Gradle](https://gradle.org/releases/): 8.1 -> 8.1.1
 - [jsoup](https://jsoup.org/): 1.15.4 -> 1.16.1

--- a/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestCommerceJsonSchemaFileProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestCommerceJsonSchemaFileProvider.kt
@@ -11,7 +11,7 @@ import com.jetbrains.jsonSchema.extension.SchemaType
 class ManifestCommerceJsonSchemaFileProvider(val project: Project) : JsonSchemaFileProvider {
 
     override fun isAvailable(file: VirtualFile) = HybrisConstants.CCV2_MANIFEST_NAME == file.name
-            && HybrisConstants.CCV2_CORE_CUSTOMIZE_NAME == file.parent.name
+            && HybrisConstants.CCV2_CORE_CUSTOMIZE_NAME == file.parent?.name
             && HybrisProjectSettingsComponent.getInstance(project).isHybrisProject()
 
     override fun getName() = "SAP Commerce Cloud Manifest"

--- a/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestDataHubJsonSchemaFileProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestDataHubJsonSchemaFileProvider.kt
@@ -10,7 +10,7 @@ import com.jetbrains.jsonSchema.extension.SchemaType
 
 class ManifestDataHubJsonSchemaFileProvider(val project: Project) : JsonSchemaFileProvider {
     override fun isAvailable(file: VirtualFile) = HybrisConstants.CCV2_MANIFEST_NAME == file.name
-            && HybrisConstants.CCV2_DATAHUB_NAME == file.parent.name
+            && HybrisConstants.CCV2_DATAHUB_NAME == file.parent?.name
             && HybrisProjectSettingsComponent.getInstance(project).isHybrisProject()
 
     override fun getName() = "SAP DataHub Manifest"

--- a/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestJavascriptStorefrontJsonSchemaFileProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/manifest/jsonSchema/providers/ManifestJavascriptStorefrontJsonSchemaFileProvider.kt
@@ -10,7 +10,7 @@ import com.jetbrains.jsonSchema.extension.SchemaType
 
 class ManifestJavascriptStorefrontJsonSchemaFileProvider(val project: Project) : JsonSchemaFileProvider {
     override fun isAvailable(file: VirtualFile) = HybrisConstants.CCV2_MANIFEST_NAME == file.name
-            && HybrisConstants.CCV2_JS_STOREFRONT_NAME == file.parent.name
+            && HybrisConstants.CCV2_JS_STOREFRONT_NAME == file.parent?.name
             && HybrisProjectSettingsComponent.getInstance(project).isHybrisProject()
 
     override fun getName() = "SAP Javascript Storefront Manifest"


### PR DESCRIPTION
```
java.lang.NullPointerException: Cannot invoke "com.intellij.openapi.vfs.VirtualFile.getName()" because the return value of "com.intellij.openapi.vfs.VirtualFile.getParent()" is null
at com.intellij.idea.plugin.hybris.system.manifest.jsonSchema.providers.ManifestCommerceJsonSchemaFileProvider.isAvailable(ManifestCommerceJsonSchemaFileProvider.kt:14)
at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.isProviderAvailable(JsonSchemaServiceImpl.java:445)
at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.getProvidersForFile(JsonSchemaServiceImpl.java:259)
at com.jetbrains.jsonSchema.impl.JsonSchemaServiceImpl.getSchemasForFile(JsonSchemaServiceImpl.java:184)
at com.jetbrains.jsonSchema.impl.JsonCachedValues.getSchemaFile(JsonCachedValues.java:246)
at com.jetbrains.jsonSchema.impl.JsonCachedValues.getSchemaFile(JsonCachedValues.java:238)
at com.jetbrains.jsonSchema.impl.JsonCachedValues.lambda$computeSchemaForFile$7(JsonCachedValues.java:224)
at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
```