### PR TITLE
Improved `qualifier` reference handling in case of set `spring-bean` for `lv:column`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### `CockpitNG` enhancements
 - Added code completion for AdvancedSearch `operator` parameter [#537](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/537)
+- Improved `qualifier` reference handling in case of set `spring-bean` for `lv:column` [#628](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/628)
 
 ### `HAC` enhancements
 - Enhanced Cluster support, support node routing [#543](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/543)

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/provider/CngTSItemAttributeReferenceProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/provider/CngTSItemAttributeReferenceProvider.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -17,17 +17,27 @@
  */
 package com.intellij.idea.plugin.hybris.system.cockpitng.psi.provider
 
+import com.intellij.idea.plugin.hybris.system.cockpitng.model.listView.ListColumn
 import com.intellij.idea.plugin.hybris.system.cockpitng.psi.reference.CngTSItemAttributeReference
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.xml.XmlTag
 import com.intellij.util.ProcessingContext
+import com.intellij.util.xml.DomManager
 
 class CngTSItemAttributeReferenceProvider : PsiReferenceProvider() {
 
     override fun getReferencesByElement(
         element: PsiElement, context: ProcessingContext
-    ) = arrayOf(CngTSItemAttributeReference(element))
+    ) = element.parentOfType<XmlTag>()
+        ?.let { DomManager.getDomManager(element.project).getDomElement(it) }
+        ?.let { it as? ListColumn }
+        ?.springBean
+        ?.takeUnless { it.stringValue == null }
+        ?.let { emptyArray() }
+        ?: arrayOf(CngTSItemAttributeReference(element))
 
     companion object {
         val instance: PsiReferenceProvider = ApplicationManager.getApplication().getService(CngTSItemAttributeReferenceProvider::class.java)


### PR DESCRIPTION
**before**
<img width="661" alt="Screenshot 2023-08-21 at 16 46 41" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/2a4978df-b0e0-42dc-890e-49ff1d59321e">

**after**
<img width="763" alt="Screenshot 2023-08-21 at 17 08 15" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/2a0787de-389d-44bd-9a47-8cc313baa529">
