### PR TITLE
Do not show `resources` folders in the `External Libraries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Adjusted inline documentation for Type System [#539](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/539)
 - Hide custom module libraries in the Project View [#569](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/569)
 - Added slack badge to README.md [#577](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/577)
+- Do not show `resources` folders in the `External Libraries` [#589](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/589)
 
 ## [2023.2.5]
 

--- a/src/com/intellij/idea/plugin/hybris/view/HybrisProjectView.kt
+++ b/src/com/intellij/idea/plugin/hybris/view/HybrisProjectView.kt
@@ -148,16 +148,20 @@ open class HybrisProjectView(val project: Project) : TreeStructureProvider, Dumb
             when (child) {
                 is PsiDirectoryNode -> {
                     val virtualFile = child.virtualFile ?: continue
-                    if (!HybrisConstants.CLASSES_DIRECTORY.equals(virtualFile.name, ignoreCase = true)) {
+                    if (!HybrisConstants.CLASSES_DIRECTORY.equals(virtualFile.name, ignoreCase = true) &&
+                        !HybrisConstants.RESOURCES_DIRECTORY.equals(virtualFile.name, ignoreCase = true)
+                    ) {
                         treeNodes.add(child)
                     }
                 }
+
                 is NamedLibraryElementNode -> {
                     val libraryName = child.value.name
                     if (hideModuleLibraries.none { libraryName.endsWith(it) }) {
                         treeNodes.add(child)
                     }
                 }
+
                 else -> treeNodes.add(child)
             }
         }


### PR DESCRIPTION
before
<img width="208" alt="Screenshot 2023-08-16 at 16 30 28" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/df106d66-0c6b-444b-8688-8ee46711d8b3">

after
<img width="229" alt="Screenshot 2023-08-16 at 16 31 22" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/078d3219-171b-41c6-9092-7df5cbb0beaf">
