### PR TITLE
Validate `parent` value according to `type` value of the `context` tag in case of `merge-by="type"` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@
 - Improved `qualifier` reference handling in case of set `spring-bean` for `lv:column` [#628](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/628)
 - Added code completion and reference resolution for Enum attributes [#629](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/629)
 
+### `CockpitNG` inspection rules
+- Validate `parent` value according to `type` value of the `context` tag in case of `merge-by="type"` mode [#631](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/631)
+- Adjusted DOM inspection fpr `AbstractActionType` tag [#626](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/626)
+- Adjusted DOM inspection for `Essentials` tag [#627](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/627)
+- Adjusted `CngContextParentIsNotValid` inspection to ignore `merge-by="type"` [#630](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/630)
+
 ### `HAC` enhancements
 - Enhanced Cluster support, support node routing [#543](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/543)
 - Allow blank port for connection settings [#542](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/542)
@@ -107,9 +113,6 @@
 - Dependant modules are not imported [#614](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/614)
 - Ensure that `Properties` Plugin dependant code works only when corresponding Plugin is enabled [#618](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/618)
 - Also hide full Module name for `web` sub-module in the Project View [#622](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/622)
-- CockpitNG DOM inspection is not properly validating `AbstractActionType` type [#626](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/626)
-- CockpitNG DOM inspection is not properly validating `Essentials` type [#627](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/627)
-- CockpitNG `CngContextParentIsNotValid` inspection should ignore `merge-by="type"` [#630](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/630)
 
 ### Other
 - Adjusted inline documentation for Type System [#539](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/539)

--- a/resources/META-INF/plugin-inspections.xml
+++ b/resources/META-INF/plugin-inspections.xml
@@ -60,6 +60,10 @@
                          bundle="i18n.HybrisBundle" key="hybris.inspections.cng.ContextParentIsNotValid.key"
                          shortName="CngContextParentIsNotValid" level="ERROR"
                          implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.cockpitng.CngContextParentIsNotValid"/>
+        <localInspection language="XML" enabledByDefault="true" groupPath="SAP Commerce" groupName="[y] Cockpit NG"
+                         bundle="i18n.HybrisBundle" key="hybris.inspections.cng.CngContextMergeByTypeParentIsNotValid.key"
+                         shortName="CngContextMergeByTypeParentIsNotValid" level="ERROR"
+                         implementationClass="com.intellij.idea.plugin.hybris.codeInspection.rule.cockpitng.CngContextMergeByTypeParentIsNotValid"/>
 
         <!-- Impex -->
         <localInspection groupPath="SAP Commerce" shortName="ImpexLanguageIsNotSupportedInspection" displayName="[y] Language is not supported"

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -343,8 +343,10 @@ hybris.inspections.fix.le.LeUnknownExtensionDeclaration.message=[y] Unknown ''{0
 
 hybris.inspections.cng.ContextMergeByPointToExistingContextAttribute.key=[y] Unknown merge-by value of the context tag
 hybris.inspections.cng.ContextParentIsNotValid.key=[y] Unknown parent value of the context tag
+hybris.inspections.cng.CngContextMergeByTypeParentIsNotValid.key=[y] Unknown parent Type of the context tag for merge-by="type"
+hybris.inspections.fix.cng.CngContextMergeByTypeParentIsNotValid.key=[y] Type ''{0}'' does not extend ''{1}'' Type as expected by merge-by="type" mode
 hybris.inspections.fix.cng.ContextMergeByPointToExistingContextAttribute.message=[y] Unknown ''{0}'' merge-by value of the context tag
-hybris.inspections.fix.cng.ContextParentIsNotValid.message=[y] Unknown ''{0}'' parent value of the context tag for merge ''{1}'' strategy
+hybris.inspections.fix.cng.ContextParentIsNotValid.message=[y] Unknown ''{0}'' parent value of the context tag for merge ''{1}'' mode
 
 hybris.inspections.DomElementsInspection.key=[y] Unresolved reference
 

--- a/resources/inspectionDescriptions/CngContextMergeByTypeParentIsNotValid.html
+++ b/resources/inspectionDescriptions/CngContextMergeByTypeParentIsNotValid.html
@@ -18,6 +18,6 @@
 
 <html>
 <body>
-Cockpit NG Context <code>parent</code> value has to point to existing value in accordance with value of the <code>merge-by</code> attribute of the wrapping <code>context</code> tag.
+Cockpit NG Context <code>parent</code> value has to point to existing type which present on a list of extends for type set via <code>type</code> attribute of the wrapping <code>context</code> tag.
 </body>
 </html>

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/cockpitng/CngContextMergeByTypeParentIsNotValid.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/cockpitng/CngContextMergeByTypeParentIsNotValid.kt
@@ -1,0 +1,76 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.codeInspection.rule.cockpitng
+
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
+import com.intellij.idea.plugin.hybris.system.cockpitng.model.config.Config
+import com.intellij.idea.plugin.hybris.system.cockpitng.model.config.Context
+import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
+import com.intellij.idea.plugin.hybris.system.type.meta.model.TSGlobalMetaEnum
+import com.intellij.idea.plugin.hybris.system.type.meta.model.TSGlobalMetaItem
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.Project
+import com.intellij.util.xml.highlighting.DomElementAnnotationHolder
+import com.intellij.util.xml.highlighting.DomHighlightingHelper
+
+class CngContextMergeByTypeParentIsNotValid : AbstractCngConfigInspection() {
+
+    override fun inspect(
+        project: Project,
+        dom: Config,
+        holder: DomElementAnnotationHolder,
+        helper: DomHighlightingHelper,
+        severity: HighlightSeverity
+    ) {
+        val metaModelAccess = TSMetaModelAccess.getInstance(project)
+        dom.contexts
+            .filter { it.mergeBy.stringValue == "type" }
+            .forEach { check(it, holder, severity, metaModelAccess) }
+    }
+
+    private fun check(
+        dom: Context,
+        holder: DomElementAnnotationHolder,
+        severity: HighlightSeverity,
+        metaModelAccess: TSMetaModelAccess
+    ) {
+        val parentType = dom.parentAttribute.stringValue ?: return
+        val type = dom.type.stringValue ?: return
+
+        val typeMeta = metaModelAccess.findMetaClassifierByName(type) ?: return
+
+        // skip enums
+        if (typeMeta is TSGlobalMetaEnum && parentType == HybrisConstants.TS_TYPE_ENUMERATION_VALUE) return
+
+        // skip non-item types
+        if (typeMeta !is TSGlobalMetaItem) return
+
+        val validParentType = typeMeta.allExtends
+            .any { parentType.equals(it.name, true) }
+
+        if (validParentType) return
+
+        holder.createProblem(
+            dom.parentAttribute,
+            severity,
+            message("hybris.inspections.fix.cng.CngContextMergeByTypeParentIsNotValid.key", type, parentType)
+        )
+    }
+}


### PR DESCRIPTION
<img width="661" alt="Screenshot 2023-08-21 at 19 33 41" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/67e6e260-b75e-4f2d-ac22-6286c395d33f">
<img width="819" alt="Screenshot 2023-08-21 at 19 33 35" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/ed1f9812-9507-490a-b3af-0f91101d1ba3">
<img width="1325" alt="Screenshot 2023-08-21 at 19 33 20" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/6e93e787-a2bf-4c9c-9831-ea3fd559b0aa">
