### PR TITLE
Added folding for `beans.xml` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Added reference resolution and advanced code completion for Bean `extends` attribute [#603](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/603)
 - Added advanced code completion for Bean `type` property attribute [#605](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/605)
 - Added reference resolution for Bean `type` property attribute [#606](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/606)
+- Added folding for bean properties [#607] (https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/607)
 
 ### `beans.xml` inspection rules
 - Java keywords and reserved words cannot be used as Bean property **name** [#591](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/591)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Added reference resolution and advanced code completion for Bean `extends` attribute [#603](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/603)
 - Added advanced code completion for Bean `type` property attribute [#605](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/605)
 - Added reference resolution for Bean `type` property attribute [#606](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/606)
-- Added folding for bean properties and enums [#607] (https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/607)
+- Added folding for `beans.xml` files [#607](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/607)
 
 ### `beans.xml` inspection rules
 - Java keywords and reserved words cannot be used as Bean property **name** [#591](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/591)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 - Added reference resolution and advanced code completion for Bean `extends` attribute [#603](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/603)
 - Added advanced code completion for Bean `type` property attribute [#605](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/605)
 - Added reference resolution for Bean `type` property attribute [#606](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/606)
-- Added folding for bean properties [#607] (https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/607)
+- Added folding for bean properties and enums [#607] (https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/607)
 
 ### `beans.xml` inspection rules
 - Java keywords and reserved words cannot be used as Bean property **name** [#591](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/591)

--- a/resources/META-INF/optional-lang-dependencies.xml
+++ b/resources/META-INF/optional-lang-dependencies.xml
@@ -40,6 +40,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <lang.foldingBuilder language="XML" implementationClass="com.intellij.idea.plugin.hybris.system.type.lang.folding.ItemsXmlFoldingBuilder"/>
         <lang.foldingBuilder language="XML" implementationClass="com.intellij.idea.plugin.hybris.system.cockpitng.lang.folding.CngConfigFoldingBuilder"/>
+        <lang.foldingBuilder language="XML" implementationClass="com.intellij.idea.plugin.hybris.system.bean.lang.folding.BeansXmlFoldingBuilder"/>
 
         <!-- ####################################################################################################### -->
         <!--                                        Project Properties                                                 -->

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
@@ -1,0 +1,35 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.system.bean.lang.folding
+
+import com.intellij.idea.plugin.hybris.system.bean.model.Bean
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiElementFilter
+import com.intellij.psi.xml.XmlTag
+
+class BeansXmlFilter : PsiElementFilter {
+    override fun isAccepted(element: PsiElement) = when (element) {
+        is XmlTag -> when (element.localName) {
+            Bean.PROPERTY -> true
+            else -> false
+        }
+
+        else -> false
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
@@ -18,17 +18,31 @@
 
 package com.intellij.idea.plugin.hybris.system.bean.lang.folding
 
-import com.intellij.idea.plugin.hybris.system.bean.model.Bean
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.system.bean.model.*
 import com.intellij.idea.plugin.hybris.system.bean.model.Enum
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiElementFilter
 import com.intellij.psi.xml.XmlTag
+import com.intellij.psi.xml.XmlToken
 
 class BeansXmlFilter : PsiElementFilter {
     override fun isAccepted(element: PsiElement) = when (element) {
         is XmlTag -> when (element.localName) {
             Bean.PROPERTY,
-            Enum.VALUE -> true
+            Enum.VALUE,
+            Beans.BEAN,
+            Beans.ENUM,
+            AbstractPojo.DESCRIPTION,
+            Hints.HINT,
+            Bean.HINTS -> true
+
+            else -> false
+        }
+
+        is XmlToken -> when (element.text) {
+            HybrisConstants.BS_SIGN_LESS_THAN_ESCAPED,
+            HybrisConstants.BS_SIGN_GREATER_THAN_ESCAPED -> true
 
             else -> false
         }

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFilter.kt
@@ -19,6 +19,7 @@
 package com.intellij.idea.plugin.hybris.system.bean.lang.folding
 
 import com.intellij.idea.plugin.hybris.system.bean.model.Bean
+import com.intellij.idea.plugin.hybris.system.bean.model.Enum
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiElementFilter
 import com.intellij.psi.xml.XmlTag
@@ -26,7 +27,9 @@ import com.intellij.psi.xml.XmlTag
 class BeansXmlFilter : PsiElementFilter {
     override fun isAccepted(element: PsiElement) = when (element) {
         is XmlTag -> when (element.localName) {
-            Bean.PROPERTY -> true
+            Bean.PROPERTY,
+            Enum.VALUE -> true
+
             else -> false
         }
 

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
@@ -23,6 +23,7 @@ import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.idea.plugin.hybris.system.bean.meta.BSMetaHelper
 import com.intellij.idea.plugin.hybris.system.bean.model.Bean
 import com.intellij.idea.plugin.hybris.system.bean.model.Beans
+import com.intellij.idea.plugin.hybris.system.bean.model.Enum
 import com.intellij.idea.plugin.hybris.system.bean.model.Property
 import com.intellij.idea.plugin.hybris.system.type.model.*
 import com.intellij.lang.ASTNode
@@ -64,6 +65,7 @@ class BeansXmlFoldingBuilder : FoldingBuilderEx(), DumbAware {
             Bean.PROPERTY -> psi.getAttributeValue(Property.NAME) + " : " +
                 (BSMetaHelper.flattenType(psi.getAttributeValue(Property.TYPE)) ?: "?")
 
+            Enum.VALUE -> psi.value.trimmedText
             else -> FALLBACK_PLACEHOLDER
         }
 
@@ -72,7 +74,8 @@ class BeansXmlFoldingBuilder : FoldingBuilderEx(), DumbAware {
 
     override fun isCollapsedByDefault(node: ASTNode) = when (val psi = node.psi) {
         is XmlTag -> when (psi.localName) {
-            Bean.PROPERTY -> true
+            Bean.PROPERTY,
+            Enum.VALUE -> true
 
             else -> false
         }

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
@@ -1,0 +1,88 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.system.bean.lang.folding
+
+import ai.grazie.utils.toDistinctTypedArray
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
+import com.intellij.idea.plugin.hybris.system.bean.meta.BSMetaHelper
+import com.intellij.idea.plugin.hybris.system.bean.model.Bean
+import com.intellij.idea.plugin.hybris.system.bean.model.Beans
+import com.intellij.idea.plugin.hybris.system.bean.model.Property
+import com.intellij.idea.plugin.hybris.system.type.model.*
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.FoldingBuilderEx
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.FoldingGroup
+import com.intellij.openapi.project.DumbAware
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import com.intellij.psi.SyntaxTraverser
+import com.intellij.psi.xml.XmlFile
+import com.intellij.psi.xml.XmlTag
+import com.intellij.util.xml.DomManager
+
+class BeansXmlFoldingBuilder : FoldingBuilderEx(), DumbAware {
+
+    private val filter = BeansXmlFilter()
+
+    override fun buildFoldRegions(root: PsiElement, document: Document, quick: Boolean): Array<FoldingDescriptor> {
+        if (!HybrisProjectSettingsComponent.getInstance(root.project).isHybrisProject()) return emptyArray()
+        if (root !is XmlFile) return emptyArray()
+        DomManager.getDomManager(root.project).getFileElement(root, Beans::class.java)
+            ?: return emptyArray()
+
+        return SyntaxTraverser.psiTraverser(root)
+            .filter { filter.isAccepted(it) }
+            .mapNotNull {
+                if (it is PsiErrorElement || it.textRange.isEmpty) return@mapNotNull null
+                FoldingDescriptor(it.node, it.textRange, FoldingGroup.newGroup(GROUP_NAME))
+            }
+            .toDistinctTypedArray()
+    }
+
+    // property : Type
+    // name       type
+    override fun getPlaceholderText(node: ASTNode) = when (val psi = node.psi) {
+        is XmlTag -> when (psi.localName) {
+            Bean.PROPERTY -> psi.getAttributeValue(Property.NAME) + " : " +
+                (BSMetaHelper.flattenType(psi.getAttributeValue(Property.TYPE)) ?: "?")
+
+            else -> FALLBACK_PLACEHOLDER
+        }
+
+        else -> FALLBACK_PLACEHOLDER
+    }
+
+    override fun isCollapsedByDefault(node: ASTNode) = when (val psi = node.psi) {
+        is XmlTag -> when (psi.localName) {
+            Bean.PROPERTY -> true
+
+            else -> false
+        }
+
+        else -> false
+    }
+
+    companion object {
+        private const val GROUP_NAME = "BeansXml"
+        private const val FALLBACK_PLACEHOLDER = "..."
+    }
+
+}

--- a/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/lang/folding/BeansXmlFoldingBuilder.kt
@@ -58,8 +58,6 @@ class BeansXmlFoldingBuilder : FoldingBuilderEx(), DumbAware {
             .toDistinctTypedArray()
     }
 
-    // property : Type
-    // name       type
     override fun getPlaceholderText(node: ASTNode) = when (val psi = node.psi) {
         is XmlTag -> when (psi.localName) {
             Bean.PROPERTY -> psi.getAttributeValue(Property.NAME) + " : " +

--- a/src/com/intellij/idea/plugin/hybris/system/bean/meta/BSMetaHelper.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/meta/BSMetaHelper.kt
@@ -82,7 +82,7 @@ object BSMetaHelper {
         .replace("&lt;", "<")
         .replace("&gt;", ">")
 
-    private fun flattenType(type: String?) = type
+    fun flattenType(type: String?) = type
         ?.replace(flattenTypeRegex, "")
         ?.replace("&lt;", "<")
         ?.replace("&gt;", ">")

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/AbstractPojo.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/AbstractPojo.java
@@ -29,7 +29,11 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface AbstractPojo extends DomElement {
 
+    String CLASS = "class";
+    String DEPRECATED = "deprecated";
+    String DEPRECATED_SINCE = "deprecatedSince";
     String TEMPLATE = "template";
+    String DESCRIPTION = "description";
 
     /**
      * Returns the value of the template child.

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Bean.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Bean.java
@@ -34,14 +34,12 @@ import java.util.List;
 @StubbedOccurrence
 public interface Bean extends DomElement, AbstractPojo {
 
-    String CLASS = "class";
     String SUPER_EQUALS = "superEquals";
     String ABSTRACT = "abstract";
-    String DEPRECATED_SINCE = "deprecatedSince";
-    String DEPRECATED = "deprecated";
     String TYPE = "type";
     String EXTENDS = "extends";
     String PROPERTY = "property";
+    String HINTS = "hints";
 
     /**
      * Returns the value of the class child.
@@ -117,7 +115,7 @@ public interface Bean extends DomElement, AbstractPojo {
     FalseAttributeValue getSuperEquals();
 
     @NotNull
-    @SubTag("hints")
+    @SubTag(HINTS)
     Hints getHints();
 
     /**

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Bean.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Bean.java
@@ -41,6 +41,7 @@ public interface Bean extends DomElement, AbstractPojo {
     String DEPRECATED = "deprecated";
     String TYPE = "type";
     String EXTENDS = "extends";
+    String PROPERTY = "property";
 
     /**
      * Returns the value of the class child.

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Beans.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Beans.java
@@ -17,6 +17,9 @@ import java.util.List;
 @StubbedOccurrence
 public interface Beans extends DomElement {
 
+    String BEAN = "bean";
+    String ENUM = "enum";
+
     /**
      * Returns the list of bean children.
      *

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Enum.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Enum.java
@@ -38,6 +38,8 @@ public interface Enum extends DomElement, AbstractPojo {
     String DEPRECATED = "deprecated";
     String DEPRECATED_SINCE = "deprecatedSince";
 
+    String VALUE = "value";
+
     /**
      * Returns the value of the class child.
      *

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Enum.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Enum.java
@@ -34,10 +34,6 @@ import java.util.List;
 @StubbedOccurrence
 public interface Enum extends DomElement, AbstractPojo {
 
-    String CLASS = "class";
-    String DEPRECATED = "deprecated";
-    String DEPRECATED_SINCE = "deprecatedSince";
-
     String VALUE = "value";
 
     /**

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Hint.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Hint.java
@@ -12,8 +12,10 @@ import org.jetbrains.annotations.NotNull;
 
 public interface Hint extends DomElement, MutableGenericValue<String> {
 
+    String NAME = "name";
+
     @NotNull
-    @Attribute("name")
+    @Attribute(NAME)
     @Required
     GenericAttributeValue<String> getName();
 

--- a/src/com/intellij/idea/plugin/hybris/system/bean/model/Hints.java
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/model/Hints.java
@@ -29,11 +29,13 @@ import java.util.List;
 
 public interface Hints extends DomElement {
 
+    String HINT = "hint";
+
     @NotNull
-    @SubTagList("hint")
+    @SubTagList(HINT)
     List<Hint> getHints();
 
-    @SubTagList("hint")
+    @SubTagList(HINT)
     Hint addHint();
 
 }


### PR DESCRIPTION
Folding on bean/enum level:
<img width="469" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/beb67196-5a6d-4270-8bc8-a073d7b8e126">


Folding on properties level:
<img width="769" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/f6e2ba85-99ba-4b4c-8cef-10d605080192">

<img width="771" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/6c575a99-8fec-4497-8d16-cd295a9d126d">

folding enum values:
<img width="617" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/2a27fe49-b6d9-49c2-be6b-f6b6fa18c3f4">

