### PR TITLE
Preselect special part of the `Header Abbreviation` starting with `@` character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Added code completion of the [Header Abbreviations](https://help.sap.com/docs/SAP_COMMERCE/d0224eca81e249cb821f2cdf45a82ace/2fb5a2a780c94325b4a48ff62b36ab23.html#using-header-abbreviations) [#613](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/613)
 - Added reference resolution for `Header Abbreviations` [#615](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/615)
 - Added own color scheme for `Header Abbreviations` [#617](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/617)
+- Preselect special part of the `Header Abbreviation` starting with `@` character [#620](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/620)
 - Adjusted Lexer to enable support of the `@` character for `Header Parameter` [#616](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/616)
 
 ### `ImpEx` inspection rules

--- a/src/com/intellij/idea/plugin/hybris/system/type/codeInsight/lookup/TSLookupElementFactory.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/codeInsight/lookup/TSLookupElementFactory.kt
@@ -18,8 +18,11 @@
 
 package com.intellij.idea.plugin.hybris.system.type.codeInsight.lookup
 
+import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.idea.plugin.hybris.codeInsight.completion.AutoPopupInsertHandler
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
 import com.intellij.idea.plugin.hybris.system.type.meta.model.*
@@ -146,5 +149,23 @@ object TSLookupElementFactory {
         LookupElementBuilder.create(lookupString)
             .withTypeText("Header Abbreviation", true)
             .withIcon(HybrisIcons.TS_HEADER_ABBREVIATION)
-        , 2.0)
+            .withInsertHandler(lookupString.contains('@')
+                .takeIf { it }
+                ?.let {
+                    object : AutoPopupInsertHandler() {
+                        override fun handle(context: InsertionContext, item: LookupElement) {
+                            lookupString.indexOf('@')
+                                .takeIf { it >= 0 }
+                                ?.let { index ->
+                                    val cursorOffset = context.editor.caretModel.offset
+                                    val moveBackTo = lookupString.length - index - 1
+                                    val offset = cursorOffset - moveBackTo
+                                    context.editor.caretModel.moveToOffset(offset)
+                                    context.editor.selectionModel.setSelection(offset, offset + moveBackTo)
+                                }
+                        }
+                    }
+                }
+            ), 2.0
+    )
 }


### PR DESCRIPTION
After selecting code completion element
<img width="588" alt="Screenshot 2023-08-20 at 13 18 04" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/1cfa955b-929e-43a7-babd-20d84487ca93">


automatically select special part of the text, one after `@` character
<img width="155" alt="Screenshot 2023-08-20 at 13 18 57" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/8afd32e0-a939-4062-afd3-928851ffffdc">
