### PR TITLE
Bus is already disposed for consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### `External Dependencies` inspection rules
 - Inspect is declared dependency downloaded [#644](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/644)
 
+### Fixes
+- Bus is already disposed for consoles [#645](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/645)
+
 ### Other
 - Added custom icon for `unmanaged-dependencies.txt` [#640](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/640)
 

--- a/resources/META-INF/lang/optional-flexibleSearch.xml
+++ b/resources/META-INF/lang/optional-flexibleSearch.xml
@@ -62,7 +62,7 @@
 
         <projectConfigurable id="hybris.project.fxs.settings" parentId="hybris.project.settings"
                              nonDefaultProject="true" dynamic="true"
-                             key="hybris.settings.project.fxs.title"
+                             bundle="i18n.HybrisBundle" key="hybris.settings.project.fxs.title"
                              provider="com.intellij.idea.plugin.hybris.flexibleSearch.settings.FlexibleSearchSettingsConfigurableProvider"/>
 
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.flexibleSearch.highlighting.FlexibleSearchSyntaxHighlighter"/>

--- a/resources/META-INF/lang/optional-impex.xml
+++ b/resources/META-INF/lang/optional-impex.xml
@@ -69,7 +69,7 @@
 
         <projectConfigurable id="hybris.project.impex.settings" parentId="hybris.project.settings"
                              nonDefaultProject="true" dynamic="true"
-                             key="hybris.settings.project.impex.title"
+                             bundle="i18n.HybrisBundle" key="hybris.settings.project.impex.title"
                              provider="com.intellij.idea.plugin.hybris.impex.settings.ImpexSettingsConfigurableProvider"/>
 
         <!-- ####################################################################################################### -->

--- a/resources/META-INF/lang/optional-polyglot-query.xml
+++ b/resources/META-INF/lang/optional-polyglot-query.xml
@@ -42,7 +42,7 @@
         <editorNotificationProvider id="pgqEditorNotificationProvider" implementation="com.intellij.idea.plugin.hybris.polyglotQuery.ui.PolyglotQueryEditorNotificationProvider"/>
 
         <projectConfigurable id="hybris.project.pgq.settings" parentId="hybris.project.settings" nonDefaultProject="true" dynamic="true"
-                             key="hybris.settings.project.pgq.title"
+                             bundle="i18n.HybrisBundle" key="hybris.settings.project.pgq.title"
                              provider="com.intellij.idea.plugin.hybris.polyglotQuery.settings.PolyglotQuerySettingsConfigurableProvider"/>
 
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.polyglotQuery.highlighting.PolyglotQuerySyntaxHighlighter"/>

--- a/resources/META-INF/optional-groovy-dependencies.xml
+++ b/resources/META-INF/optional-groovy-dependencies.xml
@@ -25,7 +25,7 @@
 
         <projectConfigurable id="hybris.project.groovy.settings" parentId="hybris.project.settings"
                              nonDefaultProject="true" dynamic="true"
-                             key="hybris.settings.project.groovy.title"
+                             bundle="i18n.HybrisBundle" key="hybris.settings.project.groovy.title"
                              provider="com.intellij.idea.plugin.hybris.groovy.settings.GroovySettingsConfigurableProvider"/>
 
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.groovy.file.GroovyFileToolbarInstaller"/>

--- a/resources/META-INF/plugin-internal.xml
+++ b/resources/META-INF/plugin-internal.xml
@@ -53,6 +53,8 @@
 
         <projectService serviceInterface="com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowService"
                         serviceImplementation="com.intellij.idea.plugin.hybris.toolwindow.impl.HybrisToolWindowServiceImpl"/>
+        <projectService serviceInterface="com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService"
+                        serviceImplementation="com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisConsoleServiceImpl"/>
         <projectService serviceImplementation="com.intellij.idea.plugin.hybris.toolwindow.system.bean.view.BSViewSettings"/>
         <projectService serviceImplementation="com.intellij.idea.plugin.hybris.toolwindow.system.type.view.TSViewSettings"/>
         <projectService serviceImplementation="com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent"/>

--- a/src/com/intellij/idea/plugin/hybris/actions/CopyFileToHybrisConsoleUtils.kt
+++ b/src/com/intellij/idea/plugin/hybris/actions/CopyFileToHybrisConsoleUtils.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -24,6 +24,7 @@ import com.intellij.ide.projectView.ProjectViewNode
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.messageFallback
 import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsole
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.idea.plugin.hybris.toolwindow.CopyFileToHybrisConsoleDialog
 import com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowFactory
 import com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowService
@@ -37,7 +38,7 @@ import javax.swing.tree.TreePath
 object CopyFileToHybrisConsoleUtils {
 
     fun copySelectedFilesToConsole(project: Project, consoleTitle: String, dialogTitle: String) {
-        val console = HybrisToolWindowService.getInstance(project).consolesPanel.findConsole(consoleTitle) ?: return
+        val console = HybrisConsoleService.getInstance(project).findConsole(consoleTitle) ?: return
         val query = getQueryFromSelectedFiles(project)
 
         if (getTextFromHybrisConsole(project, console).isNotEmpty()) {
@@ -49,8 +50,8 @@ object CopyFileToHybrisConsoleUtils {
     }
 
     fun copyQueryToConsole(project: Project, consoleTitle: String, query: String) {
-        val panel = HybrisToolWindowService.getInstance(project).consolesPanel
-        val console = panel.findConsole(consoleTitle) ?: return
+        val hybrisConsoleService = HybrisConsoleService.getInstance(project)
+        val console = hybrisConsoleService.findConsole(consoleTitle) ?: return
 
         with(HybrisToolWindowService.getInstance(project)) {
             this.activateToolWindow()
@@ -58,7 +59,7 @@ object CopyFileToHybrisConsoleUtils {
         }
 
         with(console) {
-            panel.setActiveConsole(this)
+            hybrisConsoleService.setActiveConsole(this)
             this.clear()
             this.setInputText(query)
         }

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/externalDependencies/EdDependencyIsNotYetDownloaded.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/externalDependencies/EdDependencyIsNotYetDownloaded.kt
@@ -23,14 +23,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.util.xml.highlighting.DomElementAnnotationHolder
 import com.intellij.util.xml.highlighting.DomHighlightingHelper
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import org.jetbrains.idea.maven.dom.model.MavenDomProjectModel
-import org.jetbrains.idea.maven.indices.archetype.MavenCatalog
-import java.io.File
-import java.io.FileOutputStream
-import java.net.HttpURLConnection
-import java.net.URL
 
 class EdDependencyIsNotYetDownloaded : AbstractEdInspection() {
 
@@ -61,51 +54,5 @@ class EdDependencyIsNotYetDownloaded : AbstractEdInspection() {
                     )
                 }
             }
-//
-//        val groupId = "com.example"
-//        val artifactId = "your-artifact-id"
-//        val version = "1.0.0"
-//        val targetModulePath = "/path/to/your/module"
-//
-//        downloadMavenDependencyWithSources(groupId, artifactId, version, targetModulePath)
-
-    }
-
-    fun downloadFile(url: String, targetFile: File) {
-        val connection = URL(url).openConnection() as HttpURLConnection
-        connection.connect()
-
-        val inputStream = connection.inputStream
-        val outputStream = FileOutputStream(targetFile)
-
-        inputStream.use { input ->
-            outputStream.use { output ->
-                input.copyTo(output)
-            }
-        }
-    }
-
-    fun downloadMavenDependencyWithSources(
-        groupId: String,
-        artifactId: String,
-        version: String,
-        targetModulePath: String
-    ) {
-        val repositoryUrl = MavenCatalog.System.MavenCentral.url
-        val jarUrl = "$repositoryUrl/${groupId.replace('.', '/')}/$artifactId/$version/$artifactId-$version.jar"
-        val sourcesUrl = "$repositoryUrl/${groupId.replace('.', '/')}/$artifactId/$version/$artifactId-$version-sources.jar"
-
-        val libFolder = File("$targetModulePath/lib")
-        libFolder.mkdirs()
-
-        runBlocking(Dispatchers.IO) {
-            val jarFile = File(libFolder, "$artifactId-$version.jar")
-            val sourcesFile = File(libFolder, "$artifactId-$version-sources.jar")
-
-            downloadFile(jarUrl, jarFile)
-            downloadFile(sourcesUrl, sourcesFile)
-
-            println("Dependency downloaded and copied to lib folder.")
-        }
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/actions/FlexibleSearchExecuteQueryAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/actions/FlexibleSearchExecuteQueryAction.kt
@@ -18,15 +18,18 @@
  */
 package com.intellij.idea.plugin.hybris.flexibleSearch.actions
 
+import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
 import com.intellij.idea.plugin.hybris.flexibleSearch.file.FlexibleSearchFileType
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 
-class FlexibleSearchExecuteQueryAction : AbstractExecuteAction() {
+class FlexibleSearchExecuteQueryAction : AbstractExecuteAction(
+    FlexibleSearchFileType.instance.defaultExtension,
+    HybrisConstants.CONSOLE_TITLE_FLEXIBLE_SEARCH
+) {
 
     init {
         with (templatePresentation) {
@@ -35,9 +38,6 @@ class FlexibleSearchExecuteQueryAction : AbstractExecuteAction() {
             icon = HybrisIcons.CONSOLE_EXECUTE
         }
     }
-
-    override val extension = FlexibleSearchFileType.instance.defaultExtension
-    override val consoleName = HybrisConstants.CONSOLE_TITLE_FLEXIBLE_SEARCH
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExExecuteAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExExecuteAction.kt
@@ -17,17 +17,20 @@
  */
 package com.intellij.idea.plugin.hybris.impex.actions
 
+import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
 import com.intellij.idea.plugin.hybris.impex.file.ImpexFileType
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 
-class ImpExExecuteAction : AbstractExecuteAction() {
+class ImpExExecuteAction : AbstractExecuteAction(
+    ImpexFileType.INSTANCE.defaultExtension,
+    HybrisConstants.CONSOLE_TITLE_IMPEX
+) {
 
     init {
-        with (templatePresentation) {
+        with(templatePresentation) {
             text = message("hybris.impex.actions.execute_query")
             description = message("hybris.impex.actions.execute_query.description")
             icon = HybrisIcons.CONSOLE_EXECUTE
@@ -35,6 +38,4 @@ class ImpExExecuteAction : AbstractExecuteAction() {
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.EDT
-    override val extension = ImpexFileType.INSTANCE.defaultExtension
-    override val consoleName = HybrisConstants.CONSOLE_TITLE_IMPEX
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExValidateAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExValidateAction.kt
@@ -17,28 +17,28 @@
  */
 package com.intellij.idea.plugin.hybris.impex.actions
 
+import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
 import com.intellij.idea.plugin.hybris.impex.file.ImpexFileType
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesPanel
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 
-class ImpExValidateAction : AbstractExecuteAction() {
+class ImpExValidateAction : AbstractExecuteAction(
+    ImpexFileType.INSTANCE.defaultExtension,
+    HybrisConstants.CONSOLE_TITLE_IMPEX
+) {
 
     init {
-        with (templatePresentation) {
+        with(templatePresentation) {
             text = "Validate ImpEx"
             description = "Validate ImpEx file via remote SAP Commerce instance"
             icon = HybrisIcons.IMX_VALIDATE
         }
     }
 
-    override val extension = ImpexFileType.INSTANCE.defaultExtension
-    override val consoleName = HybrisConstants.CONSOLE_TITLE_IMPEX
-
     override fun getActionUpdateThread() = ActionUpdateThread.EDT
-    override fun doExecute(consolePanel: HybrisConsolesPanel) {
-        consolePanel.validateImpex()
+    override fun doExecute(consoleService: HybrisConsoleService) {
+        consoleService.validateImpex()
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/polyglotQuery/actions/PolyglotQueryExecuteQueryAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/polyglotQuery/actions/PolyglotQueryExecuteQueryAction.kt
@@ -25,18 +25,18 @@ import com.intellij.idea.plugin.hybris.polyglotQuery.file.PolyglotQueryFileType
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 
-class PolyglotQueryExecuteQueryAction : AbstractExecuteAction() {
+class PolyglotQueryExecuteQueryAction : AbstractExecuteAction(
+    PolyglotQueryFileType.instance.defaultExtension,
+    HybrisConstants.CONSOLE_TITLE_POLYGLOT_QUERY
+) {
 
     init {
-        with (templatePresentation) {
+        with(templatePresentation) {
             text = HybrisI18NBundleUtils.message("hybris.pgq.actions.execute_query")
             description = HybrisI18NBundleUtils.message("hybris.pgq.actions.execute_query.description")
             icon = HybrisIcons.CONSOLE_EXECUTE
         }
     }
-
-    override val extension = PolyglotQueryFileType.instance.defaultExtension
-    override val consoleName = HybrisConstants.CONSOLE_TITLE_POLYGLOT_QUERY
 
     override fun update(e: AnActionEvent) {
         super.update(e)

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/CatalogVersionOption.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/CatalogVersionOption.kt
@@ -1,6 +1,5 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
  * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,24 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.groovy.actions
 
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
-import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
-import org.jetbrains.plugins.groovy.GroovyFileType
+package com.intellij.idea.plugin.hybris.tools.remote.console
 
-class GroovyExecuteAction : AbstractExecuteAction(
-    GroovyFileType.GROOVY_FILE_TYPE.defaultExtension,
-    HybrisConstants.CONSOLE_TITLE_GROOVY
-) {
-
-    init {
-        with(templatePresentation) {
-            text = "Execute Groovy Script"
-            description = "Execute Groovy Script on a remote SAP Commerce instance"
-            icon = HybrisIcons.CONSOLE_EXECUTE
-        }
-    }
-
-}
+data class CatalogVersionOption(val name: String, val value: String)

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/HybrisConsole.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/HybrisConsole.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.intellij.idea.plugin.hybris.tools.remote.console
 
 import com.intellij.execution.console.LanguageConsoleImpl
@@ -7,7 +25,6 @@ import com.intellij.idea.plugin.hybris.tools.remote.http.impex.HybrisHttpResult
 import com.intellij.lang.Language
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vcs.impl.LineStatusTrackerManager
-import java.util.concurrent.TimeUnit
 import javax.swing.Icon
 
 abstract class HybrisConsole(project: Project, title: String, language: Language) : LanguageConsoleImpl(project, title, language) {
@@ -46,6 +63,3 @@ abstract class HybrisConsole(project: Project, title: String, language: Language
 }
 
 
-data class TimeOption(val name: String, val value: Int, val unit: TimeUnit)
-
-data class CatalogVersionOption(val name: String, val value: String)

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/HybrisConsoleService.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/HybrisConsoleService.kt
@@ -1,6 +1,5 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
  * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,24 +15,21 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.groovy.actions
 
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
-import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
-import org.jetbrains.plugins.groovy.GroovyFileType
+package com.intellij.idea.plugin.hybris.tools.remote.console
 
-class GroovyExecuteAction : AbstractExecuteAction(
-    GroovyFileType.GROOVY_FILE_TYPE.defaultExtension,
-    HybrisConstants.CONSOLE_TITLE_GROOVY
-) {
+import com.intellij.openapi.project.Project
 
-    init {
-        with(templatePresentation) {
-            text = "Execute Groovy Script"
-            description = "Execute Groovy Script on a remote SAP Commerce instance"
-            icon = HybrisIcons.CONSOLE_EXECUTE
-        }
+interface HybrisConsoleService {
+
+    fun findConsole(consoleTitle: String): HybrisConsole?
+    fun setActiveConsole(console: HybrisConsole)
+    fun getActiveConsole(): HybrisConsole?
+
+    fun validateImpex()
+    fun executeStatement()
+
+    companion object {
+        fun getInstance(project: Project): HybrisConsoleService = project.getService(HybrisConsoleService::class.java)
     }
-
 }

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/TimeOption.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/TimeOption.kt
@@ -1,6 +1,5 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
  * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
@@ -16,24 +15,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package com.intellij.idea.plugin.hybris.groovy.actions
 
-import com.intellij.idea.plugin.hybris.actions.AbstractExecuteAction
-import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
-import org.jetbrains.plugins.groovy.GroovyFileType
+package com.intellij.idea.plugin.hybris.tools.remote.console
 
-class GroovyExecuteAction : AbstractExecuteAction(
-    GroovyFileType.GROOVY_FILE_TYPE.defaultExtension,
-    HybrisConstants.CONSOLE_TITLE_GROOVY
-) {
+import java.util.concurrent.TimeUnit
 
-    init {
-        with(templatePresentation) {
-            text = "Execute Groovy Script"
-            description = "Execute Groovy Script on a remote SAP Commerce instance"
-            icon = HybrisIcons.CONSOLE_EXECUTE
-        }
-    }
-
-}
+data class TimeOption(val name: String, val value: Int, val unit: TimeUnit)

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/ExecuteAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/ExecuteAction.kt
@@ -1,38 +1,68 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.intellij.idea.plugin.hybris.tools.remote.console.actions
 
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.icons.AllIcons
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.idea.plugin.hybris.tools.remote.console.actions.handler.HybrisConsoleExecuteActionHandler
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisTabs
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.EmptyAction
 import javax.swing.Icon
 
-abstract class HybrisExecuteActionBase(val executeActionHandler: HybrisConsoleExecuteActionHandler,
-                                       icon: Icon) : AnAction(null, null, icon) {
+abstract class HybrisExecuteActionBase(
+    val executeActionHandler: HybrisConsoleExecuteActionHandler,
+    icon: Icon
+) : AnAction(null, null, icon) {
 
     init {
         EmptyAction.setupAction(this, "Console.Execute.Immediately", null)
     }
 }
 
-class HybrisExecuteImmediatelyAction(private val tabbedPane: HybrisTabs, executeActionHandler: HybrisConsoleExecuteActionHandler) : 
-        HybrisExecuteActionBase(executeActionHandler, AllIcons.Actions.Execute) {
+class HybrisExecuteImmediatelyAction(executeActionHandler: HybrisConsoleExecuteActionHandler) : HybrisExecuteActionBase(executeActionHandler, AllIcons.Actions.Execute) {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
     override fun actionPerformed(e: AnActionEvent) {
-        executeActionHandler.runExecuteAction(tabbedPane)
+        executeActionHandler.runExecuteAction()
     }
+
     override fun update(e: AnActionEvent) {
-        val editor = tabbedPane.activeConsole().consoleEditor
+        val project = e.project ?: return
+
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole()
+            ?: return
+
+        val editor = activeConsole.consoleEditor
         val lookup = LookupManager.getActiveLookup(editor)
         e.presentation.isEnabled = !executeActionHandler.isProcessRunning && (lookup == null || !lookup.isCompletion)
     }
 }
 
-class HybrisSuspendAction(private val tabbedPane: HybrisTabs, executeActionHandler: HybrisConsoleExecuteActionHandler) :
-        HybrisExecuteActionBase(executeActionHandler, AllIcons.Actions.Suspend) {
+class HybrisSuspendAction(executeActionHandler: HybrisConsoleExecuteActionHandler) : HybrisExecuteActionBase(executeActionHandler, AllIcons.Actions.Suspend) {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
     override fun actionPerformed(e: AnActionEvent) {
-        
     }
 
     override fun update(e: AnActionEvent) {

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisClearAllAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisClearAllAction.kt
@@ -1,10 +1,11 @@
 /*
- * This file is part of "hybris integration" plugin for Intellij IDEA.
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
  * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
- * published by the Free Software Foundation, either version 3 of the 
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
@@ -20,18 +21,26 @@ package com.intellij.idea.plugin.hybris.tools.remote.console.actions
 
 import com.intellij.execution.ExecutionBundle
 import com.intellij.icons.AllIcons
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisTabs
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.project.DumbAwareAction
 
-class HybrisClearAllAction(val hybrisTabs: HybrisTabs) :
-        DumbAwareAction(ExecutionBundle.message("clear.all.from.console.action.name"),
-                "Clear the contents of the console", AllIcons.Actions.GC) {
+class HybrisClearAllAction : DumbAwareAction(
+    ExecutionBundle.message("clear.all.from.console.action.name"),
+    "Clear the contents of the console",
+    AllIcons.Actions.GC
+) {
+
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
-        var enabled = hybrisTabs.activeConsole().contentSize > 0
+        val project = e.project ?: return
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
+
+        var enabled = activeConsole.contentSize > 0
         if (!enabled) {
             enabled = e.getData(LangDataKeys.CONSOLE_VIEW) != null
             val editor = e.getData(CommonDataKeys.EDITOR)
@@ -43,6 +52,9 @@ class HybrisClearAllAction(val hybrisTabs: HybrisTabs) :
     }
 
     override fun actionPerformed(e: AnActionEvent) {
-        hybrisTabs.activeConsole().clear()
+        val project = e.project ?: return
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
+
+        activeConsole.clear()
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisClearAllAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisClearAllAction.kt
@@ -53,8 +53,7 @@ class HybrisClearAllAction : DumbAwareAction(
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
-
-        activeConsole.clear()
+        HybrisConsoleService.getInstance(project).getActiveConsole()
+            ?.clear()
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisImpexValidateAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisImpexValidateAction.kt
@@ -19,35 +19,40 @@
 package com.intellij.idea.plugin.hybris.tools.remote.console.actions
 
 import com.intellij.codeInsight.lookup.LookupManager
-import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils
+import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.idea.plugin.hybris.tools.remote.console.actions.handler.HybrisConsoleExecuteValidateActionHandler
 import com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisImpexConsole
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisTabs
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 
 class HybrisImpexValidateAction(
-    private val tabbedPane: HybrisTabs,
     private val executeValidationActionHandler: HybrisConsoleExecuteValidateActionHandler
 ) : AnAction(
-    HybrisI18NBundleUtils.message("action.console.hybris.impex.validate.message.text"),
-    HybrisI18NBundleUtils.message("action.console.hybris.impex.validate.message.title"),
+    message("action.console.hybris.impex.validate.message.text"),
+    message("action.console.hybris.impex.validate.message.title"),
     HybrisIcons.IMX_VALIDATE
 ) {
 
+    override fun getActionUpdateThread() = ActionUpdateThread.BGT
+
     override fun actionPerformed(e: AnActionEvent) {
-        executeValidationActionHandler.runExecuteAction(tabbedPane)
+        executeValidationActionHandler.runExecuteAction()
     }
 
     override fun update(e: AnActionEvent) {
-        val editor = tabbedPane.activeConsole().consoleEditor
+        val project = e.project ?: return
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
+
+        val editor = activeConsole.consoleEditor
         val lookup = LookupManager.getActiveLookup(editor)
 
         e.presentation.isEnabled = !executeValidationActionHandler.isProcessRunning &&
-            (lookup == null || !lookup.isCompletion) && tabbedPane.activeConsole() is HybrisImpexConsole
+            (lookup == null || !lookup.isCompletion) && activeConsole is HybrisImpexConsole
 
-        e.presentation.isVisible = tabbedPane.activeConsole() is HybrisImpexConsole
+        e.presentation.isVisible = activeConsole is HybrisImpexConsole
     }
 
 }

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/handler/HybrisConsoleExecuteActionHandler.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/handler/HybrisConsoleExecuteActionHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.intellij.idea.plugin.hybris.tools.remote.console.actions.handler
 
 
@@ -6,9 +24,9 @@ import com.intellij.execution.impl.ConsoleViewUtil
 import com.intellij.execution.ui.ConsoleViewContentType.*
 import com.intellij.idea.plugin.hybris.impex.file.ImpexFileType
 import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsole
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisImpexMonitorConsole
 import com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisSolrSearchConsole
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisTabs
 import com.intellij.idea.plugin.hybris.tools.remote.http.impex.HybrisHttpResult
 import com.intellij.idea.plugin.hybris.tools.remote.http.impex.HybrisHttpResult.HybrisHttpResultBuilder.createResult
 import com.intellij.json.JsonFileType
@@ -90,14 +108,11 @@ class HybrisConsoleExecuteActionHandler(private val project: Project,
         ConsoleViewUtil.printAsFileType(console, output, fileType)
     }
 
-    fun runExecuteAction(tabbedPane: HybrisTabs) {
+    fun runExecuteAction() {
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
 
-        val console = tabbedPane.activeConsole()
-        val consoleHistoryModel = ConsoleHistoryController.getController(console)
-
-        if (consoleHistoryModel != null) {
-            execute(console, consoleHistoryModel)
-        }
+        ConsoleHistoryController.getController(activeConsole)
+            ?.let { execute(activeConsole, it) }
     }
 
     private fun execute(console: HybrisConsole,

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/handler/HybrisConsoleExecuteValidateActionHandler.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/handler/HybrisConsoleExecuteValidateActionHandler.kt
@@ -1,3 +1,21 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.intellij.idea.plugin.hybris.tools.remote.console.actions.handler
 
 
@@ -6,9 +24,9 @@ import com.intellij.execution.impl.ConsoleViewUtil
 import com.intellij.execution.ui.ConsoleViewContentType.*
 import com.intellij.idea.plugin.hybris.impex.file.ImpexFileType
 import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsole
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
 import com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisImpexConsole
 import com.intellij.idea.plugin.hybris.tools.remote.console.impl.HybrisImpexMonitorConsole
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisTabs
 import com.intellij.idea.plugin.hybris.tools.remote.http.impex.HybrisHttpResult
 import com.intellij.idea.plugin.hybris.tools.remote.http.impex.HybrisHttpResult.HybrisHttpResultBuilder.createResult
 import com.intellij.openapi.application.ApplicationManager
@@ -19,8 +37,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtil
 
-class HybrisConsoleExecuteValidateActionHandler(private val project: Project,
-                                                private val preserveMarkup: Boolean) {
+class HybrisConsoleExecuteValidateActionHandler(
+    private val project: Project,
+    private val preserveMarkup: Boolean
+) {
 
     private fun setEditorEnabled(console: HybrisConsole, enabled: Boolean) {
         console.consoleEditor.isRendererMode = !enabled
@@ -73,10 +93,10 @@ class HybrisConsoleExecuteValidateActionHandler(private val project: Project,
 
     private fun printSyntaxText(console: HybrisConsole, httpResult: HybrisHttpResult?) {
         val result = createResult().errorMessage(httpResult?.errorMessage)
-                .output(httpResult?.output)
-                .result(httpResult?.result)
-                .detailMessage(httpResult?.detailMessage)
-                .build()
+            .output(httpResult?.output)
+            .result(httpResult?.result)
+            .detailMessage(httpResult?.detailMessage)
+            .build()
         val output = result.output
 
         console.clear()
@@ -84,18 +104,17 @@ class HybrisConsoleExecuteValidateActionHandler(private val project: Project,
 
     }
 
-    fun runExecuteAction(tabbedPane: HybrisTabs) {
+    fun runExecuteAction() {
+        val activeConsole = HybrisConsoleService.getInstance(project).getActiveConsole() ?: return
 
-        val console = tabbedPane.activeConsole()
-        val consoleHistoryModel = ConsoleHistoryController.getController(console)
-
-        if (consoleHistoryModel != null) {
-            execute(console, consoleHistoryModel)
-        }
+        ConsoleHistoryController.getController(activeConsole)
+            ?.let { execute(activeConsole, it) }
     }
 
-    private fun execute(console: HybrisConsole,
-                        consoleHistoryController: ConsoleHistoryController) {
+    private fun execute(
+        console: HybrisConsole,
+        consoleHistoryController: ConsoleHistoryController
+    ) {
 
         // Process input and add to history
         val document = console.currentEditor.document

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/impl/HybrisConsoleServiceImpl.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/impl/HybrisConsoleServiceImpl.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.tools.remote.console.impl
+
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsole
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsoleService
+import com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowService
+import com.intellij.openapi.project.Project
+
+class HybrisConsoleServiceImpl(private val project: Project) : HybrisConsoleService {
+
+    override fun findConsole(consoleTitle: String) = HybrisToolWindowService.getInstance(project).finConsolesView()
+        ?.findConsole(consoleTitle)
+
+    override fun setActiveConsole(console: HybrisConsole) {
+        HybrisToolWindowService.getInstance(project).finConsolesView()
+            ?.setActiveConsole(console)
+    }
+
+    override fun getActiveConsole() = HybrisToolWindowService.getInstance(project).finConsolesView()
+        ?.getActiveConsole()
+
+    override fun validateImpex() {
+        HybrisToolWindowService.getInstance(project).finConsolesView()
+            ?.validateImpex()
+    }
+
+    override fun executeStatement() {
+        HybrisToolWindowService.getInstance(project).finConsolesView()
+            ?.execute()
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/view/HybrisConsoleTabs.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/view/HybrisConsoleTabs.kt
@@ -1,0 +1,55 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.tools.remote.console.view
+
+import com.intellij.idea.plugin.hybris.tools.remote.console.HybrisConsole
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.JBTabsPaneImpl
+import com.intellij.ui.tabs.impl.JBEditorTabs
+import com.intellij.util.asSafely
+import javax.swing.Icon
+
+class HybrisConsoleTabs(project: Project, tabPlacement: Int, defaultConsoles: Array<HybrisConsole>, disposable: Disposable) : JBTabsPaneImpl(project, tabPlacement, disposable) {
+
+    private val consoles = arrayListOf<HybrisConsole>()
+
+    init {
+        defaultConsoles.forEach {
+            addConsoleTab(it.title(), it.icon(), it, it.tip())
+        }
+
+        addChangeListener {
+            it.source.asSafely<JBEditorTabs>()
+                ?.selectedInfo
+                ?.component.asSafely<HybrisConsole>()
+                ?.onSelection()
+        }
+    }
+
+    private fun addConsoleTab(title: String, icon: Icon?, console: HybrisConsole, tip: String) {
+        insertTab(title, icon, console.component, tip, consoles.size)
+        consoles.add(console)
+    }
+
+    fun activeConsole() = consoles[selectedIndex]
+    fun setActiveConsole(console: HybrisConsole) {
+        selectedIndex = consoles.indexOf(console);
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/HybrisToolWindowFactory.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/HybrisToolWindowFactory.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -20,7 +20,7 @@ package com.intellij.idea.plugin.hybris.toolwindow
 import com.intellij.icons.AllIcons
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
 import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesPanel
+import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesView
 import com.intellij.idea.plugin.hybris.toolwindow.system.bean.view.BSView
 import com.intellij.idea.plugin.hybris.toolwindow.system.type.view.TSView
 import com.intellij.openapi.project.DumbAware
@@ -36,9 +36,9 @@ class HybrisToolWindowFactory : ToolWindowFactory, DumbAware {
         project: Project, toolWindow: ToolWindow
     ) {
         arrayOf(
-            createTSContent(toolWindow, HybrisToolWindowService.getInstance(project).tsViewPanel),
-            createBSContent(toolWindow, HybrisToolWindowService.getInstance(project).bsViewPanel),
-            createConsolesContent(toolWindow, project, HybrisToolWindowService.getInstance(project).consolesPanel),
+            createTSContent(toolWindow, TSView(project)),
+            createBSContent(toolWindow, BSView(project)),
+            createConsolesContent(toolWindow, project, HybrisConsolesView(project)),
         ).forEach { toolWindow.contentManager.addContent(it) }
     }
 
@@ -63,7 +63,7 @@ class HybrisToolWindowFactory : ToolWindowFactory, DumbAware {
         this
     }
 
-    private fun createConsolesContent(toolWindow: ToolWindow, project: Project, panel: HybrisConsolesPanel) = with(toolWindow.contentManager.factory.createContent(panel.component, CONSOLES_ID, true)) {
+    private fun createConsolesContent(toolWindow: ToolWindow, project: Project, panel: HybrisConsolesView) = with(toolWindow.contentManager.factory.createContent(panel, CONSOLES_ID, true)) {
         Disposer.register(LineStatusTrackerManager.getInstanceImpl(project), toolWindow.disposable)
         Disposer.register(toolWindow.disposable, panel)
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/HybrisToolWindowService.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/HybrisToolWindowService.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -18,9 +18,7 @@
 
 package com.intellij.idea.plugin.hybris.toolwindow
 
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesPanel
-import com.intellij.idea.plugin.hybris.toolwindow.system.bean.view.BSView
-import com.intellij.idea.plugin.hybris.toolwindow.system.type.view.TSView
+import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesView
 import com.intellij.openapi.project.Project
 
 interface HybrisToolWindowService {
@@ -29,10 +27,7 @@ interface HybrisToolWindowService {
         fun getInstance(project: Project): HybrisToolWindowService = project.getService(HybrisToolWindowService::class.java)
     }
 
-    val consolesPanel: HybrisConsolesPanel
-    val tsViewPanel: TSView
-    val bsViewPanel: BSView
-
     fun activateToolWindow()
     fun activateToolWindowTab(id: String)
+    fun finConsolesView(): HybrisConsolesView?
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/impl/HybrisToolWindowServiceImpl.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/impl/HybrisToolWindowServiceImpl.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -18,20 +18,14 @@
 
 package com.intellij.idea.plugin.hybris.toolwindow.impl
 
-import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesPanel
+import com.intellij.idea.plugin.hybris.tools.remote.console.view.HybrisConsolesView
 import com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowFactory
 import com.intellij.idea.plugin.hybris.toolwindow.HybrisToolWindowService
-import com.intellij.idea.plugin.hybris.toolwindow.system.bean.view.BSView
-import com.intellij.idea.plugin.hybris.toolwindow.system.type.view.TSView
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 
 class HybrisToolWindowServiceImpl(val project: Project) : HybrisToolWindowService {
-
-    override val consolesPanel: HybrisConsolesPanel by lazy { HybrisConsolesPanel(project) }
-    override val tsViewPanel: TSView by lazy { TSView(project) }
-    override val bsViewPanel: BSView by lazy { BSView(project) }
 
     override fun activateToolWindow() {
         hybrisToolWindow()
@@ -53,6 +47,12 @@ class HybrisToolWindowServiceImpl(val project: Project) : HybrisToolWindowServic
                     }
             }
     }
+
+    override fun finConsolesView() = hybrisToolWindow()
+        ?.contentManager
+        ?.findContent(HybrisToolWindowFactory.CONSOLES_ID)
+        ?.component
+        ?.let { it as? HybrisConsolesView }
 
     private fun hybrisToolWindow() = ToolWindowManager.getInstance(project).getToolWindow(HybrisToolWindowFactory.ID)
 


### PR DESCRIPTION
Long-live bug, hopefully fixed.
```
2023-08-22 12:56:19,139 [ 280834] SEVERE - #c.i.u.m.i.MessageBusImpl - Bus is already disposed
java.lang.Throwable: Bus is already disposed
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:370)
	at com.intellij.util.messages.impl.MessageBusConnectionImpl.deliverImmediately(MessageBusConnectionImpl.kt:47)
	at com.intellij.execution.console.ConsoleExecutionEditor.dispose(ConsoleExecutionEditor.java:202)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:129)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:161)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:262)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:250)
	at com.intellij.serviceContainer.ComponentManagerImpl.dispose(ComponentManagerImpl.kt:1214)
	at com.intellij.openapi.project.impl.ProjectImpl.dispose(ProjectImpl.kt:295)
	at com.intellij.openapi.util.ObjectTree.runWithTrace(ObjectTree.java:129)
	at com.intellij.openapi.util.ObjectTree.executeAll(ObjectTree.java:161)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:262)
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:250)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$lambda$15(ProjectManagerImpl.kt:405)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWriteAction(ApplicationImpl.java:992)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject(ProjectManagerImpl.kt:387)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeProject$default(ProjectManagerImpl.kt:317)
	at com.intellij.openapi.project.impl.ProjectManagerImpl.closeAndDisposeAllProjects(ProjectManagerImpl.kt:310)
	at com.intellij.openapi.application.impl.ApplicationImpl.lambda$doExit$5(ApplicationImpl.java:650)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.computeWithSpanIgnoreThrows(trace.kt:73)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.computeWithSpanThrows(TraceUtil.java:18)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:646)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:595)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:584)
	at com.intellij.openapi.application.ex.ApplicationEx.exit(ApplicationEx.java:77)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.initMacApplication$lambda$4$lambda$3(MacOSApplicationProvider.kt:78)
	at com.intellij.ui.mac.MacOSApplicationProvider$Worker.submit$lambda$6(MacOSApplicationProvider.kt:170)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:208)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:190)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.openapi.application.impl.ApplicationImpl$4.run(ApplicationImpl.java:478)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:79)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:121)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:41)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:792)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:739)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:733)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:761)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:685)
	at com.intellij.ide.IdeEventQueue._dispatchEvent$lambda$10(IdeEventQueue.kt:589)
	at com.intellij.openapi.application.impl.ApplicationImpl.runWithoutImplicitRead(ApplicationImpl.java:1485)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:589)
	at com.intellij.ide.IdeEventQueue.access$_dispatchEvent(IdeEventQueue.kt:67)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:369)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1$1.compute(IdeEventQueue.kt:368)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:787)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:368)
	at com.intellij.ide.IdeEventQueue$dispatchEvent$processEventRunnable$1$1.invoke(IdeEventQueue.kt:363)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$1(IdeEventQueue.kt:992)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:992)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$7(IdeEventQueue.kt:363)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:861)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:405)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```