### PR TITLE
Fixed single character header column width in TS/BS Systems previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Improved substitution of the `$config-xxx` properties [#496](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/496)
 
 ### Fixes
-- Java single characters are not respected when copying `FlexibleSearch` query  [#495](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/495)
+- Fixed single character header column width in TS/BS Systems previews [#500](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/500)
+- Java single characters are not respected when copying `FlexibleSearch` query [#495](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/495)
 
 ## [2023.2.2]
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/components/AbstractTable.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/components/AbstractTable.kt
@@ -110,8 +110,10 @@ abstract class AbstractTable<Owner : Any, Item>(val myProject: Project) : JBTabl
     private fun setFixedColumnWidth(column: TableColumn, table: JTable, text: String) = with(column) {
         val width = table
             .getFontMetrics(table.font)
-            .stringWidth(" $text ") + JBUIScale.scale(4)
+            .stringWidth("   $text   ")
+            .let { JBUIScale.scale(it) }
 
+        headerValue = " $headerValue"
         preferredWidth = width
         minWidth = width
         maxWidth = width


### PR DESCRIPTION
**before**

<img width="74" alt="Screenshot 2023-07-01 at 7 23 28 PM" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/7ccac3c9-8ee9-4d16-88c4-e7b42ad74be2">

**after**

<img width="91" alt="Screenshot 2023-07-01 at 6 04 39 PM" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/93a84955-3467-4495-a201-bd3c745f7d79">
<img width="245" alt="Screenshot 2023-07-01 at 6 04 55 PM" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/b9342a5d-e8e6-4298-91f7-01a6fd50bdd3">
