### PR TITLE
Introduced inlay hint to display default value in value lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [2023.2.8]
 
 ### `ImpEx` enhancements
+- Introduced inlay hint to display default value in value lines [#670](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/670)
 - Added colorization for `odd` and `even` value lines [#667](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/667)
 
 ### `items.xml` enhancements

--- a/resources/META-INF/lang/impex-dependencies.xml
+++ b/resources/META-INF/lang/impex-dependencies.xml
@@ -97,6 +97,14 @@
                              implementation="com.intellij.idea.plugin.hybris.startup.ImpexHeaderHighlighterStartupActivity"/>
         <psi.treeChangeListener implementation="com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiTreeChangeListener"/>
 
+        <codeInsight.declarativeInlayProvider language="ImpEx"
+                                              implementationClass="com.intellij.idea.plugin.hybris.impex.codeInsight.hints.ImpExDefaultValueDeclarativeInlayProvider"
+                                              isEnabledByDefault="true"
+                                              group="VALUES_GROUP"
+                                              providerId="hybris.ImpEx.defaultValue"
+                                              bundle="i18n/HybrisBundle"
+                                              nameKey="hybris.editor.impex.inlay_provider.default_value.name"
+                                              descriptionKey="hybris.editor.impex.inlay_provider.default_value.description"/>
 
         <projectService serviceInterface="com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor"
                         serviceImplementation="com.intellij.idea.plugin.hybris.impex.completion.impl.ImpexImplementationClassCompletionContributorImpl"/>
@@ -116,7 +124,6 @@
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.flexibleSearch.injection.impl.FlexibleSearchToImpexInjectorProvider"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.file.ImpExFileToolbarInstaller"/>
     </extensions>
-
 
     <actions>
         <action id="ImpEx.NewImpExFile" class="com.intellij.idea.plugin.hybris.impex.file.actions.ImpexFileCreateAction"

--- a/resources/i18n/HybrisBundle.properties
+++ b/resources/i18n/HybrisBundle.properties
@@ -479,10 +479,13 @@ hybris.copy.file.dialog.fxs=FlexibleSearch Console
 hybris.editor.java.inlay_provider.dynamic_attribute.name=[y] Dynamic attributes
 hybris.editor.java.inlay_provider.dynamic_attribute.description=[y] Show 'dynamic' inlay hint for dynamic attributes getters and setters
 
+hybris.editor.impex.inlay_provider.default_value.name=[y] Default Value
+hybris.editor.impex.inlay_provider.default_value.description=[y] Show inlay hint with default value
+
 hybris.toolwindow.action.view_options.text=View Options
 hybris.toolwindow.action.separator.show=Show
 hybris.toolwindow.action.only_custom.text=Only Custom
-hybris.toolwindow.ts.action.only_custom.description=Will exclude types defined outside of the current project
+hybris.toolwindow.ts.action.only_custom.description=Will exclude types defined outside the current project
 hybris.toolwindow.ts.action.enums.text=Enums
 hybris.toolwindow.ts.action.collections.text=Collections
 hybris.toolwindow.ts.action.atomics.text=Atomics

--- a/resources/inlayProviders/hybris.ImpEx.defaultValue/preview.impex
+++ b/resources/inlayProviders/hybris.ImpEx.defaultValue/preview.impex
@@ -1,0 +1,5 @@
+INSERT Product; code[unique = true]; approvalStatus(code)[default = 'approved']
+              ; 00011              ;/*<# approved #>*/
+              ; 00012              ; unapporved
+              ; 00013              ;/*<# approved #>*/
+              ; 00014              ; check

--- a/src/com/intellij/idea/plugin/hybris/impex/codeInsight/hints/ImpExDefaultValueDeclarativeInlayHintsCollector.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/codeInsight/hints/ImpExDefaultValueDeclarativeInlayHintsCollector.kt
@@ -1,0 +1,43 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.impex.codeInsight.hints
+
+import com.intellij.codeInsight.hints.declarative.InlayTreeSink
+import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
+import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexValueGroup
+import com.intellij.psi.PsiElement
+
+class ImpExDefaultValueDeclarativeInlayHintsCollector : SharedBypassCollector {
+
+    override fun collectFromElement(element: PsiElement, sink: InlayTreeSink) {
+        if (!element.isValid || element.project.isDefault) return
+        if (element !is ImpexValueGroup) return
+        if (element.value != null) return
+
+        val defaultValue = element.computeValue() ?: return
+
+        sink.addPresentation(
+            InlineInlayPosition(element.textRange.startOffset + 1, true),
+            hasBackground = true
+        ) {
+            text(defaultValue)
+        }
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/impex/codeInsight/hints/ImpExDefaultValueDeclarativeInlayProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/codeInsight/hints/ImpExDefaultValueDeclarativeInlayProvider.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.impex.codeInsight.hints
+
+import com.intellij.codeInsight.hints.declarative.InlayHintsProvider
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+
+class ImpExDefaultValueDeclarativeInlayProvider : InlayHintsProvider {
+
+    private val collector by lazy {
+        ImpExDefaultValueDeclarativeInlayHintsCollector()
+    }
+
+    override fun createCollector(file: PsiFile, editor: Editor) = if (HybrisProjectSettingsComponent.getInstance(file.project).isHybrisProject()) collector
+    else null
+}


### PR DESCRIPTION
Unfortunately, current IntelliJ inlay implementation does not work well in combination with code formatting, which may lead to inconsistent table-like visualisation of the ImpEx.
Most probably that's due independent workers responsible for Code Formatting and Inlay processing, which leads to simultaneous processing of the same file and inability to understand dependant worker.
This issue is known, yet without feasible solution.

This inlay hint can be always disabled via IntelliJ settings.

<img width="977" alt="Screenshot 2023-09-02 at 18 17 13" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/51d45c6c-b45c-4651-913d-44d44bddafec">
