### PR TITLE
Added ability to navigate from the declared bean property to the generated property in the java class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Added find usages for bean properties [#608](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/608)
 - Added code completion for Hint `name` attribute [#609](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/609)
 - Added Bean Generics code completion for Property `type` attribute [#610](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/610)
+- Added navigation from a declared bean property to the generated java property [#624](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/624)
 
 ### `beans.xml` inspection rules
 - Java keywords and reserved words cannot be used as Bean property **name** [#591](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/591)

--- a/src/com/intellij/idea/plugin/hybris/system/bean/codeInsight/hints/BeansXmlInlayHintsCollector.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/codeInsight/hints/BeansXmlInlayHintsCollector.kt
@@ -40,6 +40,7 @@ import com.intellij.psi.xml.XmlToken
 import com.intellij.psi.xml.XmlTokenType
 import com.intellij.refactoring.suggested.startOffset
 import com.intellij.util.OpenSourceUtil
+import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
 import java.awt.Cursor
 import javax.swing.Icon
@@ -48,6 +49,9 @@ import javax.swing.Icon
  * use com.intellij.codeInsight.hints.presentation.PresentationFactory#referenceOnHover and show popup from clickListener
  */
 class BeansXmlInlayHintsCollector(editor: Editor) : FactoryInlayHintsCollector(editor) {
+
+    val fileLabel = "Navigate to the Generated File"
+    val propertyLabel = "Navigate to the Generated Property"
 
     val unknown: InlayPresentation by lazy {
         val icon = factory.icon(AllIcons.General.ExclMark)
@@ -82,12 +86,12 @@ class BeansXmlInlayHintsCollector(editor: Editor) : FactoryInlayHintsCollector(e
     private fun retrievePresentation(parent: XmlTag, attribute: String, project: Project, element: XmlToken) = when {
         parent.name == "enum" && attribute == "class" -> finEnumClass(project, element.text)
             ?.let { arrayOf(it) }
-            ?.let { inlayPresentation(HybrisIcons.BS_ENUM, it) }
+            ?.let { inlayPresentation(HybrisIcons.BS_ENUM, it, fileLabel) }
             ?: unknown
 
         parent.name == "bean" && attribute == "class" -> findItemClass(project, element.text)
             ?.let { arrayOf(it) }
-            ?.let { inlayPresentation(HybrisIcons.BS_BEAN, it) }
+            ?.let { inlayPresentation(HybrisIcons.BS_BEAN, it, fileLabel) }
             ?: unknown
 
         parent.name == "value" -> parent.parentOfType<XmlTag>()
@@ -96,16 +100,26 @@ class BeansXmlInlayHintsCollector(editor: Editor) : FactoryInlayHintsCollector(e
             ?.let { finEnumClass(project, it) }
             ?.let { it.allFields.find { field -> field.name.equals(element.text, true) } }
             ?.let { arrayOf(it) }
-            ?.let { inlayPresentation(HybrisIcons.TS_ENUM_VALUE, it) }
+            ?.let { inlayPresentation(HybrisIcons.TS_ENUM_VALUE, it, fileLabel) }
+            ?: unknown
+
+        parent.name == "property" && attribute == "name" -> element.parentOfType<XmlTag>()
+            ?.getParentOfType<XmlTag>(true)
+            ?.getAttributeValue("class")
+            ?.let { findItemClass(project, it) }
+            ?.allFields
+            ?.find { it.name == parent.getAttributeValue("name") }
+            ?.let { arrayOf(it) }
+            ?.let { inlayPresentation(HybrisIcons.BS_PROPERTY, it, propertyLabel) }
             ?: unknown
 
         else -> null
     }
 
-    private fun inlayPresentation(i: Icon, navigatables: Array<out Navigatable>): InlayPresentation {
+    private fun inlayPresentation(i: Icon, navigatables: Array<out Navigatable>, label: String): InlayPresentation {
         val icon = factory.icon(i)
         val inset = factory.inset(icon, right = 5, top = 3)
-        val tooltip = factory.withTooltip("Navigate to the Generated File", inset)
+        val tooltip = factory.withTooltip(label, inset)
 
         return factory.referenceOnHover(tooltip) { _, _ -> OpenSourceUtil.navigate(*navigatables) }
     }

--- a/src/com/intellij/idea/plugin/hybris/system/bean/codeInsight/hints/BeansXmlInlayHintsCollector.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/bean/codeInsight/hints/BeansXmlInlayHintsCollector.kt
@@ -24,6 +24,10 @@ import com.intellij.codeInsight.hints.presentation.InlayPresentation
 import com.intellij.icons.AllIcons
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.system.bean.model.Bean
+import com.intellij.idea.plugin.hybris.system.bean.model.Beans
+import com.intellij.idea.plugin.hybris.system.bean.model.Enum
+import com.intellij.idea.plugin.hybris.system.bean.model.Property
 import com.intellij.idea.plugin.hybris.system.type.model.EnumType
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbService
@@ -84,18 +88,18 @@ class BeansXmlInlayHintsCollector(editor: Editor) : FactoryInlayHintsCollector(e
     }
 
     private fun retrievePresentation(parent: XmlTag, attribute: String, project: Project, element: XmlToken) = when {
-        parent.name == "enum" && attribute == "class" -> finEnumClass(project, element.text)
+        parent.name == Beans.ENUM && attribute == Bean.CLASS -> finEnumClass(project, element.text)
             ?.let { arrayOf(it) }
             ?.let { inlayPresentation(HybrisIcons.BS_ENUM, it, fileLabel) }
             ?: unknown
 
-        parent.name == "bean" && attribute == "class" -> findItemClass(project, element.text)
+        parent.name == Beans.BEAN && attribute == Bean.CLASS -> findItemClass(project, element.text)
             ?.let { arrayOf(it) }
             ?.let { inlayPresentation(HybrisIcons.BS_BEAN, it, fileLabel) }
             ?: unknown
 
-        parent.name == "value" -> parent.parentOfType<XmlTag>()
-            ?.takeIf { it.name == "enum" }
+        parent.name == Enum.VALUE -> parent.parentOfType<XmlTag>()
+            ?.takeIf { it.name == Beans.ENUM }
             ?.getAttributeValue(EnumType.CODE)
             ?.let { finEnumClass(project, it) }
             ?.let { it.allFields.find { field -> field.name.equals(element.text, true) } }
@@ -103,12 +107,12 @@ class BeansXmlInlayHintsCollector(editor: Editor) : FactoryInlayHintsCollector(e
             ?.let { inlayPresentation(HybrisIcons.TS_ENUM_VALUE, it, fileLabel) }
             ?: unknown
 
-        parent.name == "property" && attribute == "name" -> element.parentOfType<XmlTag>()
+        parent.name == Bean.PROPERTY && attribute == Property.NAME -> element.parentOfType<XmlTag>()
             ?.getParentOfType<XmlTag>(true)
-            ?.getAttributeValue("class")
+            ?.getAttributeValue(Bean.CLASS)
             ?.let { findItemClass(project, it) }
             ?.allFields
-            ?.find { it.name == parent.getAttributeValue("name") }
+            ?.find { it.name == parent.getAttributeValue(Property.NAME) }
             ?.let { arrayOf(it) }
             ?.let { inlayPresentation(HybrisIcons.BS_PROPERTY, it, propertyLabel) }
             ?: unknown


### PR DESCRIPTION
Navigation from a property declared in the beans.xml to the generated java property
<img width="788" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/d228297e-b733-47f5-91ca-b5cd71f5031a">
<img width="820" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/e3ada055-7d72-4843-b876-6d6f1114643f">
