### PR TITLE
Fix UI freeze due new Intellij IDEA startup activity API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@
 - Improved substitution of the `$config-xxx` properties [#496](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/496)
 
 ### Fixes
+- Fix UI freeze due new Intellij IDEA startup activity API [#504](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/504)
+- Improve disposing of the `ImpEx` Editor listeners [#504](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/504)
 - Ensure that console storage is under `.idea` folder [#503](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/503)
 - Fix UI freeze due legacy `items.xml` analysis [#502](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/502)
 - Use DPI-aware borders [#501](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/501)
 - Fixed single character header column width in TS/BS Systems previews [#500](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/500)
 - Java single characters are not respected when copying `FlexibleSearch` query [#495](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/495)
+
+### Other
+- Updated Gradle plugin to 1.14.2
 
 ## [2023.2.2]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ solrSolrj = "8.11.2"
 # https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
 kotlin = "1.8.21"
 # https://plugins.gradle.org/plugin/org.jetbrains.intellij
-gradleIntelliJPlugin = "1.14.1"
+gradleIntelliJPlugin = "1.14.2"
 # https://plugins.gradle.org/plugin/org.jetbrains.changelog
 changelog = "2.0.0"
 

--- a/resources/META-INF/lang/optional-impex.xml
+++ b/resources/META-INF/lang/optional-impex.xml
@@ -105,8 +105,12 @@
 
         <editorFactoryListener implementation="com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexEditorFactoryListener"/>
 
-        <postStartupActivity order="after hybrisProjectImport" implementation="com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity"/>
-
+        <postStartupActivity order="after hybrisProjectImport"
+                             implementation="com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity"/>
+        <psi.treeChangeListener implementation="com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiTreeChangeListener"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiManager"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexHeaderHighlightingCaretListener"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexColumnHighlightingCaretListener"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.flexibleSearch.injection.impl.FlexibleSearchToImpexInjectorProvider"/>
     </extensions>
 

--- a/resources/META-INF/optional-lang-dependencies.xml
+++ b/resources/META-INF/optional-lang-dependencies.xml
@@ -258,6 +258,8 @@
         <projectService serviceInterface="com.intellij.idea.plugin.hybris.system.bean.meta.BSMetaModelMerger"
                         serviceImplementation="com.intellij.idea.plugin.hybris.system.bean.meta.impl.BSMetaModelMergerImpl"/>
 
+        <projectService serviceImplementation="com.intellij.idea.plugin.hybris.startup.HybrisStandalonePluginUpdateChecker"/>
+
         <postStartupActivity order="first" id="hybrisProjectImport"
                              implementation="com.intellij.idea.plugin.hybris.startup.HybrisProjectImportStartupActivity"/>
         <postStartupActivity order="after hybrisProjectImport"

--- a/src/com/intellij/idea/plugin/hybris/impex/assistance/event/ImpexColumnHighlightingCaretListener.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/assistance/event/ImpexColumnHighlightingCaretListener.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,21 +19,23 @@ package com.intellij.idea.plugin.hybris.impex.assistance.event
 
 import com.intellij.idea.plugin.hybris.common.services.CommonIdeaService
 import com.intellij.idea.plugin.hybris.impex.assistance.ImpexColumnHighlighterService
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 
 class ImpexColumnHighlightingCaretListener : CaretListener {
 
-    private val commonIdeaService = CommonIdeaService.instance
-    private val impexColumnHighlighterService = ImpexColumnHighlighterService.instance
-
     override fun caretPositionChanged(e: CaretEvent) {
-        if (commonIdeaService.isTypingActionInProgress()) {
-            return
-        }
-        impexColumnHighlighterService.highlight(e.editor)
+        if (CommonIdeaService.instance.isTypingActionInProgress()) return
+
+        ImpexColumnHighlighterService.instance.highlight(e.editor)
     }
 
     override fun caretAdded(e: CaretEvent) {}
     override fun caretRemoved(e: CaretEvent) {}
+
+    companion object {
+        val instance: ImpexColumnHighlightingCaretListener = ApplicationManager.getApplication().getService(ImpexColumnHighlightingCaretListener::class.java)
+    }
+
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiManager.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiManager.kt
@@ -15,27 +15,27 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.impex.assistance.event
+package com.intellij.idea.plugin.hybris.impex.psi
 
-import com.intellij.idea.plugin.hybris.common.services.CommonIdeaService
-import com.intellij.idea.plugin.hybris.impex.assistance.ImpexHeaderNameHighlighterService
+import com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexColumnHighlightingCaretListener
+import com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexHeaderHighlightingCaretListener
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.editor.event.CaretEvent
-import com.intellij.openapi.editor.event.CaretListener
+import com.intellij.openapi.editor.EditorFactory
 
-class ImpexHeaderHighlightingCaretListener : CaretListener {
+class ImpexPsiManager : Disposable {
 
-    override fun caretPositionChanged(e: CaretEvent) {
-        if (CommonIdeaService.instance.isTypingActionInProgress()) return
-
-        ImpexHeaderNameHighlighterService.instance.highlight(e.editor)
+    fun registerListeners() {
+        with(EditorFactory.getInstance()) {
+            this.eventMulticaster.addCaretListener(ImpexHeaderHighlightingCaretListener.instance, this@ImpexPsiManager)
+            this.eventMulticaster.addCaretListener(ImpexColumnHighlightingCaretListener.instance, this@ImpexPsiManager)
+        }
     }
 
-    override fun caretAdded(e: CaretEvent) {}
-    override fun caretRemoved(e: CaretEvent) {}
+    override fun dispose() = Unit
 
     companion object {
-        val instance: ImpexHeaderHighlightingCaretListener = ApplicationManager.getApplication().getService(ImpexHeaderHighlightingCaretListener::class.java)
+        val instance: ImpexPsiManager = ApplicationManager.getApplication().getService(ImpexPsiManager::class.java)
     }
 
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiTreeChangeListener.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiTreeChangeListener.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -27,9 +27,6 @@ import com.intellij.psi.util.PsiUtilBase
 
 class ImpexPsiTreeChangeListener : PsiTreeChangeListener {
 
-    private val impexColumnHighlighterService = ImpexColumnHighlighterService.instance
-    private val impexHeaderNameHighlighterService = ImpexHeaderNameHighlighterService.instance
-
     private fun highlightHeader(psiTreeChangeEvent: PsiTreeChangeEvent) {
         val file = psiTreeChangeEvent.file ?: return
         val editor = PsiEditorUtil.findEditor(file) ?: return
@@ -37,27 +34,9 @@ class ImpexPsiTreeChangeListener : PsiTreeChangeListener {
         if (project.isDisposed) return
 
         if (PsiUtilBase.getLanguageInEditor(editor, project) is ImpexLanguage) {
-            impexHeaderNameHighlighterService.highlight(editor)
-            impexColumnHighlighterService.highlight(editor)
+            ImpexHeaderNameHighlighterService.instance.highlight(editor)
+            ImpexColumnHighlighterService.instance.highlight(editor)
         }
-    }
-
-    override fun beforeChildAddition(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
-    override fun beforeChildRemoval(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
-    override fun beforeChildReplacement(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
-    override fun beforeChildMovement(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
-    override fun beforeChildrenChange(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
-    override fun beforePropertyChange(psiTreeChangeEvent: PsiTreeChangeEvent) {
     }
 
     override fun childAdded(psiTreeChangeEvent: PsiTreeChangeEvent) {
@@ -72,13 +51,17 @@ class ImpexPsiTreeChangeListener : PsiTreeChangeListener {
         highlightHeader(psiTreeChangeEvent)
     }
 
-    override fun childrenChanged(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
-
     override fun childMoved(psiTreeChangeEvent: PsiTreeChangeEvent) {
         highlightHeader(psiTreeChangeEvent)
     }
 
-    override fun propertyChanged(psiTreeChangeEvent: PsiTreeChangeEvent) {
-    }
+
+    override fun beforeChildAddition(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun beforeChildRemoval(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun beforeChildReplacement(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun beforeChildMovement(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun beforeChildrenChange(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun beforePropertyChange(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun childrenChanged(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
+    override fun propertyChanged(psiTreeChangeEvent: PsiTreeChangeEvent) = Unit
 }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -67,6 +67,9 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
 
         configureCommonRoots(moduleDescriptor, contentEntry, dirsToIgnore);
 
+        if (moduleDescriptor instanceof final CCv2ModuleDescriptor yCCv2ModuleDescriptor) {
+            contentEntry.addExcludePattern("hybris");
+        }
         if (moduleDescriptor instanceof final YWebSubModuleDescriptor ySubModuleDescriptor) {
             configureSubModule(ySubModuleDescriptor, contentEntry, dirsToIgnore);
         }

--- a/src/com/intellij/idea/plugin/hybris/startup/HybrisPluginUpdateCheckerStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/HybrisPluginUpdateCheckerStartupActivity.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -17,35 +17,20 @@
  */
 package com.intellij.idea.plugin.hybris.startup
 
-import com.intellij.ide.plugins.StandalonePluginUpdateChecker
-import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
-import com.intellij.notification.NotificationGroupManager
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.openapi.updateSettings.impl.UpdateSettings
-import com.intellij.openapi.util.Disposer
 
-class HybrisPluginUpdateCheckerStartupActivity : ProjectActivity, Disposable {
+class HybrisPluginUpdateCheckerStartupActivity : ProjectActivity {
 
     override suspend fun execute(project: Project) {
         ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) return@invokeLater
+
             UpdateSettings.getInstance().state.isCheckNeeded = true
-            val checker = StandalonePluginUpdateChecker(
-                PluginId.getId(HybrisConstants.PLUGIN_ID),
-                HybrisConstants.UPDATE_TIMESTAMP_PROPERTY,
-                NotificationGroupManager.getInstance().getNotificationGroup(HybrisConstants.NOTIFICATION_GROUP_HYBRIS),
-                HybrisIcons.Y_LOGO_BLUE
-            )
-            Disposer.register(this, checker)
+            val checker = HybrisStandalonePluginUpdateChecker.getInstance(project)
             checker.pluginUsed()
         }
-    }
-
-    override fun dispose() {
-        // NOP
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/startup/HybrisStandalonePluginUpdateChecker.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/HybrisStandalonePluginUpdateChecker.kt
@@ -15,17 +15,24 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.system.cockpitng.meta
 
+package com.intellij.idea.plugin.hybris.startup
+
+import com.intellij.ide.plugins.StandalonePluginUpdateChecker
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 
-interface CngMetaModelAccess {
+class HybrisStandalonePluginUpdateChecker : StandalonePluginUpdateChecker(
+    PluginId.getId(HybrisConstants.PLUGIN_ID),
+    HybrisConstants.UPDATE_TIMESTAMP_PROPERTY,
+    NotificationGroupManager.getInstance().getNotificationGroup(HybrisConstants.NOTIFICATION_GROUP_HYBRIS),
+    HybrisIcons.Y_LOGO_BLUE
+) {
 
     companion object {
-        fun getInstance(project: Project): CngMetaModelAccess = project.getService(CngMetaModelAccess::class.java)
+        fun getInstance(project: Project): HybrisStandalonePluginUpdateChecker = project.getService(HybrisStandalonePluginUpdateChecker::class.java)
     }
-
-    fun initMetaModel()
-    fun getMetaModel(): CngGlobalMetaModel
-
 }

--- a/src/com/intellij/idea/plugin/hybris/startup/ImpexHeaderHighlighterStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/ImpexHeaderHighlighterStartupActivity.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -17,27 +17,16 @@
  */
 package com.intellij.idea.plugin.hybris.startup
 
-import com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexColumnHighlightingCaretListener
-import com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexHeaderHighlightingCaretListener
-import com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiTreeChangeListener
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiManager
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
-import com.intellij.openapi.Disposable
-import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
-import com.intellij.psi.PsiManager
 
-class ImpexHeaderHighlighterStartupActivity : ProjectActivity, Disposable {
+class ImpexHeaderHighlighterStartupActivity : ProjectActivity {
 
     override suspend fun execute(project: Project) {
         if (!HybrisProjectSettingsComponent.getInstance(project).isHybrisProject()) return
 
-        PsiManager.getInstance(project).addPsiTreeChangeListener(ImpexPsiTreeChangeListener(), this)
-        val eventFactory = EditorFactory.getInstance()
-        eventFactory.eventMulticaster.addCaretListener(ImpexHeaderHighlightingCaretListener(), this)
-        eventFactory.eventMulticaster.addCaretListener(ImpexColumnHighlightingCaretListener(), this)
-    }
-
-    override fun dispose() {
+        ImpexPsiManager.instance.registerListeners();
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/startup/ItemsXmlFileOpenStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/ItemsXmlFileOpenStartupActivity.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -55,7 +55,7 @@ class ItemsXmlFileOpenStartupActivity : ProjectActivity {
                 }
             }
         }
-        DumbService.getInstance(project).smartInvokeLater {
+        DumbService.getInstance(project).runWhenSmart {
             ProgressManager.getInstance().runProcessWithProgressAsynchronously(task, BackgroundableProcessIndicator(task))
         }
     }

--- a/src/com/intellij/idea/plugin/hybris/startup/PreLoadSystemsStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/PreLoadSystemsStartupActivity.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -21,8 +21,8 @@ import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.idea.plugin.hybris.system.bean.meta.BSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.cockpitng.meta.CngMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 
@@ -31,13 +31,13 @@ class PreLoadSystemsStartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
         if (!HybrisProjectSettingsComponent.getInstance(project).isHybrisProject()) return
 
-        refreshSystem(project) { TSMetaModelAccess.getInstance(project).getMetaModel() }
-        refreshSystem(project) { BSMetaModelAccess.getInstance(project).getMetaModel() }
-        refreshSystem(project) { CngMetaModelAccess.getInstance(project).getMetaModel() }
+        refreshSystem(project) { TSMetaModelAccess.getInstance(project).initMetaModel() }
+        refreshSystem(project) { BSMetaModelAccess.getInstance(project).initMetaModel() }
+        refreshSystem(project) { CngMetaModelAccess.getInstance(project).initMetaModel() }
     }
 
     private fun refreshSystem(project: Project, refresher: (Project) -> Unit) {
-        ApplicationManager.getApplication().runReadAction {
+        DumbService.getInstance(project).runWhenSmart {
             try {
                 refresher.invoke(project)
             } catch (e: ProcessCanceledException) {

--- a/src/com/intellij/idea/plugin/hybris/system/bean/meta/BSMetaModelAccess.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/meta/BSMetaModelAccess.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -34,6 +34,7 @@ interface BSMetaModelAccess {
         fun getInstance(project: Project): BSMetaModelAccess = project.getService(BSMetaModelAccess::class.java)
     }
 
+    fun initMetaModel()
     fun getMetaModel(): BSGlobalMetaModel
     fun findMetaEnumByName(name: String?): BSGlobalMetaEnum?
     fun findMetaForDom(dom: Enum): BSGlobalMetaEnum?

--- a/src/com/intellij/idea/plugin/hybris/system/type/meta/TSMetaModelAccess.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/meta/TSMetaModelAccess.kt
@@ -1,10 +1,10 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com>
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
@@ -31,6 +31,7 @@ interface TSMetaModelAccess {
         fun getInstance(project: Project): TSMetaModelAccess = project.getService(TSMetaModelAccess::class.java)
     }
 
+    fun initMetaModel()
     fun getMetaModel(): TSGlobalMetaModel
     fun findMetaClassifierByName(name: String?): TSGlobalMetaClassifier<out DomElement>?
     fun findRelationByName(name: String?): List<TSMetaRelation>

--- a/src/com/intellij/idea/plugin/hybris/view/HybrisProjectView.kt
+++ b/src/com/intellij/idea/plugin/hybris/view/HybrisProjectView.kt
@@ -111,17 +111,18 @@ open class HybrisProjectView(val project: Project) : TreeStructureProvider, Dumb
 
         val vf = node.virtualFile
             ?: return true
+
+        // hide `core-customize/hybris` node
+        if (HybrisConstants.HYBRIS_DIRECTORY == vf.name
+            && HybrisConstants.CCV2_CORE_CUSTOMIZE_NAME == parent.name
+        ) return false
+
         val module = ProjectRootManager.getInstance(project).fileIndex.getModuleForFile(vf)
             ?: return true
 
         // hide `platform/ext` node
         if (HybrisConstants.PLATFORM_EXTENSIONS_DIRECTORY_NAME == vf.name
             && HybrisConstants.EXTENSION_NAME_PLATFORM == module.yExtensionName()
-        ) return false
-
-        // hide `core-customize/hybris` node
-        if (HybrisConstants.HYBRIS_DIRECTORY == vf.name
-            && HybrisConstants.CCV2_CORE_CUSTOMIZE_NAME == module.yExtensionName()
         ) return false
 
         return YFacet.getState(module)


### PR DESCRIPTION
```
> Task :runIde
CompileCommand: exclude com/intellij/openapi/vfs/impl/FilePartNodeRoot.trieDescend bool exclude = true
2023-07-01 21:30:53,720 [    536]   WARN - #c.i.u.m.MacOSApplicationProvider - No URL bundle (CFBundleURLTypes) is defined in the main bundle.
To be able to open external links, specify protocols in the app layout section of the build file.
Example: args.urlSchemes = ["your-protocol"] will handle following links: your-protocol://open?file=file&line=line
2023-07-01 21:30:54,405 [   1221]   WARN - #c.i.c.ComponentStoreImpl - Duplicated scheme Light - old: Light, new Light
2023-07-01 21:30:55,859 [   2675]   WARN - #c.i.u.i.IndexId - IndexId name[com.android.tools.idea.model.AndroidManifestIndex$Companion$NAME$1.NAME] should match [[A-Za-z0-9_.\-]+]. Names with unsafe characters could cause issues on some platforms. This warning likely will be escalated to an error in the following releases.

2023-07-01 21:30:56,840 [   3656]   WARN - #c.i.u.i.IndexId - IndexId name[shared.index.hashes.com.android.tools.idea.model.AndroidManifestIndex$Companion$NAME$1.NAME] should match [[A-Za-z0-9_.\-]+]. Names with unsafe characters could cause issues on some platforms. This warning likely will be escalated to an error in the following releases.
2023-07-01 21:30:58,006 [   4822]   WARN - #c.i.u.x.Binding - no accessors for com.intellij.openapi.fileEditor.impl.FileEditorProviderManagerImpl$FileEditorProviderManagerState
2023-07-01 21:31:01,901 [   8717]   WARN - #c.i.i.s.p.i.BundledSharedIndexPostStartupActivity - Skipped 1 pre-built shared indexes: bundled-js-predefined-1d06a55b98c1-d0de29cf174f-JavaScript-IU-232.8453.116
2023-07-01 21:31:17,349 [  24165]   WARN - #c.i.d.PerformanceWatcherImpl - UI was frozen for 9902ms, details saved to /Users/mykhailo_lytvyn/projects/sap-commerce-intellij-idea-plugin/build/idea-sandbox/system/log/threadDumps-freeze-20230701-213112-IU-232.8453.116-Unsafe.park-9sec
2023-07-01 21:32:10,800 [  77616]   WARN - #c.i.u.x.Binding - no accessors for java.time.LocalTime
2023-07-01 21:32:10,965 [  77781] SEVERE - #c.i.u.m.i.MessageBusImpl - Bus is already disposed
java.lang.Throwable: Bus is already disposed
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:370)
	at com.intellij.util.messages.impl.MessageBusConnectionImpl.deliverImmediately(MessageBusConnectionImpl.kt:47)
	at com.intellij.execution.console.ConsoleExecutionEditor.dispose(ConsoleExecutionEditor.java:202)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:129)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:161)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:262)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:250)
	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1214)
	at com.intellij.openapi.project.impl.ProjectImpl.dispose(ProjectImpl.kt:295)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:129)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:161)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:262)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:250)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$lambda$15(ProjectManagerImpl.kt:407)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:992)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject(ProjectManagerImpl.kt:389)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$default(ProjectManagerImpl.kt:319)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeAndDisposeAllProjects(ProjectManagerImpl.kt:312)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$doExit$5(ApplicationImpl.java:650)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.computeWithSpanIgnoreThrows(trace.kt:73)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.computeWithSpanThrows(TraceUtil.java:18)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:646)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:595)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:584)
	at com.intellij.openapi.application.ex.ApplicationEx.exit(ApplicationEx.java:77)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.initMacApplication$lambda$4$lambda$3(MacOSApplicationProvider.kt:78)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.submit$lambda$6(MacOSApplicationProvider.kt:170)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:208)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:190)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:478)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:121)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:789)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:740)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:734)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:759)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$10(IdeEventQueue.kt:589)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithoutImplicitRead(ApplicationImpl.java:1485)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
2023-07-01 21:32:10,968 [  77784] SEVERE - #c.i.u.m.i.MessageBusImpl - IntelliJ IDEA 2023.2 EAP  Build #IU-232.8453.116
2023-07-01 21:32:10,968 [  77784] SEVERE - #c.i.u.m.i.MessageBusImpl - JDK: 17.0.7; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o.
2023-07-01 21:32:10,968 [  77784] SEVERE - #c.i.u.m.i.MessageBusImpl - OS: Mac OS X
2023-07-01 21:32:11,327 [  78143] SEVERE - #c.i.o.u.ObjectTree - Memory leak detected: 'com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity@5685c277' (class com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
The corresponding Disposer.register() stacktrace is shown as the cause:

java.lang.RuntimeException: Memory leak detected: 'com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity@5685c277' (class com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
The corresponding Disposer.register() stacktrace is shown as the cause:

	at com.intellij.openapi.util.ObjectNode.assertNoChildren(ObjectNode.java:45)
	at com.intellij.openapi.util.ObjectTree.assertIsEmpty(ObjectTree.java:218)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:278)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:272)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeContainer(ApplicationImpl.java:223)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$doExit$5(ApplicationImpl.java:660)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.computeWithSpanIgnoreThrows(trace.kt:73)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.computeWithSpanThrows(TraceUtil.java:18)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:646)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:595)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:584)
	at com.intellij.openapi.application.ex.ApplicationEx.exit(ApplicationEx.java:77)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.initMacApplication$lambda$4$lambda$3(MacOSApplicationProvider.kt:78)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.submit$lambda$6(MacOSApplicationProvider.kt:170)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:208)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:190)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:478)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:121)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:789)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:740)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:734)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:759)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$10(IdeEventQueue.kt:589)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithoutImplicitRead(ApplicationImpl.java:1485)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
Caused by: java.lang.Throwable
	at com.intellij.openapi.util.ObjectNode.<init>(ObjectNode.java:24)
	at com.intellij.openapi.util.ObjectNode.findOrCreateChildNode(ObjectNode.java:140)
Caused by: java.lang.Throwable

	at com.intellij.openapi.util.ObjectTree.register(ObjectTree.java:51)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:161)
	at com.intellij.psi.impl.PsiManagerImpl.addPsiTreeChangeListener(PsiManagerImpl.java:184)
	at com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity.execute(ImpexHeaderHighlighterStartupActivity.kt:35)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchActivity$1$1.invokeSuspend(StartupManagerImpl.kt:534)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchActivity$1$1.invoke(StartupManagerImpl.kt)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchActivity$1$1.invoke(StartupManagerImpl.kt)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:78)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:167)
	at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
	at com.intellij.ide.startup.impl.StartupManagerImplKt$launchActivity$1.invokeSuspend(StartupManagerImpl.kt:532)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:793)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:697)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:684)
2023-07-01 21:32:11,329 [  78145] SEVERE - #c.i.o.u.ObjectTree - IntelliJ IDEA 2023.2 EAP  Build #IU-232.8453.116
2023-07-01 21:32:11,330 [  78146] SEVERE - #c.i.o.u.ObjectTree - JDK: 17.0.7; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o.
2023-07-01 21:32:11,330 [  78146] SEVERE - #c.i.o.u.ObjectTree - OS: Mac OS X
2023-07-01 21:32:11,330 [  78146] SEVERE - #c.i.o.u.ObjectTree - Plugin to blame: SAP Commerce Developers Toolset version: 2023.2.3
2023-07-01 21:32:11,330 [  78146] SEVERE - #c.i.o.u.ObjectTree - Memory leak detected: 'com.intellij.idea.plugin.hybris.startup.HybrisPluginUpdateCheckerStartupActivity@2f8963e1' (class com.intellij.idea.plugin.hybris.startup.HybrisPluginUpdateCheckerStartupActivity) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
The corresponding Disposer.register() stacktrace is shown as the cause:

java.lang.RuntimeException: Memory leak detected: 'com.intellij.idea.plugin.hybris.startup.HybrisPluginUpdateCheckerStartupActivity@2f8963e1' (class com.intellij.idea.plugin.hybris.startup.HybrisPluginUpdateCheckerStartupActivity) was registered in Disposer as a child of 'ROOT_DISPOSABLE' (class com.intellij.openapi.util.Disposer$2) but wasn't disposed.
Register it with a proper parentDisposable or ensure that it's always disposed by direct Disposer.dispose call.
See https://jetbrains.org/intellij/sdk/docs/basics/disposers.html for more details.
The corresponding Disposer.register() stacktrace is shown as the cause:

	at com.intellij.openapi.util.ObjectNode.assertNoChildren(ObjectNode.java:45)
	at com.intellij.openapi.util.ObjectTree.assertIsEmpty(ObjectTree.java:218)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:278)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:272)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeContainer(ApplicationImpl.java:223)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$doExit$5(ApplicationImpl.java:660)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.computeWithSpanIgnoreThrows(trace.kt:73)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.computeWithSpanThrows(TraceUtil.java:18)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:646)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:595)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:584)
	at com.intellij.openapi.application.ex.ApplicationEx.exit(ApplicationEx.java:77)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.initMacApplication$lambda$4$lambda$3(MacOSApplicationProvider.kt:78)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.submit$lambda$6(MacOSApplicationProvider.kt:170)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:208)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:190)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:478)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:121)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:789)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:740)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:734)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:759)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$10(IdeEventQueue.kt:589)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithoutImplicitRead(ApplicationImpl.java:1485)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
Caused by: java.lang.Throwable
	at com.intellij.openapi.util.ObjectNode.<init>(ObjectNode.java:24)
	at com.intellij.openapi.util.ObjectNode.findOrCreateChildNode(ObjectNode.java:140)
	at com.intellij.openapi.util.ObjectTree.register(ObjectTree.java:51)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:161)
	at com.intellij.idea.plugin.hybris.startup.HybrisPluginUpdateCheckerStartupActivity.execute$lambda$0(HybrisPluginUpdateCheckerStartupActivity.kt:43)
	... 37 more
2023-07-01 21:32:11,333 [  78149] SEVERE - #c.i.o.u.ObjectTree - IntelliJ IDEA 2023.2 EAP  Build #IU-232.8453.116
2023-07-01 21:32:11,333 [  78149] SEVERE - #c.i.o.u.ObjectTree - JDK: 17.0.7; VM: OpenJDK 64-Bit Server VM; Vendor: JetBrains s.r.o.
2023-07-01 21:32:11,333 [  78149] SEVERE - #c.i.o.u.ObjectTree - OS: Mac OS X
2023-07-01 21:32:11,334 [  78150] SEVERE - #c.i.o.u.ObjectTree - Plugin to blame: SAP Commerce Developers Toolset version: 2023.2.3


```