### PR TITLE
Added own color scheme for `Header Abbreviations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Ignore case for type in the reference type (e.g. `groups(customer.uid)`) [#545](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/545)
 - Added code completion of the [Header Abbreviations](https://help.sap.com/docs/SAP_COMMERCE/d0224eca81e249cb821f2cdf45a82ace/2fb5a2a780c94325b4a48ff62b36ab23.html#using-header-abbreviations) [#613](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/613)
 - Added reference resolution for `Header Abbreviations` [#615](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/615)
+- Added own color scheme for `Header Abbreviations` [#617](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/617)
 - Adjusted Lexer to enable support of the `@` character for `Header Parameter` [#616](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/616)
 
 ### `CockpitNG` enhancements

--- a/resources/colorSchemes/ImpExDarcula.xml
+++ b/resources/colorSchemes/ImpExDarcula.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <!--
   ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
-  ~ Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+  ~ Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU Lesser General Public License as
@@ -52,8 +52,7 @@
     </option>
     <option name="HEADER_SPECIAL_PARAMETER_NAME">
         <value>
-            <option name="FOREGROUND" value="9876AA"/>
-            <!--<option name="BACKGROUND" value=""/>-->
+            <option name="FOREGROUND" value="B79DFA"/>
             <option name="FONT_TYPE" value="2"/>
         </value>
     </option>
@@ -132,6 +131,12 @@
         <value>
             <option name="FOREGROUND" value="FFF9F1"/>
             <option name="FONT_TYPE" value="1" />
+        </value>
+    </option>
+    <option name="IMPEX_ATTRIBUTE_HEADER_ABBREVIATION">
+        <value>
+            <option name="FOREGROUND" value="22E5B8"/>
+            <option name="FONT_TYPE" value="2"/>
         </value>
     </option>
 </list>

--- a/resources/colorSchemes/ImpExDefault.xml
+++ b/resources/colorSchemes/ImpExDefault.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <!--
   ~ This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
-  ~ Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+  ~ Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU Lesser General Public License as
@@ -130,7 +130,7 @@
     </option>
     <option name="HEADER_SPECIAL_PARAMETER_NAME">
         <value>
-            <option name="FOREGROUND" value="000000"/>
+            <option name="FOREGROUND" value="6A598D"/>
             <option name="FONT_TYPE" value="2"/>
         </value>
     </option>
@@ -218,6 +218,12 @@
         <value>
             <option name="FOREGROUND" value="000000"/>
             <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="IMPEX_ATTRIBUTE_HEADER_ABBREVIATION">
+        <value>
+            <option name="FOREGROUND" value="158C71"/>
+            <option name="FONT_TYPE" value="2"/>
         </value>
     </option>
 </list>

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -267,6 +267,7 @@ hybris.inspections.impex.unresolved.typeAttribute.key=[y] Unresolved type attrib
 hybris.inspections.impex.userRights.header.mandatory.expected=[y] Mandatory column ''{0}'' expected at position {1}, but found ''{2}''
 hybris.inspections.impex.userRights.header.mandatory.order=[y] Mandatory column ''{0}'' must have position {1}
 hybris.inspections.impex.ImpexOnlyUpdateAllowedForNonDynamicEnumInspection.key=[y] ''{0}'' for non-dynamic enum ''{1}'' cannot be performed. Only ''{2}'' is permitted.
+hybris.inspections.impex.ImpExIncompleteHeaderAbbreviationUsageInspection.key=[y] Header Abbreviation ''{0}''  for non-dynamic enum ''{1}'' cannot be performed. Only ''{2}'' is permitted.
 
 hybris.inspections.ts.AttributeHandlerMustBeSetForDynamicAttribute.key=[y] Attribute handler must be defined for Dynamic Attribute
 hybris.inspections.ts.DeploymentTypeCodeMustBeUnique.key=[y] Deployment type code must be unique

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownAttributeModifierInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownAttributeModifierInspection.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -37,9 +37,14 @@ class ImpexUnknownAttributeModifierInspection : LocalInspectionTool() {
     private class ImpexTypeModifierVisitor(private val problemsHolder: ProblemsHolder) : ImpexVisitor() {
 
         override fun visitAnyAttributeName(attribute: ImpexAnyAttributeName) {
-            PsiTreeUtil.getParentOfType(attribute, ImpexFullHeaderParameter::class.java) ?: return
+            val fullHeaderParameter = PsiTreeUtil.getParentOfType(attribute, ImpexFullHeaderParameter::class.java)
+                ?: return
 
-            if (AttributeModifier.getByModifierName(attribute.text) == null) {
+            val noTranslator = fullHeaderParameter.modifiersList
+                .flatMap { it.attributeList }
+                .map { it.anyAttributeName }
+                .none { it.textMatches(AttributeModifier.TRANSLATOR.modifierName) }
+            if (AttributeModifier.getByModifierName(attribute.text) == null && noTranslator) {
                 problemsHolder.registerProblem(
                     attribute,
                     HybrisI18NBundleUtils.message("hybris.inspections.impex.ImpexUnknownAttributeModifierInspection.key", attribute.text),

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownTypeModifierInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownTypeModifierInspection.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -31,7 +31,7 @@ import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.util.PsiTreeUtil
 
 class ImpexUnknownTypeModifierInspection : LocalInspectionTool() {
-    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.WARNING
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.WEAK_WARNING
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = ImpexTypeModifierVisitor(holder)
 
     private class ImpexTypeModifierVisitor(private val problemsHolder: ProblemsHolder) : ImpexVisitor() {
@@ -43,7 +43,7 @@ class ImpexUnknownTypeModifierInspection : LocalInspectionTool() {
                 problemsHolder.registerProblem(
                     attribute,
                     HybrisI18NBundleUtils.message("hybris.inspections.impex.ImpexUnknownTypeModifierInspection.key", attribute.text),
-                    ProblemHighlightType.WARNING
+                    ProblemHighlightType.LIKE_UNKNOWN_SYMBOL
                 )
             }
         }

--- a/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexColorSettingsPage.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexColorSettingsPage.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -32,7 +32,7 @@ class ImpexColorSettingsPage : ColorSettingsPage {
     override fun getIcon(): Icon = HybrisIcons.IMPEX_FILE
     override fun getHighlighter() = DefaultImpexSyntaxHighlighter.instance
     override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String, TextAttributesKey> = customTags
-    override fun getAttributeDescriptors() = DESCRIPTORS
+    override fun getAttributeDescriptors() = descriptors
     override fun getColorDescriptors(): Array<ColorDescriptor> = ColorDescriptor.EMPTY_ARRAY
     override fun getDisplayName() = HybrisConstants.IMPEX
 
@@ -54,7 +54,7 @@ ${"$"}macro = qwe;qwe, qwe, ;qwe
 
 #% impex.setLocale( Locale.GERMAN );
 
-INSERT_UPDATE SomeType; ${"$"}contentCV[unique = true][map-delimiter = |][dateformat = yyyy-MM-dd HH:mm:ss]; uid[unique = true]; title[lang = ${"$"}lang]
+INSERT_UPDATE SomeType; ${"$"}contentCV[unique = true][map-delimiter = |][dateformat = yyyy-MM-dd HH:mm:ss]; uid[unique = true]; title[lang = ${"$"}lang]; ${attributeHeaderAbbreviation("C@someAttribute")}
 Subtype ; ; account                ; "Your Account"
         ; ; <ignore>               ; "Add/Edit Address"
         ; ; key -> vaue | key ->
@@ -75,60 +75,61 @@ INSERT_UPDATE Media; @media[translator = de.hybris.platform.impex.jalo.media.Med
 """
     }
 
-    companion object {
-        private const val inheritedPermission = "<permission_inherited>.</permission_inherited>"
 
-        private val DESCRIPTORS = arrayOf(
-            AttributesDescriptor("Comment line", ImpexHighlighterColors.PROPERTY_COMMENT),
-            AttributesDescriptor("Macro name declaration", ImpexHighlighterColors.MACRO_NAME_DECLARATION),
-            AttributesDescriptor("Macro value", ImpexHighlighterColors.MACRO_VALUE),
-            AttributesDescriptor("Macro usage", ImpexHighlighterColors.MACRO_USAGE),
-            AttributesDescriptor("Assign value", ImpexHighlighterColors.ASSIGN_VALUE),
-            AttributesDescriptor("Insert", ImpexHighlighterColors.HEADER_MODE_INSERT),
-            AttributesDescriptor("Update", ImpexHighlighterColors.HEADER_MODE_UPDATE),
-            AttributesDescriptor("Insert or update", ImpexHighlighterColors.HEADER_MODE_INSERT_UPDATE),
-            AttributesDescriptor("Remove", ImpexHighlighterColors.HEADER_MODE_REMOVE),
-            AttributesDescriptor("Function call", ImpexHighlighterColors.FUNCTION_CALL),
-            AttributesDescriptor("Header type", ImpexHighlighterColors.HEADER_TYPE),
-            AttributesDescriptor("Value sub-type", ImpexHighlighterColors.VALUE_SUBTYPE),
-            AttributesDescriptor("Field value separator", ImpexHighlighterColors.FIELD_VALUE_SEPARATOR),
-            AttributesDescriptor("List item separator", ImpexHighlighterColors.FIELD_LIST_ITEM_SEPARATOR),
-            AttributesDescriptor("Field value", ImpexHighlighterColors.FIELD_VALUE),
-            AttributesDescriptor("Single string", ImpexHighlighterColors.SINGLE_STRING),
-            AttributesDescriptor("Double string", ImpexHighlighterColors.DOUBLE_STRING),
-            AttributesDescriptor("Ignore value", ImpexHighlighterColors.FIELD_VALUE_IGNORE),
-            AttributesDescriptor("Bean Shell marker", ImpexHighlighterColors.BEAN_SHELL_MARKER),
-            AttributesDescriptor("Bean Shell body", ImpexHighlighterColors.BEAN_SHELL_BODY),
-            AttributesDescriptor("Square brackets", ImpexHighlighterColors.SQUARE_BRACKETS),
-            AttributesDescriptor("Round brackets", ImpexHighlighterColors.ROUND_BRACKETS),
-            AttributesDescriptor("Attribute name", ImpexHighlighterColors.ATTRIBUTE_NAME),
-            AttributesDescriptor("Attribute value", ImpexHighlighterColors.ATTRIBUTE_VALUE),
-            AttributesDescriptor("Attribute separator", ImpexHighlighterColors.ATTRIBUTE_SEPARATOR),
-            AttributesDescriptor("Boolean", ImpexHighlighterColors.BOOLEAN),
-            AttributesDescriptor("Digit", ImpexHighlighterColors.DIGIT),
-            AttributesDescriptor("Alternative map delimiter", ImpexHighlighterColors.ALTERNATIVE_MAP_DELIMITER),
-            AttributesDescriptor("Default key-value delimiter", ImpexHighlighterColors.DEFAULT_KEY_VALUE_DELIMITER),
-            AttributesDescriptor("Default path delimiter", ImpexHighlighterColors.DEFAULT_PATH_DELIMITER),
-            AttributesDescriptor("Parameter name", ImpexHighlighterColors.HEADER_PARAMETER_NAME),
-            AttributesDescriptor("Special parameter name", ImpexHighlighterColors.HEADER_SPECIAL_PARAMETER_NAME),
-            AttributesDescriptor("Parameters separator", ImpexHighlighterColors.PARAMETERS_SEPARATOR),
-            AttributesDescriptor("Comma", ImpexHighlighterColors.COMMA),
-            AttributesDescriptor("Alternative pattern", ImpexHighlighterColors.ALTERNATIVE_PATTERN),
-            AttributesDescriptor("Document id", ImpexHighlighterColors.DOCUMENT_ID),
-            AttributesDescriptor("Bad character", HighlighterColors.BAD_CHARACTER),
-            AttributesDescriptor("Warnings", ImpexHighlighterColors.WARNINGS_ATTRIBUTES),
-            AttributesDescriptor("User rights", ImpexHighlighterColors.USER_RIGHTS),
-            AttributesDescriptor("User rights//Parameter name", ImpexHighlighterColors.USER_RIGHTS_HEADER_PARAMETER),
-            AttributesDescriptor("User rights//Mandatory parameter name", ImpexHighlighterColors.USER_RIGHTS_HEADER_MANDATORY_PARAMETER),
-            AttributesDescriptor("User rights//Permission allowed", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_ALLOWED),
-            AttributesDescriptor("User rights//Permission denied", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_DENIED),
-            AttributesDescriptor("User rights//Permission inherited", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_INHERITED)
-        )
-
-        private val customTags = RainbowHighlighter.createRainbowHLM()
-
-        init {
-            customTags["permission_inherited"] = ImpexHighlighterColors.USER_RIGHTS_PERMISSION_INHERITED
-        }
+    private val customTags = with (RainbowHighlighter.createRainbowHLM()) {
+        put("permission_inherited", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_INHERITED)
+        put("attribute_header_abbreviation", ImpexHighlighterColors.ATTRIBUTE_HEADER_ABBREVIATION)
+        this
     }
+    private val inheritedPermission = "<permission_inherited>.</permission_inherited>"
+    private fun attributeHeaderAbbreviation(abbreviation : String) = "<attribute_header_abbreviation>${"$$abbreviation"}</attribute_header_abbreviation>"
+
+    private val descriptors = arrayOf(
+        AttributesDescriptor("Comment line", ImpexHighlighterColors.PROPERTY_COMMENT),
+        AttributesDescriptor("Macro name declaration", ImpexHighlighterColors.MACRO_NAME_DECLARATION),
+        AttributesDescriptor("Macro value", ImpexHighlighterColors.MACRO_VALUE),
+        AttributesDescriptor("Macro usage", ImpexHighlighterColors.MACRO_USAGE),
+        AttributesDescriptor("Assign value", ImpexHighlighterColors.ASSIGN_VALUE),
+        AttributesDescriptor("Insert", ImpexHighlighterColors.HEADER_MODE_INSERT),
+        AttributesDescriptor("Update", ImpexHighlighterColors.HEADER_MODE_UPDATE),
+        AttributesDescriptor("Insert or update", ImpexHighlighterColors.HEADER_MODE_INSERT_UPDATE),
+        AttributesDescriptor("Remove", ImpexHighlighterColors.HEADER_MODE_REMOVE),
+        AttributesDescriptor("Function call", ImpexHighlighterColors.FUNCTION_CALL),
+        AttributesDescriptor("Header type", ImpexHighlighterColors.HEADER_TYPE),
+        AttributesDescriptor("Value sub-type", ImpexHighlighterColors.VALUE_SUBTYPE),
+        AttributesDescriptor("Field value separator", ImpexHighlighterColors.FIELD_VALUE_SEPARATOR),
+        AttributesDescriptor("List item separator", ImpexHighlighterColors.FIELD_LIST_ITEM_SEPARATOR),
+        AttributesDescriptor("Field value", ImpexHighlighterColors.FIELD_VALUE),
+        AttributesDescriptor("Single string", ImpexHighlighterColors.SINGLE_STRING),
+        AttributesDescriptor("Double string", ImpexHighlighterColors.DOUBLE_STRING),
+        AttributesDescriptor("Ignore value", ImpexHighlighterColors.FIELD_VALUE_IGNORE),
+        AttributesDescriptor("Bean Shell marker", ImpexHighlighterColors.BEAN_SHELL_MARKER),
+        AttributesDescriptor("Bean Shell body", ImpexHighlighterColors.BEAN_SHELL_BODY),
+        AttributesDescriptor("Square brackets", ImpexHighlighterColors.SQUARE_BRACKETS),
+        AttributesDescriptor("Round brackets", ImpexHighlighterColors.ROUND_BRACKETS),
+        AttributesDescriptor("Attribute name", ImpexHighlighterColors.ATTRIBUTE_NAME),
+        AttributesDescriptor("Attribute value", ImpexHighlighterColors.ATTRIBUTE_VALUE),
+        AttributesDescriptor("Attribute separator", ImpexHighlighterColors.ATTRIBUTE_SEPARATOR),
+        AttributesDescriptor("Attribute header abbreviation", ImpexHighlighterColors.ATTRIBUTE_HEADER_ABBREVIATION),
+        AttributesDescriptor("Boolean", ImpexHighlighterColors.BOOLEAN),
+        AttributesDescriptor("Digit", ImpexHighlighterColors.DIGIT),
+        AttributesDescriptor("Alternative map delimiter", ImpexHighlighterColors.ALTERNATIVE_MAP_DELIMITER),
+        AttributesDescriptor("Default key-value delimiter", ImpexHighlighterColors.DEFAULT_KEY_VALUE_DELIMITER),
+        AttributesDescriptor("Default path delimiter", ImpexHighlighterColors.DEFAULT_PATH_DELIMITER),
+        AttributesDescriptor("Parameter name", ImpexHighlighterColors.HEADER_PARAMETER_NAME),
+        AttributesDescriptor("Special parameter name", ImpexHighlighterColors.HEADER_SPECIAL_PARAMETER_NAME),
+        AttributesDescriptor("Parameters separator", ImpexHighlighterColors.PARAMETERS_SEPARATOR),
+        AttributesDescriptor("Comma", ImpexHighlighterColors.COMMA),
+        AttributesDescriptor("Alternative pattern", ImpexHighlighterColors.ALTERNATIVE_PATTERN),
+        AttributesDescriptor("Document id", ImpexHighlighterColors.DOCUMENT_ID),
+        AttributesDescriptor("Bad character", HighlighterColors.BAD_CHARACTER),
+        AttributesDescriptor("Warnings", ImpexHighlighterColors.WARNINGS_ATTRIBUTES),
+        AttributesDescriptor("User rights", ImpexHighlighterColors.USER_RIGHTS),
+        AttributesDescriptor("User rights//Parameter name", ImpexHighlighterColors.USER_RIGHTS_HEADER_PARAMETER),
+        AttributesDescriptor("User rights//Mandatory parameter name", ImpexHighlighterColors.USER_RIGHTS_HEADER_MANDATORY_PARAMETER),
+        AttributesDescriptor("User rights//Permission allowed", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_ALLOWED),
+        AttributesDescriptor("User rights//Permission denied", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_DENIED),
+        AttributesDescriptor("User rights//Permission inherited", ImpexHighlighterColors.USER_RIGHTS_PERMISSION_INHERITED)
+    )
+
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexHighlighterColors.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexHighlighterColors.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -82,6 +82,7 @@ public final class ImpexHighlighterColors {
     public static final TextAttributesKey DOCUMENT_ID = key("DOCUMENT_ID", STATIC_FIELD);
     public static final TextAttributesKey WARNINGS_ATTRIBUTES = key("IMPEX_WARNING_ATTRIBUTES", CodeInsightColors.WARNINGS_ATTRIBUTES);
     public static final TextAttributesKey FUNCTION_CALL = key("IMPEX_FUNCTION_CALL", DefaultLanguageHighlighterColors.FUNCTION_CALL);
+    public static final TextAttributesKey ATTRIBUTE_HEADER_ABBREVIATION = key("IMPEX_ATTRIBUTE_HEADER_ABBREVIATION", KEYWORD);
     public static final TextAttributesKey USER_RIGHTS = key("IMPEX_USER_RIGHTS", STATIC_FIELD);
     public static final TextAttributesKey USER_RIGHTS_HEADER_PARAMETER = key("IMPEX_USER_RIGHTS_HEADER_PARAMETER", HEADER_PARAMETER_NAME);
     public static final TextAttributesKey USER_RIGHTS_HEADER_MANDATORY_PARAMETER = key("IMPEX_USER_RIGHTS_HEADER_MANDATORY_PARAMETER", USER_RIGHTS_HEADER_PARAMETER);

--- a/src/com/intellij/idea/plugin/hybris/impex/lang/annotation/ImpexAnnotator.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/lang/annotation/ImpexAnnotator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -22,6 +22,7 @@ import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.messag
 import com.intellij.idea.plugin.hybris.impex.highlighting.DefaultImpexSyntaxHighlighter
 import com.intellij.idea.plugin.hybris.impex.highlighting.ImpexHighlighterColors
 import com.intellij.idea.plugin.hybris.impex.psi.*
+import com.intellij.idea.plugin.hybris.impex.psi.references.ImpExHeaderAbbreviationReference
 import com.intellij.idea.plugin.hybris.lang.annotation.AbstractAnnotator
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.util.TextRange
@@ -161,6 +162,16 @@ class ImpexAnnotator : AbstractAnnotator(DefaultImpexSyntaxHighlighter.instance)
                         holder,
                         element,
                         range = TextRange.from(element.textRange.startOffset, textLength)
+                    )
+                }
+            }
+
+            ImpexTypes.HEADER_PARAMETER_NAME -> {
+                if (element.parent.reference is ImpExHeaderAbbreviationReference) {
+                    highlight(
+                        ImpexHighlighterColors.ATTRIBUTE_HEADER_ABBREVIATION,
+                        holder,
+                        element,
                     )
                 }
             }


### PR DESCRIPTION
<img width="363" alt="Screenshot 2023-08-20 at 10 08 17" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/2df74796-490b-426a-b393-761e8ce5419b">
<img width="370" alt="Screenshot 2023-08-20 at 10 08 35" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/4297e2e7-122c-4c88-91fa-c69e308d5c2e">
