### PR TITLE
Bugfix: Add dependant modules to be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - DB Datasource cannot be configured due backslash [#584](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/584) 
 - Some classes are not visible from `storefrontcommons` if searchable class is in read-only storefrontcommons [#579](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/579)
 - Properties defined in the `advanced.properties` are not available [#612](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/612)
+- Dependant modules are not imported [#614](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/614)
 
 ### Other
 - Adjusted inline documentation for Type System [#539](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/539)

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -161,6 +161,11 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
                 && yModuleDescriptor instanceof final YRegularModuleDescriptor yRegularModuleDescriptor
             ) {
                 yRegularModuleDescriptor.setInLocalExtensions(true);
+                yRegularModuleDescriptor.getDirectDependencies()
+                    .stream()
+                    .filter(YCustomRegularModuleDescriptor.class::isInstance)
+                    .map(YCustomRegularModuleDescriptor.class::cast)
+                    .forEach(module -> module.setNeededDependency(true));
             }
         }
         preselectConfigModules(configHybrisModuleDescriptor, foundModules);

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/impl/YRegularModuleDescriptor.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/impl/YRegularModuleDescriptor.kt
@@ -34,6 +34,7 @@ abstract class YRegularModuleDescriptor protected constructor(
 ) {
 
     var isInLocalExtensions = false
+    var isNeededDependency = false
 
     val hasHmcModule = extensionInfo.extension.hmcmodule != null
     val isHacAddon = isMetaKeySetToTrue(HybrisConstants.EXTENSION_META_KEY_HAC_MODULE)
@@ -44,7 +45,7 @@ abstract class YRegularModuleDescriptor protected constructor(
     val hasWebModule = extensionInfo.extension.webmodule != null
         && File(moduleRootDirectory, HybrisConstants.WEB_MODULE_DIRECTORY).isDirectory
 
-    override fun isPreselected() = isInLocalExtensions
+    override fun isPreselected() = isInLocalExtensions || isNeededDependency
 
     override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>): Set<String> {
         val extension = extensionInfo.extension


### PR DESCRIPTION
Ddependant modules are not imported, event though another preselected module needs it as dependency.

Signed-off-by: Viktors Jengovatovs <viktors.jengovatovs@gmail.com>