### PR TITLE
Use `HAC` project properties during first project import for remote connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - Hide custom module libraries in the Project View [#569](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/569)
 - Added slack badge to README.md [#577](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/577)
 - Do not show `resources` folders in the `External Libraries` [#589](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/589)
+- Use `HAC` project properties during first project import for remote connections [#623](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/623)
 
 ## [2023.2.5]
 

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownConfigPropertyInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/impex/ImpexUnknownConfigPropertyInspection.kt
@@ -57,7 +57,7 @@ private class UnknownConfigPropertyVisitor(private val problemsHolder: ProblemsH
                 )
             } else {
                 val propertiesService = PropertiesService.getInstance(usage.project) ?: return
-                val property = propertiesService.findMacroProperty(usage.project, propertyName)
+                val property = propertiesService.findMacroProperty(propertyName)
 
                 if (property == null) {
                     cachedProperties[propertyName] = false

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableNameLengthShouldBeValid.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/typeSystem/TSDeploymentTableNameLengthShouldBeValid.kt
@@ -49,7 +49,7 @@ class TSDeploymentTableNameLengthShouldBeValid : AbstractCustomOnlyTSInspection(
     ) {
         val tableName = dom.table.stringValue ?: return
         val maxLength = PropertiesService.getInstance(project)
-            ?.findMacroProperty(project, HybrisConstants.PROPERTY_DEPLOYMENT_TABLENAME_MAXLENGTH)
+            ?.findMacroProperty(HybrisConstants.PROPERTY_DEPLOYMENT_TABLENAME_MAXLENGTH)
             ?.value
             ?.toIntOrNull()
             ?: HybrisConstants.DEFAULT_DEPLOYMENT_TABLENAME_MAXLENGTH

--- a/src/com/intellij/idea/plugin/hybris/impex/lang/folding/ImpexMacroFoldingBuilder.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/lang/folding/ImpexMacroFoldingBuilder.java
@@ -219,7 +219,7 @@ public class ImpexMacroFoldingBuilder implements FoldingBuilder {
 
             if (propertiesService == null) return;
 
-            final var iProperty = propertiesService.findMacroProperty(macroUsage.getProject(), propertyName);
+            final var iProperty = propertiesService.findMacroProperty(propertyName);
 
             if (iProperty == null) return;
 

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiUtil.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/ImpexPsiUtil.kt
@@ -124,7 +124,7 @@ fun getConfigPropertyKey(element: ImpexMacroUsageDec): String? {
     return if (DumbService.isDumb(project)) {
         element.text.replace(HybrisConstants.IMPEX_CONFIG_COMPLETE_PREFIX, "")
     } else PropertiesService.getInstance(project)
-        ?.findMacroProperty(project, propertyKey)
+        ?.findMacroProperty(propertyKey)
         ?.key
         ?: element.text.replace(HybrisConstants.IMPEX_CONFIG_COMPLETE_PREFIX, "")
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexPropertyReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexPropertyReference.kt
@@ -50,7 +50,7 @@ class ImpexPropertyReference(owner: ImpexMacroUsageDec) : PsiReferenceBase.Poly<
             ?: return emptyArray()
 
         return getPropertyKey()
-            ?.let { propertiesService.findMacroProperty(element.project, it) }
+            ?.let { propertiesService.findMacroProperty(it) }
             ?.let { PsiElementResolveResult.createResults(it.psiElement) }
             ?: ResolveResult.EMPTY_ARRAY
     }

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultKotlinCompilerConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultKotlinCompilerConfigurator.kt
@@ -49,7 +49,7 @@ class DefaultKotlinCompilerConfigurator : KotlinCompilerConfigurator {
         if (!hasKotlinnatureExtension) return
 
         val compilerVersion = PropertiesService.getInstance(project)
-            ?.findMacroProperty(project, HybrisConstants.KOTLIN_COMPILER_VERSION_PROPERTY_KEY)
+            ?.findMacroProperty(HybrisConstants.KOTLIN_COMPILER_VERSION_PROPERTY_KEY)
             ?.value
             ?: HybrisConstants.KOTLIN_COMPILER_FALLBACK_VERSION
         setKotlinCompilerVersion(project, compilerVersion)

--- a/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
+++ b/src/com/intellij/idea/plugin/hybris/project/tasks/ImportProjectProgressModalWindow.java
@@ -30,7 +30,6 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.idea.plugin.hybris.common.HybrisConstants;
-import com.intellij.idea.plugin.hybris.common.services.CommonIdeaService;
 import com.intellij.idea.plugin.hybris.impex.ImpexLanguage;
 import com.intellij.idea.plugin.hybris.project.configurators.*;
 import com.intellij.idea.plugin.hybris.project.descriptors.HybrisProjectDescriptor;
@@ -43,7 +42,6 @@ import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisApplicationSettingsComponent;
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettings;
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent;
-import com.intellij.idea.plugin.hybris.startup.HybrisProjectImportStartupActivity;
 import com.intellij.javaee.application.facet.JavaeeApplicationFacet;
 import com.intellij.javaee.web.facet.WebFacet;
 import com.intellij.lang.Language;
@@ -504,10 +502,6 @@ public class ImportProjectProgressModalWindow extends Task.Modal {
             .map(ModuleDescriptor::getName)
             .collect(Collectors.toSet()));
         hybrisProjectSettings.setExcludeTestSources(hybrisProjectDescriptor.isExcludeTestSources());
-
-        CommonIdeaService.Companion.getInstance().fixRemoteConnectionSettings(project);
-
-        project.putUserData(HybrisProjectImportStartupActivity.Companion.getSyncProjectSettingsKey(), true);
     }
 
     private Set<String> createModulesOnBlackList() {

--- a/src/com/intellij/idea/plugin/hybris/properties/PropertiesService.kt
+++ b/src/com/intellij/idea/plugin/hybris/properties/PropertiesService.kt
@@ -29,11 +29,13 @@ interface PropertiesService {
 
     fun findProperty(query: String): String?
 
-    fun findMacroProperty(project: Project, query: String): IProperty?
+    fun findMacroProperty(query: String): IProperty?
 
     fun findAutoCompleteProperties(query: String): List<IProperty>
 
     companion object {
         fun getInstance(project: Project): PropertiesService? = project.getService(PropertiesService::class.java)
     }
+
+    fun getProperty(key: String): IProperty?
 }

--- a/src/com/intellij/idea/plugin/hybris/psi/reference/LanguageReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/psi/reference/LanguageReference.kt
@@ -51,7 +51,7 @@ class LanguageReference(owner: PsiElement) : PsiReferenceBase.Poly<PsiElement>(o
 
         private val provider = ParameterizedCachedValueProvider<Array<ResolveResult>, LanguageReference> { ref ->
             val result: Array<ResolveResult> = PropertiesService.getInstance(ref.element.project)
-                ?.findMacroProperty(ref.element.project, HybrisConstants.PROPERTY_LANG_PACKS)
+                ?.findMacroProperty(HybrisConstants.PROPERTY_LANG_PACKS)
                 ?.let {
                     val property = it as? PsiElement
                         ?: PomService.convertToPsi(it as PsiTarget)

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisDeveloperSpecificProjectSettingsComponent.java
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisDeveloperSpecificProjectSettingsComponent.java
@@ -181,7 +181,7 @@ public class HybrisDeveloperSpecificProjectSettingsComponent implements Persiste
 
     private static String getPropertyOrDefault(final Project project, final String key, final String fallback) {
         return Optional.ofNullable(PropertiesService.Companion.getInstance(project))
-            .map(it -> it.findMacroProperty(project, key))
+            .map(it -> it.getProperty(key))
             .map(IProperty::getValue)
             .orElse(fallback);
     }

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.kt
@@ -27,10 +27,10 @@ import com.intellij.openapi.components.BaseState
 import java.util.*
 
 class HybrisProjectSettings : BaseState() {
-    var flexibleSearchSettings: FlexibleSearchSettings = FlexibleSearchSettings()
-    var polyglotQuerySettings: PolyglotQuerySettings = PolyglotQuerySettings()
-    var impexSettings: ImpexSettings = ImpexSettings()
-    var groovySettings: GroovySettings = GroovySettings()
+    var flexibleSearchSettings by property(FlexibleSearchSettings()) { false }
+    var polyglotQuerySettings by property(PolyglotQuerySettings()) { false }
+    var impexSettings by property(ImpexSettings()) { false }
+    var groovySettings by property(GroovySettings()) { false }
 
     var customDirectory by string(null)
     var hybrisDirectory by string(null)
@@ -50,10 +50,9 @@ class HybrisProjectSettings : BaseState() {
     var excludeTestSources by property(false)
     var importCustomAntBuildFiles by property(false)
     var showFullModuleName by property(false)
-    var completeSetOfAvailableExtensionsInHybris: Set<String> = mutableSetOf()
-    var unusedExtensions: Set<String> = mutableSetOf()
-    var modulesOnBlackList: Set<String> = mutableSetOf()
-    var availableExtensions: MutableMap<String, ExtensionDescriptor> = TreeMap<String, ExtensionDescriptor> { a, b ->
-        a.compareTo(b, true)
-    }
+    var completeSetOfAvailableExtensionsInHybris by stringSet()
+    var unusedExtensions by stringSet()
+    var modulesOnBlackList by stringSet()
+    var availableExtensions by property(TreeMap<String, ExtensionDescriptor> { a, b -> a.compareTo(b, true) }) { it.isEmpty() }
+
 }

--- a/src/com/intellij/idea/plugin/hybris/startup/HybrisProjectStructureStartupActivity.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/HybrisProjectStructureStartupActivity.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -101,7 +101,6 @@ class HybrisProjectStructureStartupActivity : ProjectActivity {
         resetSpringGeneralSettings(project)
         fixBackOfficeJRebelSupport(project)
 
-        CommonIdeaService.instance.fixRemoteConnectionSettings(project)
         ConsolePersistenceService.getInstance(project).loadPersistedQueries()
     }
 


### PR DESCRIPTION
After first init:
<img width="314" alt="Screenshot 2023-08-20 at 19 24 42" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/fdb7da21-f0b4-4d32-9f32-90ec85f330e9">


default props:
- `hac.webroot`
- `tomcat.ssl.port`