### PR TITLE
Added colorization for `(+)`, `(-)` and `(+?)` inline collection merge modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Introduced inlay hint to display default value in value lines [#670](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/670)
 - Added colorization for `odd` and `even` value lines [#667](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/667)
 - Added inline collection merge modes: `(+)`, `(-)`, `(+?)` [#671](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/671)
+- Added colorization for `(+)`, `(-)` and `(+?)` inline collection merge modes [#672](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/672)
 
 ### `items.xml` enhancements
 - Improved folding for `persistence`:`columntype` tags [#662](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/662)

--- a/resources/colorSchemes/ImpExDarcula.xml
+++ b/resources/colorSchemes/ImpExDarcula.xml
@@ -144,4 +144,22 @@
             <option name="BACKGROUND" value="28292C"/>
         </value>
     </option>
+    <option name="IMPEX_COLLECTION_APPEND_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="94ECBD"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="IMPEX_COLLECTION_REMOVE_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="F87773"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="IMPEX_COLLECTION_MERGE_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="82CAD3"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
 </list>

--- a/resources/colorSchemes/ImpExDefault.xml
+++ b/resources/colorSchemes/ImpExDefault.xml
@@ -231,4 +231,22 @@
             <option name="BACKGROUND" value="FAFAFA"/>
         </value>
     </option>
+    <option name="IMPEX_COLLECTION_APPEND_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="2F8D5E"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="IMPEX_COLLECTION_REMOVE_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="960702"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
+    <option name="IMPEX_COLLECTION_MERGE_PREFIX">
+        <value>
+            <option name="FOREGROUND" value="2F858D"/>
+            <option name="FONT_TYPE" value="1"/>
+        </value>
+    </option>
 </list>

--- a/src/com/intellij/idea/plugin/hybris/impex/highlighting/DefaultImpexSyntaxHighlighter.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/highlighting/DefaultImpexSyntaxHighlighter.kt
@@ -87,6 +87,10 @@ class DefaultImpexSyntaxHighlighter : SyntaxHighlighterBase() {
             ImpexTypes.PERMISSION_ALLOWED -> USER_RIGHTS_PERMISSION_ALLOWED_KEYS
             ImpexTypes.PERMISSION_DENIED -> USER_RIGHTS_PERMISSION_DENIED_KEYS
 
+            ImpexTypes.COLLECTION_APPEND_PREFIX -> COLLECTION_APPEND_PREFIX
+            ImpexTypes.COLLECTION_REMOVE_PREFIX -> COLLECTION_REMOVE_PREFIX
+            ImpexTypes.COLLECTION_MERGE_PREFIX -> COLLECTION_MERGE_PREFIX
+
             TokenType.BAD_CHARACTER -> BAD_CHARACTER_KEYS
             else -> EMPTY_KEYS
         }
@@ -96,6 +100,9 @@ class DefaultImpexSyntaxHighlighter : SyntaxHighlighterBase() {
         val instance: DefaultImpexSyntaxHighlighter = ApplicationManager.getApplication().getService(DefaultImpexSyntaxHighlighter::class.java)
 
         val PROPERTY_COMMENT_KEYS: Array<TextAttributesKey> = pack(ImpexHighlighterColors.PROPERTY_COMMENT)
+        val COLLECTION_APPEND_PREFIX: Array<TextAttributesKey> = pack(ImpexHighlighterColors.COLLECTION_APPEND_PREFIX)
+        val COLLECTION_REMOVE_PREFIX: Array<TextAttributesKey> = pack(ImpexHighlighterColors.COLLECTION_REMOVE_PREFIX)
+        val COLLECTION_MERGE_PREFIX: Array<TextAttributesKey> = pack(ImpexHighlighterColors.COLLECTION_MERGE_PREFIX)
         val MACRO_NAME_DECLARATION_KEYS: Array<TextAttributesKey> = pack(ImpexHighlighterColors.MACRO_NAME_DECLARATION)
         val MACRO_VALUE_KEYS: Array<TextAttributesKey> = pack(ImpexHighlighterColors.MACRO_VALUE)
         val MACRO_USAGE_KEYS: Array<TextAttributesKey> = pack(ImpexHighlighterColors.MACRO_USAGE)

--- a/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexColorSettingsPage.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexColorSettingsPage.kt
@@ -54,6 +54,11 @@ ${"$"}macro = qwe;qwe, qwe, ;qwe
 
 #% impex.setLocale( Locale.GERMAN );
 
+UPDATE Language ; isoCode[unique=true]; fallbackLanguages(isoCode)
+; en ; (+) de
+; en ; (+?) zh
+; en ; (-) fr
+
 INSERT SomeType; param; param2; param3
 <vlo>; value; value; another value</vlo>
 <vle>; value; value; another value</vle>
@@ -125,6 +130,10 @@ INSERT_UPDATE Media; @media[translator = de.hybris.platform.impex.jalo.media.Med
 
         AttributesDescriptor("Brackets//Square brackets", ImpexHighlighterColors.SQUARE_BRACKETS),
         AttributesDescriptor("Brackets//Round brackets", ImpexHighlighterColors.ROUND_BRACKETS),
+
+        AttributesDescriptor("Collection prefix//Append", ImpexHighlighterColors.COLLECTION_APPEND_PREFIX),
+        AttributesDescriptor("Collection prefix//Remove", ImpexHighlighterColors.COLLECTION_REMOVE_PREFIX),
+        AttributesDescriptor("Collection prefix//Merge", ImpexHighlighterColors.COLLECTION_MERGE_PREFIX),
 
         AttributesDescriptor("Attribute//Name", ImpexHighlighterColors.ATTRIBUTE_NAME),
         AttributesDescriptor("Attribute//Value", ImpexHighlighterColors.ATTRIBUTE_VALUE),

--- a/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexHighlighterColors.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/highlighting/ImpexHighlighterColors.kt
@@ -75,6 +75,9 @@ object ImpexHighlighterColors {
     val USER_RIGHTS_PERMISSION_INHERITED = key("IMPEX_USER_RIGHTS_PERMISSION_INHERITED", HighlighterColors.TEXT)
     val VALUE_LINE_ODD = key("IMPEX_VALUE_LINE_ODD", HighlighterColors.NO_HIGHLIGHTING)
     val VALUE_LINE_EVEN = key("IMPEX_VALUE_LINE_EVEN", HighlighterColors.NO_HIGHLIGHTING)
+    val COLLECTION_APPEND_PREFIX = key("IMPEX_COLLECTION_APPEND_PREFIX", HighlighterColors.TEXT)
+    val COLLECTION_REMOVE_PREFIX = key("IMPEX_COLLECTION_REMOVE_PREFIX", HighlighterColors.TEXT)
+    val COLLECTION_MERGE_PREFIX = key("IMPEX_COLLECTION_MERGE_PREFIX", HighlighterColors.TEXT)
 
     private fun key(externalName: String, fallbackAttributeKey: TextAttributesKey) = TextAttributesKey.createTextAttributesKey(externalName, fallbackAttributeKey)
 }


### PR DESCRIPTION
**Light**
<img width="540" alt="Screenshot 2023-09-03 at 15 30 18" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/ace451ad-4aaf-4133-8e4a-b7aafc51c4e8">

**Dark**
<img width="533" alt="Screenshot 2023-09-03 at 15 31 16" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/124d680d-e5fa-410b-8af4-576ae91bb118">
