### PR TITLE
Fix UI freeze due legacy `items.xml` analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved substitution of the `$config-xxx` properties [#496](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/496)
 
 ### Fixes
+- Fix UI freeze due legacy `items.xml` analysis [#502](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/502)
 - Use DPI-aware borders [#501](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/501)
 - Fixed single character header column width in TS/BS Systems previews [#500](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/500)
 - Java single characters are not respected when copying `FlexibleSearch` query [#495](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/495)

--- a/src/com/intellij/idea/plugin/hybris/system/type/validation/impl/ItemsFileValidation.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/validation/impl/ItemsFileValidation.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -28,6 +28,7 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -46,6 +47,7 @@ class ItemsFileValidation(private val project: Project) : ItemsXmlFileValidation
         if (!HybrisApplicationSettingsComponent.getInstance().state.warnIfGeneratedItemsAreOutOfDate) return false
         if (!file.name.endsWith(HybrisConstants.HYBRIS_ITEMS_XML_FILE_ENDING)) return false
         if (!ModuleUtil.projectContainsFile(project, file, false)) return false
+        if (DumbService.isDumb(project)) return false
 
         return isFileOutOfDateWithGeneratedClasses(file)
     }


### PR DESCRIPTION
```
"AWT-EventQueue-0" prio=0 tid=0x0 nid=0x0 runnable
     java.lang.Thread.State: RUNNABLE
	at kotlin.reflect.jvm.internal.impl.metadata.ProtoBuf$Property.getSerializedSize(ProtoBuf.java:18713)
	at kotlin.reflect.jvm.internal.impl.protobuf.AbstractMessageLite.writeDelimitedTo(AbstractMessageLite.java:86)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.packToByteArray(DeserializedMemberScope.kt:246)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.<init>(DeserializedMemberScope.kt:235)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope.createImplementation(DeserializedMemberScope.kt:226)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope.<init>(DeserializedMemberScope.kt:49)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.<init>(DeserializedClassDescriptor.kt:267)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$memberScopeHolder$1.invoke(DeserializedClassDescriptor.kt:68)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$memberScopeHolder$1.invoke(DeserializedClassDescriptor.kt:68)
	at kotlin.reflect.jvm.internal.impl.descriptors.ScopesHolderForClass$scopeForOwnerModule$2.invoke(ScopesHolderForClass.kt:22)
	at kotlin.reflect.jvm.internal.impl.descriptors.ScopesHolderForClass$scopeForOwnerModule$2.invoke(ScopesHolderForClass.kt:21)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
	at kotlin.reflect.jvm.internal.impl.storage.StorageKt.getValue(storage.kt:42)
	at kotlin.rAAeflect.jvm.internal.impl.descriptors.ScopesHolderForClass.getScopeForOwnerModule(ScopesHolderForClass.kt:21)
	at kotlin.reflect.jvm.internal.impl.descriptors.ScopesHolderForClass.getScope(ScopesHolderForClass.kt:40)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor.getUnsubstitutedMemberScope(DeserializedClassDescriptor.kt:123)
	at kotlin.reflect.jvm.internal.impl.descriptors.impl.AbstractClassDescriptor.getUnsubstitutedMemberScope(AbstractClassDescriptor.java:160)
	at kotlin.reflect.jvm.internal.impl.descriptors.impl.AbstractClassDescriptor$1.invoke(AbstractClassDescriptor.java:50)
	at kotlin.reflect.jvm.internal.impl.descriptors.impl.AbstractClassDescriptor$1.invoke(AbstractClassDescriptor.java:46)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
	at kotlin.reflect.jvm.internal.impl.descriptors.impl.AbstractClassDescriptor.getDefaultType(AbstractClassDescriptor.java:175)
	at kotlin.reflect.jvm.internal.impl.types.KotlinTypeFactory.simpleType(KotlinTypeFactory.kt:85)
	at kotlin.reflect.jvm.internal.impl.types.KotlinTypeFactory.simpleType$default(KotlinTypeFactory.kt:77)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.TypeDeserializer.simpleType(TypeDeserializer.kt:126)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.TypeDeserializer.type(TypeDeserializer.kt:68)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.TypeDeserializer.typeArgument(TypeDeserializer.kt:300)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.TypeDeserializer.simpleType(TypeDeserializer.kt:106)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.TypeDeserializer.type(TypeDeserializer.kt:68)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.MemberDeserializer.loadFunction(MemberDeserializer.kt:218)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.computeFunctions(DeserializedMemberScope.kt:276)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.access$computeFunctions(DeserializedMemberScope.kt:228)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation$functions$1.invoke(DeserializedMemberScope.kt:251)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation$functions$1.invoke(DeserializedMemberScope.kt:251)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunction.invoke(LockBasedStorageManager.java:578)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$MapBasedMemoizedFunctionToNotNull.invoke(LockBasedStorageManager.java:651)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.getContributedFunctions(DeserializedMemberScope.kt:329)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.addFunctionsAndPropertiesTo(DeserializedMemberScope.kt:360)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedMemberScope.computeDescriptors(DeserializedMemberScope.kt:115)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope$allDescriptors$1.invoke(DeserializedClassDescriptor.kt:274)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope$allDescriptors$1.invoke(DeserializedClassDescriptor.kt:273)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
	at kotlin.reflect.jvm.internal.impl.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
	at kotlin.reflect.jvm.internal.impl.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.getContributedDescriptors(DeserializedClassDescriptor.kt:284)
	at kotlin.reflect.jvm.internal.impl.resolve.scopes.ResolutionScope$DefaultImpls.getContributedDescriptors$default(ResolutionScope.kt:50)
	at kotlin.reflect.jvm.internal.KDeclarationContainerImpl.getMembers(KDeclarationContainerImpl.kt:56)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$declaredNonStaticMembers$2.invoke(KClassImpl.kt:162)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$declaredNonStaticMembers$2.invoke(KClassImpl.kt:162)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:93)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getDeclaredNonStaticMembers(KClassImpl.kt:162)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$allNonStaticMembers$2.invoke(KClassImpl.kt:171)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$allNonStaticMembers$2.invoke(KClassImpl.kt:171)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:93)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getAllNonStaticMembers(KClassImpl.kt:171)
	at kotlin.reflect.full.KClasses.getMemberProperties(KClasses.kt:148)
	at org.jetbrains.kotlin.cli.common.arguments.ParseCommandLineArgumentsKt.parsePreprocessedCommandLineArguments(parseCommandLineArguments.kt:126)
	at org.jetbrains.kotlin.cli.common.arguments.ParseCommandLineArgumentsKt.parseCommandLineArguments(parseCommandLineArguments.kt:106)
	at org.jetbrains.kotlin.cli.common.arguments.ParseCommandLineArgumentsKt.parseCommandLineArguments$default(parseCommandLineArguments.kt:103)
	at org.jetbrains.kotlin.config.KotlinFacetSettings.updateMergedArguments(KotlinFacetSettings.kt:182)
	at org.jetbrains.kotlin.config.KotlinFacetSettings.setCompilerArguments(KotlinFacetSettings.kt:192)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetUtils.initializeIfNeeded(KotlinFacetUtils.kt:59)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetUtils.initializeIfNeeded$default(KotlinFacetUtils.kt:36)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetSettingsProviderImpl.calculate(KotlinFacetSettingsProviderImpl.kt:33)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetSettingsProviderImpl.calculate(KotlinFacetSettingsProviderImpl.kt:21)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedEntityCache.get(FineGrainedEntityCache.kt:287)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetSettingsProviderImpl$getInitializedSettings$1.invoke(KotlinFacetSettingsProviderImpl.kt:29)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetSettingsProviderImpl$getInitializedSettings$1.invoke(KotlinFacetSettingsProviderImpl.kt:29)
	at com.intellij.openapi.application.ActionsKt.runReadAction$lambda$3(actions.kt:31)
	at com.intellij.openapi.application.ActionsKt$$Lambda$3101/0x0000000801a0f5a8.compute(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:909)
	at com.intellij.openapi.application.ActionsKt.runReadAction(actions.kt:31)
	at org.jetbrains.kotlin.idea.facet.KotlinFacetSettingsProviderImpl.getInitializedSettings(KotlinFacetSettingsProviderImpl.kt:29)
	at org.jetbrains.kotlin.idea.project.ModulePlatformCache.calculate(ModulePlatformCache.kt:27)
	at org.jetbrains.kotlin.idea.project.ModulePlatformCache.calculate(ModulePlatformCache.kt:15)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedEntityCache.get(FineGrainedEntityCache.kt:287)
	at org.jetbrains.kotlin.idea.base.facet.platform.TargetPlatformDetectorUtils$platform$1.invoke(TargetPlatformDetector.kt:37)
	at org.jetbrains.kotlin.idea.base.facet.platform.TargetPlatformDetectorUtils$platform$1.invoke(TargetPlatformDetector.kt:37)
	at com.intellij.openapi.application.ActionsKt.runReadAction$lambda$3(actions.kt:31)
	at com.intellij.openapi.application.ActionsKt$$Lambda$3101/0x0000000801a0f5a8.compute(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:909)
	at com.intellij.openapi.application.ActionsKt.runReadAction(actions.kt:31)
	at org.jetbrains.kotlin.idea.base.facet.platform.TargetPlatformDetectorUtils.getPlatform(TargetPlatformDetector.kt:37)
	at org.jetbrains.kotlin.idea.base.facet.JvmOnlyProjectChecker$calculate$1.invoke(JvmOnlyProjectChecker.kt:26)
	at org.jetbrains.kotlin.idea.base.facet.JvmOnlyProjectChecker$calculate$1.invoke(JvmOnlyProjectChecker.kt:23)
	at com.intellij.openapi.application.ActionsKt.runReadAction$lambda$3(actions.kt:31)
	at com.intellij.openapi.application.ActionsKt$$Lambda$3101/0x0000000801a0f5a8.compute(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:909)
	at com.intellij.openapi.application.ActionsKt.runReadAction(actions.kt:31)
	at org.jetbrains.kotlin.idea.base.facet.JvmOnlyProjectChecker.calculate(JvmOnlyProjectChecker.kt:23)
	at org.jetbrains.kotlin.idea.base.facet.JvmOnlyProjectChecker.calculate(JvmOnlyProjectChecker.kt:17)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedValueCache.calculate(FineGrainedEntityCache.kt:326)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedValueCache.calculate(FineGrainedEntityCache.kt:313)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedEntityCache.get(FineGrainedEntityCache.kt:287)
	at org.jetbrains.kotlin.idea.base.util.caching.SynchronizedFineGrainedValueCache.value(FineGrainedEntityCache.kt:324)
	at org.jetbrains.kotlin.idea.caches.resolve.IDEKotlinAsJavaSupport.platformSourcesFirst(IDEKotlinAsJavaSupport.kt:192)
	at org.jetbrains.kotlin.idea.caches.resolve.IDEKotlinAsJavaSupport.findFilesForFacade(IDEKotlinAsJavaSupport.kt:167)
	at org.jetbrains.kotlin.asJava.KotlinAsJavaSupportBase.getFacadeClasses(KotlinAsJavaSupportBase.kt:96)
	at org.jetbrains.kotlin.asJava.finder.JavaElementFinder.findClasses(JavaElementFinder.kt:47)
	at org.jetbrains.kotlin.asJava.finder.JavaElementFinder.findClass(JavaElementFinder.kt:35)
	at com.intellij.psi.impl.JavaPsiFacadeImpl.doFindClass(JavaPsiFacadeImpl.java:94)
	at com.intellij.psi.impl.JavaPsiFacadeImpl.findClass(JavaPsiFacadeImpl.java:72)
	at com.intellij.java.library.JavaLibraryUtil.lambda$getLibraryClassMap$0(JavaLibraryUtil.java:93)
	at com.intellij.java.library.JavaLibraryUtil$$Lambda$3446/0x0000000801c036e8.fun(Unknown Source)
	at com.intellij.util.containers.ConcurrentFactoryMap$2.create(ConcurrentFactoryMap.java:174)
	at com.intellij.util.containers.ConcurrentFactoryMap.get(ConcurrentFactoryMap.java:40)
	at java.base@17.0.7/java.util.concurrent.ConcurrentMap.getOrDefault(ConcurrentMap.java:88)
	at com.intellij.java.library.JavaLibraryUtil.hasLibraryClass(JavaLibraryUtil.java:75)
	at com.intellij.microservices.jvm.oas.SwSemContributor.isAvailable(SwSemContributor.kt:18)
	at com.intellij.semantic.SemServiceImpl.lambda$collectProducers$2(SemServiceImpl.java:99)
	at com.intellij.semantic.SemServiceImpl$$Lambda$3438/0x0000000801c0f1e0.accept(Unknown Source)
	at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processWithPluginDescriptor(ExtensionPointImpl.java:300)
	at com.intellij.openapi.extensions.ExtensionPointName.processWithPluginDescriptor(ExtensionPointName.kt:139)
	at com.intellij.semantic.SemServiceImpl.collectProducers(SemServiceImpl.java:83)
	at com.intellij.semantic.SemServiceImpl.ensureInitialized(SemServiceImpl.java:161)
	at com.intellij.semantic.SemServiceImpl.createSemElements(SemServiceImpl.java:117)
	at com.intellij.semantic.SemServiceImpl.getSemElements(SemServiceImpl.java:111)
	at com.intellij.semantic.SemService.getSemElement(SemService.java:31)
	at com.intellij.microservices.url.parameters.RenameableSemElementKt.getSemElement(RenameableSemElement.kt:65)
	at com.intellij.microservices.url.parameters.SemElementRenamePsiElementProcessorKt.t(SemElementRenamePsiElementProcessor.kt:160)
	at com.intellij.microservices.url.parameters.SemElementRenamePsiElementProcessorKt.access$createPomTargetFromSemElement(SemElementRenamePsiElementProcessor.kt:1)
	at com.intellij.microservices.url.parameters.RenameableSemElementUseScopeEnlarger$getAdditionalUseScope$1.invoke(SemElementRenamePsiElementProcessor.kt:115)
	at com.intellij.microservices.url.parameters.RenameableSemElementUseScopeEnlarger$getAdditionalUseScope$1.invoke(SemElementRenamePsiElementProcessor.kt:115)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.SequencesKt___SequencesKt.firstOrNull(_Sequences.kt:168)
	at com.intellij.microservices.url.parameters.SemElementRenamePsiElementProcessorKt.t(SemElementRenamePsiElementProcessor.kt:153)
	at com.intellij.microservices.url.parameters.SemElementRenamePsiElementProcessorKt.access$provide(SemElementRenamePsiElementProcessor.kt:1)
	at com.intellij.microservices.url.parameters.RenameableSemElementUseScopeEnlarger.getAdditionalUseScope(SemElementRenamePsiElementProcessor.kt:115)
	at com.intellij.psi.impl.search.PsiSearchHelperImpl.getUseScope(PsiSearchHelperImpl.java:94)
	at com.intellij.psi.impl.search.PsiSearchHelperImpl.getUseScope(PsiSearchHelperImpl.java:78)
	at com.intellij.psi.search.searches.ClassInheritorsSearch.lambda$search$3(ClassInheritorsSearch.java:200)
	at com.intellij.psi.search.searches.ClassInheritorsSearch$$Lambda$3425/0x0000000801bbf398.compute(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:923)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:76)
	at com.intellij.psi.search.searches.ClassInheritorsSearch.search(ClassInheritorsSearch.java:195)
	at com.intellij.psi.search.searches.ClassInheritorsSearch.search(ClassInheritorsSearch.java:206)
	at com.intellij.idea.plugin.hybris.system.type.validation.impl.ItemsFileValidation.findAllInheritClasses(ItemsFileValidation.kt:124)
	at com.intellij.idea.plugin.hybris.system.type.validation.impl.ItemsFileValidation.isFileOutOfDateWithGeneratedClasses(ItemsFileValidation.kt:83)
	at com.intellij.idea.plugin.hybris.system.type.validation.impl.ItemsFileValidation.isFileOutOfDate(ItemsFileValidation.kt:50)
	at com.intellij.idea.plugin.hybris.startup.event.ItemsXmlFileEditorManagerListener.fileOpened(ItemsXmlFileEditorManagerListener.kt:31)
	at java.base@17.0.7/java.lang.invoke.LambdaForm$DMH/0x00000008010dc000.invokeInterface(LambdaForm$DMH)
	at java.base@17.0.7/java.lang.invoke.LambdaForm$MH/0x00000008010dd000.invoke(LambdaForm$MH)
	at java.base@17.0.7/java.lang.invoke.LambdaForm$MH/0x0000000800631c00.invokeExact_MT(LambdaForm$MH)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:699)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:663)
	at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:422)
	at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:401)
	at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
	at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:460)
	at jdk.proxy2/jdk.proxy2.$Proxy55.fileOpened(Unknown Source)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl$openFileInEdt$3.invokeSuspend(FileEditorManagerImpl.kt:2111)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at com.intellij.openapi.application.impl.DispatchedRunnable.run(DispatchedRunnable.kt:43)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:208)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:190)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:478)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:121)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at com.intellij.openapi.application.impl.FlushQueue$$Lambda$479/0x0000000800606000.run(Unknown Source)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:789)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:740)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:734)
	at java.base@17.0.7/java.security.AccessController.executePrivileged(AccessController.java:776)
	at java.base@17.0.7/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base@17.0.7/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:759)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$10(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue$$Lambda$471/0x00000008005dee08.run(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithoutImplicitRead(ApplicationImpl.java:1485)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueueKt$$Lambda$469/0x00000008005dc000.run(Unknown Source)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueue$$Lambda$468/0x00000008005d6888.run(Unknown Source)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)


```