### PR TITLE
Common `java.lang` package can be omitted in the Bean property type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Java keywords and reserved words cannot be used as Bean property **name** [#591](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/591)
 - Unescaped `<` sign usage is not allowed in the Bean property **type** [#594](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/594)
 - Escape `>` sign in the Bean property **type** [#595](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/595)
+- Common `java.lang` package can be omitted in the Bean property **type** [#596](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/596)
 
 ### Fixes
 - Inject `FlexibleSearch` into Kotlin String template [#535](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/535)

--- a/resources/META-INF/plugin-inspections.xml
+++ b/resources/META-INF/plugin-inspections.xml
@@ -168,6 +168,10 @@
                          bundle="i18n.HybrisBundle" key="hybris.inspections.bs.BSUnescapedGreaterThanSignIsNotAllowedInBeanPropertyType.key"
                          shortName="BSUnescapedGreaterThanSignIsNotAllowedInBeanPropertyType" level="WARNING"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.beanSystem.BSUnescapedGreaterThanSignIsNotAllowedInBeanPropertyType"/>
+        <localInspection language="XML" enabledByDefault="true" groupPath="SAP Commerce" groupName="[y] Bean System"
+                         bundle="i18n.HybrisBundle" key="hybris.inspections.bs.BSOmitJavaLangPackageInBeanPropertyType.key"
+                         shortName="BSOmitJavaLangPackageInBeanPropertyType" level="WEAK WARNING"
+                         implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.beanSystem.BSOmitJavaLangPackageInBeanPropertyType"/>
 
         <!-- Type System  -->
         <!-- Weak Warnings -->

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -317,6 +317,8 @@ hybris.inspections.bs.BSUnescapedLessThanSignIsNotAllowedInBeanPropertyType.key=
 hybris.inspections.bs.BSUnescapedLessThanSignIsNotAllowedInBeanPropertyType.message=[y] Unescaped ''<'' sign usage is not allowed in the Bean property type ''{0}''
 hybris.inspections.bs.BSUnescapedGreaterThanSignIsNotAllowedInBeanPropertyType.key=[y] Unescaped ''>'' sign usage is not allowed in the Bean property type
 hybris.inspections.bs.BSUnescapedGreaterThanSignIsNotAllowedInBeanPropertyType.message=[y] Unescaped ''>'' sign usage is not allowed in the Bean property type ''{0}''
+hybris.inspections.bs.BSOmitJavaLangPackageInBeanPropertyType.key=[y] ''java.lang'' package can be omitted in the Bean property type
+hybris.inspections.bs.BSOmitJavaLangPackageInBeanPropertyType.message=[y] ''java.lang'' package can be omitted in the Bean property type ''{0}''
 
 hybris.inspections.UnknownTypeNameInspection.key=[y] Unknown type ''{0}''
 hybris.inspections.UnknownTypeAttributeInspection.key=[y] Unknown attribute ''{0}'' for type ''{1}''

--- a/resources/inspectionDescriptions/BSOmitJavaLangPackageInBeanPropertyType.html
+++ b/resources/inspectionDescriptions/BSOmitJavaLangPackageInBeanPropertyType.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+  ~ Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html>
+<body>
+<p>Default Java package <code>java.lang</code> can be omitted for Bean Property type.</p>
+</body>
+</html>

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/beanSystem/BSOmitJavaLangPackageInBeanPropertyType.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/beanSystem/BSOmitJavaLangPackageInBeanPropertyType.kt
@@ -1,0 +1,67 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.rule.beanSystem
+
+import com.intellij.idea.plugin.hybris.codeInspection.fix.xml.XmlUpdateAttributeQuickFix
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.system.bean.model.Beans
+import com.intellij.idea.plugin.hybris.system.bean.model.Property
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.Project
+import com.intellij.util.xml.highlighting.DomElementAnnotationHolder
+import com.intellij.util.xml.highlighting.DomHighlightingHelper
+
+class BSOmitJavaLangPackageInBeanPropertyType : AbstractBSInspection() {
+
+    override fun inspect(
+        project: Project,
+        dom: Beans,
+        holder: DomElementAnnotationHolder,
+        helper: DomHighlightingHelper,
+        severity: HighlightSeverity
+    ) {
+        dom.beans
+            .flatMap { it.properties }
+            .forEach { inspect(it, holder, severity) }
+    }
+
+    private fun inspect(
+        dom: Property,
+        holder: DomElementAnnotationHolder,
+        severity: HighlightSeverity
+    ) {
+        val propertyName = dom.name.xmlAttributeValue?.value ?: return
+        val propertyType = dom.type.xmlAttributeValue
+            ?.value
+            ?.takeIf { it.contains(HybrisConstants.BS_JAVA_LANG_PREFIX) }
+            ?: return
+
+        holder.createProblem(
+            dom.type,
+            severity,
+            message("hybris.inspections.bs.BSOmitJavaLangPackageInBeanPropertyType.message", propertyName),
+            XmlUpdateAttributeQuickFix(
+                Property.TYPE,
+                propertyType.replace(HybrisConstants.BS_JAVA_LANG_PREFIX, "")
+            )
+        )
+    }
+
+}

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -209,11 +209,14 @@ object HybrisConstants {
     const val ANT_HEAP_SIZE_MB = 512
     const val ANT_STACK_SIZE_MB = 128
 
+    private const val JAVA_LANG_PREFIX = "java.lang."
+
     const val BS_TYPE_OBJECT = "java.lang.Object"
     const val BS_SIGN_LESS_THAN = "<"
     const val BS_SIGN_GREATER_THAN = ">"
     const val BS_SIGN_LESS_THAN_ESCAPED = "&lt;"
     const val BS_SIGN_GREATER_THAN_ESCAPED = "&gt;"
+    const val BS_JAVA_LANG_PREFIX = JAVA_LANG_PREFIX
 
     const val TS_MAX_RECURSION_LEVEL = 2
     const val TS_TYPE_OBJECT = "java.lang.Object"
@@ -229,7 +232,7 @@ object HybrisConstants {
     const val TS_TYPE_SEARCH_RESTRICTION = "SearchRestriction"
     const val TS_TYPE_ENUMERATION_VALUE = "EnumerationValue"
     const val TS_META_TYPE_ATTRIBUTE_DESCRIPTOR = "AttributeDescriptor"
-    const val TS_JAVA_LANG_PREFIX = "java.lang."
+    const val TS_JAVA_LANG_PREFIX = JAVA_LANG_PREFIX
     const val TS_ATTRIBUTE_LOCALIZED_PREFIX = "localized:"
     const val TS_UNIQUE_KEY_ATTRIBUTE_QUALIFIER = "uniqueKeyAttributeQualifier"
     const val TS_CATALOG_ITEM_TYPE = "catalogItemType"


### PR DESCRIPTION
<img width="1047" alt="Screenshot 2023-08-17 at 11 18 07" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/fae67e6c-ae22-4b03-8240-1a1cf13fde47">
<img width="836" alt="Screenshot 2023-08-17 at 11 18 26" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/734415fb-4bd2-49f8-9408-b23ab28f3dfe">
