### PR TITLE
Refactoring: Get project state only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Features
 - Added possibility to skip non-existing source directories during project import [#511](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/511)
+### Fixes
+- Refactored `ImportProjectProgressModalWindow` so that is calls so that project state retrieved only once [#512](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/512)
+- Changed generated `*.iml` file name when grouping is not selected so file name does not start with a dot [#512](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/512)
 
 ## [2023.2.3]
 

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/ContentRootConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/ContentRootConfigurator.kt
@@ -21,6 +21,7 @@ package com.intellij.idea.plugin.hybris.project.configurators
 import com.intellij.idea.plugin.hybris.project.configurators.impl.ReadOnlyContentRootConfigurator
 import com.intellij.idea.plugin.hybris.project.configurators.impl.RegularContentRootConfigurator
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.roots.ModifiableRootModel
@@ -30,7 +31,8 @@ interface ContentRootConfigurator {
     fun configure(
         indicator: ProgressIndicator,
         modifiableRootModel: ModifiableRootModel,
-        moduleDescriptor: ModuleDescriptor
+        moduleDescriptor: ModuleDescriptor,
+        appSettings: HybrisApplicationSettings
     )
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/JavadocModuleConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/JavadocModuleConfigurator.kt
@@ -19,6 +19,7 @@
 package com.intellij.idea.plugin.hybris.project.configurators
 
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.roots.ModifiableRootModel
@@ -28,7 +29,8 @@ interface JavadocModuleConfigurator {
     fun configure(
         indicator: ProgressIndicator,
         modifiableRootModel: ModifiableRootModel,
-        moduleDescriptor: ModuleDescriptor
+        moduleDescriptor: ModuleDescriptor,
+        appSettings: HybrisApplicationSettings
     )
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/SearchScopeConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/SearchScopeConfigurator.kt
@@ -18,6 +18,7 @@
  */
 package com.intellij.idea.plugin.hybris.project.configurators
 
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.ModifiableModuleModel
 import com.intellij.openapi.progress.ProgressIndicator
@@ -28,6 +29,7 @@ interface SearchScopeConfigurator {
     fun configure(
         indicator: ProgressIndicator,
         project: Project,
+        applicationSettings: HybrisApplicationSettings,
         model: ModifiableModuleModel
     )
 

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultJavadocModuleConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultJavadocModuleConfigurator.java
@@ -21,6 +21,7 @@ package com.intellij.idea.plugin.hybris.project.configurators.impl;
 
 import com.intellij.idea.plugin.hybris.project.configurators.JavadocModuleConfigurator;
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.roots.JavaModuleExternalPaths;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -37,13 +38,14 @@ public class DefaultJavadocModuleConfigurator implements JavadocModuleConfigurat
     public void configure(
         @NotNull ProgressIndicator indicator,
         @NotNull final ModifiableRootModel modifiableRootModel,
-        @NotNull final ModuleDescriptor moduleDescriptor
+        @NotNull final ModuleDescriptor moduleDescriptor,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         indicator.setText2(message("hybris.project.import.module.javadoc"));
 
         final String javadocUrl = moduleDescriptor.getRootProjectDescriptor().getJavadocUrl();
 
-        final List<String> javadocPathList = MavenUtils.resolveMavenJavadocs(modifiableRootModel, moduleDescriptor, indicator);
+        final List<String> javadocPathList = MavenUtils.resolveMavenJavadocs(modifiableRootModel, moduleDescriptor, indicator, appSettings);
         final JavaModuleExternalPaths javaModuleExternalPaths = modifiableRootModel.getModuleExtension(
             JavaModuleExternalPaths.class
         );

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultLibRootsConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultLibRootsConfigurator.kt
@@ -199,7 +199,7 @@ class DefaultLibRootsConfigurator : LibRootsConfigurator {
         moduleDescriptor: ModuleDescriptor,
         progressIndicator: ProgressIndicator
     ) = if (LibraryDescriptorType.LIB == javaLibraryDescriptor.descriptorType) {
-        MavenUtils.resolveMavenSources(modifiableRootModel, moduleDescriptor, progressIndicator)
+        MavenUtils.resolveMavenSources(modifiableRootModel, moduleDescriptor, progressIndicator, HybrisApplicationSettingsComponent.getInstance().getState())
     } else emptyList()
 
     private fun resolveStandardProvidedSources(

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultSearchScopeConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultSearchScopeConfigurator.java
@@ -23,6 +23,7 @@ import com.intellij.find.FindSettings;
 import com.intellij.ide.projectView.impl.ModuleGroup;
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils;
 import com.intellij.idea.plugin.hybris.project.configurators.SearchScopeConfigurator;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.ModifiableModuleModel;
@@ -45,16 +46,14 @@ public class DefaultSearchScopeConfigurator implements SearchScopeConfigurator {
 
     @Override
     public void configure(
-        final @NotNull ProgressIndicator indicator, @NotNull final Project project,
-        @NotNull final ModifiableModuleModel model
+        @NotNull final ProgressIndicator indicator, @NotNull final Project project,
+        @NotNull final HybrisApplicationSettings appSettings, @NotNull final ModifiableModuleModel model
     ) {
         indicator.setText(message("hybris.project.import.search.scope"));
-        final String customGroupName = HybrisApplicationSettingsComponent.getInstance().getState().getGroupCustom();
-        final String commerceGroupName = HybrisApplicationSettingsComponent.getInstance().getState().getGroupHybris();
-        final String nonHybrisGroupName = HybrisApplicationSettingsComponent.getInstance()
-                                                                            .getState()
-                                                                            .getGroupNonHybris();
-        final String platformGroupName = HybrisApplicationSettingsComponent.getInstance().getState().getGroupPlatform();
+        final String customGroupName = appSettings.getGroupCustom();
+        final String commerceGroupName = appSettings.getGroupHybris();
+        final String nonHybrisGroupName = appSettings.getGroupNonHybris();
+        final String platformGroupName = appSettings.getGroupPlatform();
         final List<NamedScope> newScopes = new ArrayList<>();
         NamedScope customScope = null;
         NamedScope platformScope = null;
@@ -75,7 +74,7 @@ public class DefaultSearchScopeConfigurator implements SearchScopeConfigurator {
 
             newScopes.add(new NamedScope(
                 SEARCH_SCOPE_Y_PREFIX + ' ' + HybrisI18NBundleUtils.message("hybris.scope.editable.custom.ts.beans.impex.files"),
-                createCustomTsImpexBeansFilesPattern()
+                createCustomTsImpexBeansFilesPattern(appSettings)
             ));
         }
         if (groupExists(model, platformGroupName)) {
@@ -111,8 +110,8 @@ public class DefaultSearchScopeConfigurator implements SearchScopeConfigurator {
     }
 
     @NotNull
-    public static PackageSet createCustomTsImpexBeansFilesPattern() {
-        final String customGroupName = HybrisApplicationSettingsComponent.getInstance().getState().getGroupCustom();
+    public static PackageSet createCustomTsImpexBeansFilesPattern(final @NotNull HybrisApplicationSettings appSettings) {
+        final String customGroupName = appSettings.getGroupCustom();
         final FilePatternPackageSet tsFilePatternPackageSet = new FilePatternPackageSet(
             customGroupName + '*',
             "*//*" + HYBRIS_ITEMS_XML_FILE_ENDING

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/MavenUtils.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/MavenUtils.java
@@ -20,7 +20,6 @@ package com.intellij.idea.plugin.hybris.project.configurators.impl;
 
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor;
 import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
-import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -62,9 +61,8 @@ public interface MavenUtils {
      static List<String> resolveMavenJavadocs(
         final @NotNull ModifiableRootModel modifiableRootModel,
         final @NotNull ModuleDescriptor moduleDescriptor,
-        final @NotNull ProgressIndicator progressIndicator
+        final @NotNull ProgressIndicator progressIndicator, final HybrisApplicationSettings appSettings
     ) {
-        final HybrisApplicationSettings appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
         if (appSettings.getWithMavenJavadocs()) {
             return resolveMavenDependencies(modifiableRootModel, moduleDescriptor, progressIndicator, false, true);
         }
@@ -72,12 +70,11 @@ public interface MavenUtils {
     }
 
      static List<String> resolveMavenSources(
-        final @NotNull ModifiableRootModel modifiableRootModel,
-        final @NotNull ModuleDescriptor moduleDescriptor,
-        final @NotNull ProgressIndicator progressIndicator
-    ) {
-        final HybrisApplicationSettings appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
-        if (appSettings.getWithMavenSources()) {
+         final @NotNull ModifiableRootModel modifiableRootModel,
+         final @NotNull ModuleDescriptor moduleDescriptor,
+         final @NotNull ProgressIndicator progressIndicator, final HybrisApplicationSettings appSettings
+     ) {
+         if (appSettings.getWithMavenSources()) {
             return resolveMavenDependencies(modifiableRootModel, moduleDescriptor, progressIndicator, true, false);
         }
         return Collections.emptyList();

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/ReadOnlyContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/ReadOnlyContentRootConfigurator.java
@@ -21,6 +21,8 @@ package com.intellij.idea.plugin.hybris.project.configurators.impl;
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.impl.YBackofficeSubModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.impl.YWebSubModuleDescriptor;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.vfs.VfsUtil;
 import org.jetbrains.annotations.NotNull;
@@ -37,9 +39,10 @@ public class ReadOnlyContentRootConfigurator extends RegularContentRootConfigura
     protected void configureCommonRoots(
         @NotNull final ModuleDescriptor moduleDescriptor,
         @NotNull final ContentEntry contentEntry,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
-        configureResourceDirectory(contentEntry, moduleDescriptor, dirsToIgnore);
+        configureResourceDirectory(contentEntry, moduleDescriptor, dirsToIgnore, appSettings);
 
         excludeCommonNeedlessDirs(contentEntry, moduleDescriptor);
     }
@@ -48,7 +51,8 @@ public class ReadOnlyContentRootConfigurator extends RegularContentRootConfigura
     protected void configureSubModule(
         @NotNull final YBackofficeSubModuleDescriptor moduleDescriptor,
         @NotNull final ContentEntry contentEntry,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         final File classesDirectory = new File(moduleDescriptor.getModuleRootDirectory(), CLASSES_DIRECTORY);
         contentEntry.addExcludeFolder(VfsUtil.pathToUrl(classesDirectory.getAbsolutePath()));

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/RegularContentRootConfigurator.java
@@ -25,6 +25,7 @@ import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.ModuleDescriptorType;
 import com.intellij.idea.plugin.hybris.project.descriptors.YSubModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.impl.*;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.roots.ContentEntry;
@@ -60,7 +61,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     public void configure(
         @NotNull final ProgressIndicator indicator,
         @NotNull final ModifiableRootModel modifiableRootModel,
-        @NotNull final ModuleDescriptor moduleDescriptor
+        @NotNull final ModuleDescriptor moduleDescriptor,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         indicator.setText2(message("hybris.project.import.module.content"));
         final ContentEntry contentEntry = modifiableRootModel.addContentEntry(VfsUtil.pathToUrl(
@@ -71,7 +73,7 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             .map(relPath -> new File(moduleDescriptor.getModuleRootDirectory(), relPath))
             .collect(Collectors.toList());
 
-        configureCommonRoots(moduleDescriptor, contentEntry, dirsToIgnore);
+        configureCommonRoots(moduleDescriptor, contentEntry, dirsToIgnore, appSettings);
 
         if (moduleDescriptor instanceof final CCv2ModuleDescriptor yCCv2ModuleDescriptor) {
             contentEntry.addExcludePattern("hybris");
@@ -86,7 +88,7 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             configureSubModule(ySubModuleDescriptor, contentEntry);
         }
         if (moduleDescriptor instanceof final YBackofficeSubModuleDescriptor ySubModuleDescriptor) {
-            configureSubModule(ySubModuleDescriptor, contentEntry, dirsToIgnore);
+            configureSubModule(ySubModuleDescriptor, contentEntry, dirsToIgnore, appSettings);
         }
 
         configurePlatformRoots(moduleDescriptor, contentEntry);
@@ -103,14 +105,15 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     protected void configureCommonRoots(
         @NotNull final ModuleDescriptor moduleDescriptor,
         @NotNull final ContentEntry contentEntry,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         for (String srcDirName : SRC_DIR_NAMES) {
             addSourceFolderIfNotIgnored(
                 contentEntry,
                 new File(moduleDescriptor.getModuleRootDirectory(), srcDirName),
                 JavaSourceRootType.SOURCE,
-                dirsToIgnore
+                dirsToIgnore, appSettings
             );
         }
 
@@ -119,17 +122,17 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             new File(moduleDescriptor.getModuleRootDirectory(), GEN_SRC_DIRECTORY),
             JavaSourceRootType.SOURCE,
             JpsJavaExtensionService.getInstance().createSourceRootProperties("", true),
-            dirsToIgnore
+            dirsToIgnore, appSettings
         );
 
         if (moduleDescriptor instanceof YCustomRegularModuleDescriptor
             || !moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
-            addTestSourceRoots(contentEntry, moduleDescriptor.getModuleRootDirectory(), dirsToIgnore);
+            addTestSourceRoots(contentEntry, moduleDescriptor.getModuleRootDirectory(), dirsToIgnore, appSettings);
         } else {
             excludeTestSourceRoots(contentEntry, moduleDescriptor.getModuleRootDirectory());
         }
 
-        configureResourceDirectory(contentEntry, moduleDescriptor, dirsToIgnore);
+        configureResourceDirectory(contentEntry, moduleDescriptor, dirsToIgnore, appSettings);
 
         excludeCommonNeedlessDirs(contentEntry, moduleDescriptor);
     }
@@ -137,12 +140,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     protected void configureResourceDirectory(
         @NotNull final ContentEntry contentEntry,
         @NotNull final ModuleDescriptor moduleDescriptor,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         final File resourcesDirectory = new File(moduleDescriptor.getModuleRootDirectory(), RESOURCES_DIRECTORY);
 
         if (!isResourceDirExcluded(moduleDescriptor.getName())) {
-            addSourceFolderIfNotIgnored(contentEntry, resourcesDirectory, JavaResourceRootType.RESOURCE, dirsToIgnore);
+            addSourceFolderIfNotIgnored(contentEntry, resourcesDirectory, JavaResourceRootType.RESOURCE, dirsToIgnore, appSettings);
         } else {
             excludeDirectory(contentEntry, resourcesDirectory);
         }
@@ -209,12 +213,13 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     protected void configureSubModule(
         @NotNull final YBackofficeSubModuleDescriptor moduleDescriptor,
         @NotNull final ContentEntry contentEntry,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
         final File backOfficeModuleDirectory = moduleDescriptor.getModuleRootDirectory();
 
         if (!moduleDescriptor.getRootProjectDescriptor().isExcludeTestSources()) {
-            addTestSourceRoots(contentEntry, backOfficeModuleDirectory, dirsToIgnore);
+            addTestSourceRoots(contentEntry, backOfficeModuleDirectory, dirsToIgnore, appSettings);
         } else {
             excludeTestSourceRoots(contentEntry, backOfficeModuleDirectory);
         }
@@ -272,7 +277,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
     private static void addTestSourceRoots(
         @NotNull final ContentEntry contentEntry,
         @NotNull final File dir,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
 
         for (String testSrcDirName : TEST_SRC_DIR_NAMES) {
@@ -280,7 +286,7 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
                 contentEntry,
                 new File(dir, testSrcDirName),
                 JavaSourceRootType.TEST_SOURCE,
-                dirsToIgnore
+                dirsToIgnore, appSettings
             );
         }
     }
@@ -299,7 +305,8 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
         @NotNull final ContentEntry contentEntry,
         @NotNull final File testSrcDir,
         @NotNull final JpsModuleSourceRootType<P> rootType,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings appSettings
     ) {
 
         addSourceFolderIfNotIgnored(
@@ -307,7 +314,7 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
             testSrcDir,
             rootType,
             rootType.createDefaultProperties(),
-            dirsToIgnore
+            dirsToIgnore, appSettings
         );
     }
 
@@ -327,10 +334,11 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
         @NotNull final File testSrcDir,
         @NotNull final JpsModuleSourceRootType<P> rootType,
         @NotNull P properties,
-        @NotNull final List<File> dirsToIgnore
+        @NotNull final List<File> dirsToIgnore,
+        @NotNull final HybrisApplicationSettings applicationSettings
     ) {
         if (dirsToIgnore.stream().noneMatch(it -> FileUtil.isAncestor(it, testSrcDir, false))) {
-            final boolean ignoreEmpty = HybrisApplicationSettingsComponent.getInstance().getState().getIgnoreNonExistingSourceDirectories();
+            final boolean ignoreEmpty = applicationSettings.getIgnoreNonExistingSourceDirectories();
             if (BooleanUtils.isTrue(ignoreEmpty) && !testSrcDir.exists()) {
                 return;
             }
@@ -350,7 +358,7 @@ public class RegularContentRootConfigurator implements ContentRootConfigurator {
 
         if (moduleDescriptor.getDescriptorType() == ModuleDescriptorType.CUSTOM
             || (!moduleDescriptor.getRootProjectDescriptor().isImportOotbModulesInReadOnlyMode()
-                && srcDirectoriesExists(rootDirectory))
+            && srcDirectoriesExists(rootDirectory))
         ) {
             excludeDirectory(contentEntry, new File(rootDirectory, WEBROOT_WEBINF_CLASSES_PATH));
         }

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/ModuleDescriptor.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/ModuleDescriptor.kt
@@ -30,7 +30,7 @@ interface ModuleDescriptor : Comparable<ModuleDescriptor> {
     var readonly: Boolean
 
     fun extensionDescriptor(): ExtensionDescriptor
-    fun ideaModuleName() = groupNames.joinToString(separator = ".", postfix = ".") + name
+    fun ideaModuleName(): String = (if (groupNames.size == 0) "" else groupNames.joinToString(separator = ".", postfix = ".")) + name
     fun isPreselected(): Boolean
     fun ideaModuleFile(): File
     fun getRelativePath(): String

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -39,6 +39,7 @@ import com.intellij.idea.plugin.hybris.project.descriptors.YModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.YSubModuleDescriptor;
 import com.intellij.idea.plugin.hybris.project.descriptors.impl.*;
 import com.intellij.idea.plugin.hybris.project.utils.PluginCommon;
+import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent;
@@ -142,12 +143,15 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
             .collect(Collectors.toMap(YModuleDescriptor::getName, Function.identity()));
         final var allModuleDescriptors = allModules.stream()
             .collect(Collectors.toMap(ModuleDescriptor::getName, Function.identity()));
+        final var appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
 
-        this.initializeHybrisProjectSettings(project);
+        final var projectSettingsComponent = HybrisProjectSettingsComponent.getInstance(project);
+        final var hybrisProjectSettings = projectSettingsComponent.getState();
+        this.initializeHybrisProjectSettings(project, hybrisProjectSettings);
         this.updateProjectDictionary(project, hybrisProjectDescriptor.getModulesChosenForImport());
         this.selectSdk(project);
-        this.saveCustomDirectoryLocation(project);
-        this.saveImportedSettings(project);
+        this.saveCustomDirectoryLocation(project, hybrisProjectSettings);
+        this.saveImportedSettings(project, hybrisProjectSettings, appSettings, projectSettingsComponent);
         this.disableWrapOnType(ImpexLanguage.getInstance());
 
         PropertiesComponent.getInstance(project).setValue(PluginCommon.SHOW_UNLINKED_GRADLE_POPUP, false);
@@ -164,7 +168,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         int counter = 0;
 
         for (ModuleDescriptor moduleDescriptor : allModules) {
-            final Module javaModule = createJavaModule(indicator, allYModules, rootProjectModifiableModel, moduleDescriptor);
+            final Module javaModule = createJavaModule(indicator, allYModules, rootProjectModifiableModel, moduleDescriptor, appSettings);
             modules.add(javaModule);
             counter++;
 
@@ -185,7 +189,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         configuratorFactory.getSpringConfigurator().configure(indicator, hybrisProjectDescriptor, allModuleDescriptors, modifiableModelsProvider);
         configuratorFactory.getDebugRunConfigurationConfigurator().configure(indicator, hybrisProjectDescriptor, project, cache);
         configuratorFactory.getVersionControlSystemConfigurator().configure(indicator, hybrisProjectDescriptor, project);
-        configuratorFactory.getSearchScopeConfigurator().configure(indicator, project, rootProjectModifiableModel);
+        configuratorFactory.getSearchScopeConfigurator().configure(indicator, project, appSettings, rootProjectModifiableModel);
 //        Optional.ofNullable(configuratorFactory.getDataSourcesConfigurator())
 //            .ifPresent(it -> it.configure(indicator, project));
 
@@ -256,11 +260,10 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
     }
 
     @NotNull
-    private Module createJavaModule(
-        final @NotNull ProgressIndicator indicator,
-        final Map<String, YModuleDescriptor> allYModules,
-        final ModifiableModuleModel rootProjectModifiableModel,
-        final ModuleDescriptor moduleDescriptor
+    private Module createJavaModule(final @NotNull ProgressIndicator indicator,
+                                    final Map<String, YModuleDescriptor> allYModules,
+                                    final ModifiableModuleModel rootProjectModifiableModel,
+                                    final ModuleDescriptor moduleDescriptor, final @NotNull HybrisApplicationSettings appSettings
     ) {
         indicator.setText(message("hybris.project.import.module.import", moduleDescriptor.getName()));
         indicator.setText2(message("hybris.project.import.module.settings"));
@@ -281,9 +284,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         modifiableRootModel.inheritSdk();
 
         configuratorFactory.getLibRootsConfigurator().configure(indicator, allYModules, modifiableRootModel, moduleDescriptor, modifiableModelsProvider, indicator);
-        configuratorFactory.getContentRootConfigurator(moduleDescriptor).configure(indicator, modifiableRootModel, moduleDescriptor);
+        configuratorFactory.getContentRootConfigurator(moduleDescriptor).configure(indicator, modifiableRootModel, moduleDescriptor, appSettings);
         configuratorFactory.getCompilerOutputPathsConfigurator().configure(indicator, modifiableRootModel, moduleDescriptor);
-        configuratorFactory.getJavadocModuleConfigurator().configure(indicator, modifiableRootModel, moduleDescriptor);
+        configuratorFactory.getJavadocModuleConfigurator().configure(indicator, modifiableRootModel, moduleDescriptor, appSettings);
 
         indicator.setText2(message("hybris.project.import.module.facet"));
         for (final FacetConfigurator facetConfigurator : configuratorFactory.getFacetConfigurators()) {
@@ -385,11 +388,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         hybrisDictionary.addToDictionary(moduleNames);
     }
 
-    private void initializeHybrisProjectSettings(@NotNull final Project project) {
+    private void initializeHybrisProjectSettings(@NotNull final Project project, final @NotNull HybrisProjectSettings hybrisProjectSettings) {
         Validate.notNull(project);
 
-        final @NotNull HybrisProjectSettings hybrisProjectSettings = HybrisProjectSettingsComponent.getInstance(project)
-            .getState();
         hybrisProjectSettings.setHybrisProject(true);
         final IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId(HybrisConstants.PLUGIN_ID));
 
@@ -420,9 +421,7 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         }
     }
 
-    private void saveCustomDirectoryLocation(final Project project) {
-        final HybrisProjectSettings hybrisProjectSettings = HybrisProjectSettingsComponent.getInstance(project)
-            .getState();
+    private void saveCustomDirectoryLocation(final Project project, final HybrisProjectSettings hybrisProjectSettings) {
         final File customDirectory = hybrisProjectDescriptor.getExternalExtensionsDirectory();
         final File hybrisDirectory = hybrisProjectDescriptor.getHybrisDistributionDirectory();
         final VirtualFile projectDir = ProjectUtil.guessProjectDir(project);
@@ -441,10 +440,9 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
         }
     }
 
-    private void saveImportedSettings(final Project project) {
-        final var hybrisSettingsComponent = HybrisProjectSettingsComponent.getInstance(project);
-        final var hybrisProjectSettings = hybrisSettingsComponent.getState();
-        final var appSettings = HybrisApplicationSettingsComponent.getInstance().getState();
+    private void saveImportedSettings(final Project project, @NotNull final HybrisProjectSettings hybrisProjectSettings,
+                                      @NotNull final HybrisApplicationSettings appSettings,
+                                      @NotNull final HybrisProjectSettingsComponent hybrisSettingsComponent) {
         hybrisProjectSettings.setImportOotbModulesInReadOnlyMode(hybrisProjectDescriptor.isImportOotbModulesInReadOnlyMode());
         final File extDir = hybrisProjectDescriptor.getExternalExtensionsDirectory();
         if (extDir != null && extDir.isDirectory()) {


### PR DESCRIPTION
Refactored `ImportProjectProgressModalWindow` so that is calls so that project state retrieved only once [#511](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/511)

Signed-off-by: Your Real Name your.email@email.com
