### PR TITLE
Make language code case-insensitive for `FlexibleSearch`, `ImpEx` and `Polyglot` languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### `FlexibleSearch` enhancements
 - Add case-insensitive suggestion support in FxS query for attribute parameters [#484](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/484)
 
+### Fixes
+- Make language code case-insensitive for FlexibleSearch, ImpEx and Polyglot languages [#485](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/485)
+
 ## [2023.2.1]
 
 ### Features

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -358,7 +358,7 @@ hybris.inspections.fxs.unresolved.columnAlias.key=[y] Unresolved column alias ''
 
 hybris.inspections.fxs.element.language.missing=Missing language isocode for localized attribute
 hybris.inspections.language.unexpected=Language element is not expected for non-localized attribute ''{0}''
-hybris.inspections.language.unsupported=Language ''{0}'' does not present in the property `lang.packs` = ''{1}''
+hybris.inspections.language.unsupported=Language ''{0}'' is not present in the property `lang.packs` = ''{1}''
 hybris.inspections.fxs.element.separator.colon.notAllowed=Colon '':'' separator cannot be used for non-[y] columns
 
 hybris.inspections.pgq.unresolved.type.key=[y] Unresolved type ''{0}''

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageIsNotSupportedInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexLanguageIsNotSupportedInspection.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -47,9 +47,10 @@ class ImpexLanguageIsNotSupportedInspection : LocalInspectionTool() {
             }
                 .trim()
 
-            val supportedLanguages = PropertiesService.getInstance(psi.project).getLanguages()
+            val propertiesService = PropertiesService.getInstance(psi.project)
+            val supportedLanguages = propertiesService.getLanguages()
 
-            if (supportedLanguages.contains(language)) return
+            if (propertiesService.containsLanguage(language, supportedLanguages)) return
 
             holder.registerProblem(
                 psi,

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -410,6 +410,8 @@ object HybrisConstants {
     @JvmField
     val EXCLUDE_GIT_DIRECTORY = FileUtilRt.toSystemDependentName("/.git")
     @JvmField
+    val EXCLUDE_GRADLE_DIRECTORY = FileUtilRt.toSystemDependentName("/.gradle")
+    @JvmField
     val EXCLUDE_TEMP_DIRECTORY = FileUtilRt.toSystemDependentName("/temp")
     @JvmField
     val EXCLUDE_IDEA_DIRECTORY = FileUtilRt.toSystemDependentName("/.idea")

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -119,8 +119,11 @@ class FlexibleSearchAnnotator : AbstractAnnotator(FlexibleSearchSyntaxHighlighte
 
             COLUMN_LOCALIZED_NAME -> {
                 val language = element.text.trim()
-                val supportedLanguages = PropertiesService.getInstance(element.project).getLanguages()
-                if (!supportedLanguages.contains(language)) {
+
+                val propertiesService = PropertiesService.getInstance(element.project)
+                val supportedLanguages = propertiesService.getLanguages()
+
+                if (!propertiesService.containsLanguage(language, supportedLanguages)) {
                     highlightError(
                         holder, element,
                         message(

--- a/src/com/intellij/idea/plugin/hybris/polyglotQuery/lang/annotation/PolyglotQueryAnnotator.kt
+++ b/src/com/intellij/idea/plugin/hybris/polyglotQuery/lang/annotation/PolyglotQueryAnnotator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -49,8 +49,13 @@ class PolyglotQueryAnnotator : Annotator {
                 BIND_PARAMETER -> highlight(BIND_PARAMETER, holder, element)
                 LOCALIZED_NAME -> {
                     val language = element.text.trim()
-                    val supportedLanguages = PropertiesService.getInstance(element.project).getLanguages()
-                    if (!supportedLanguages.contains(language)) {
+
+                    val propertiesService = PropertiesService.getInstance(element.project)
+                    val supportedLanguages = propertiesService.getLanguages()
+
+                    if (propertiesService.containsLanguage(language, supportedLanguages)) {
+                        highlight(LOCALIZED_NAME, holder, element)
+                    } else {
                         highlightError(
                             holder, element,
                             message(
@@ -59,8 +64,6 @@ class PolyglotQueryAnnotator : Annotator {
                                 supportedLanguages.joinToString()
                             )
                         )
-                    } else {
-                        highlight(LOCALIZED_NAME, holder, element)
                     }
                 }
             }

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -685,6 +685,7 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
         final String path = file.toString();
         return path.endsWith(HybrisConstants.EXCLUDE_BOOTSTRAP_DIRECTORY) ||
             path.endsWith(HybrisConstants.EXCLUDE_DATA_DIRECTORY) ||
+            path.endsWith(HybrisConstants.EXCLUDE_GRADLE_DIRECTORY) ||
             path.endsWith(HybrisConstants.EXCLUDE_ECLIPSEBIN_DIRECTORY) ||
             path.endsWith(HybrisConstants.EXCLUDE_GIT_DIRECTORY) ||
             path.endsWith(HybrisConstants.EXCLUDE_IDEA_DIRECTORY) ||

--- a/src/com/intellij/idea/plugin/hybris/properties/PropertiesService.kt
+++ b/src/com/intellij/idea/plugin/hybris/properties/PropertiesService.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -23,6 +23,8 @@ import com.intellij.openapi.project.Project
 interface PropertiesService {
 
     fun getLanguages(): Set<String>
+
+    fun containsLanguage(language: String, supportedLanguages: Set<String>): Boolean
 
     companion object {
         fun getInstance(project: Project): PropertiesService = project.getService(PropertiesService::class.java)

--- a/src/com/intellij/idea/plugin/hybris/properties/impl/PropertiesServiceImpl.kt
+++ b/src/com/intellij/idea/plugin/hybris/properties/impl/PropertiesServiceImpl.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -36,6 +36,11 @@ class PropertiesServiceImpl(val project: Project) : PropertiesService {
         uniqueLanguages.add(HybrisConstants.DEFAULT_LANGUAGE_ISOCODE)
 
         return uniqueLanguages
+            .map { it.lowercase() }
+            .toSet()
     }
+
+    override fun containsLanguage(language: String, supportedLanguages: Set<String>) = supportedLanguages
+        .contains(language.lowercase())
 
 }

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/model/config/hybris/MergeMode.java
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/model/config/hybris/MergeMode.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -29,9 +29,9 @@ package com.intellij.idea.plugin.hybris.system.cockpitng.model.config.hybris;
  * </pre>
  */
 public enum MergeMode implements com.intellij.util.xml.NamedEnum {
-    MERGE("merge"),
-    REMOVE("remove"),
-    REPLACE("replace");
+    MERGE("MERGE"),
+    REMOVE("REMOVE"),
+    REPLACE("REPLACE");
 
     private final String value;
 


### PR DESCRIPTION
- exclude `.gradle` directory during project import scan
- adjusted MergeMode enum values for CockpitNG