### PR TITLE
Automatically add `=` after type and attribute modifier and trigger code completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added inline collection merge modes: `(+)`, `(-)`, `(+?)` [#671](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/671)
 - Added colorization for `(+)`, `(-)` and `(+?)` inline collection merge modes [#672](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/672)
 - Added support of the `<null>` special value [#673](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/673)
+- Automatically add `=` after type and attribute modifier and trigger code completion [#674](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/674)
 
 ### `items.xml` enhancements
 - Improved folding for `persistence`:`columntype` tags [#662](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/662)

--- a/gen/com/intellij/idea/plugin/hybris/impex/ImpexParser.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/ImpexParser.java
@@ -1521,24 +1521,8 @@ public class ImpexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // ((  FIELD_VALUE
-  //              | FIELD_VALUE_URL
-  //              | BOOLEAN
-  //              | DIGIT
-  //              | string
-  //              | macro_usage_dec
-  //              | FIELD_LIST_ITEM_SEPARATOR
-  //              | DEFAULT_PATH_DELIMITER
-  //              | DEFAULT_KEY_VALUE_DELIMITER
-  //              | ALTERNATIVE_MAP_DELIMITER
-  //              | COLLECTION_APPEND_PREFIX
-  //              | COLLECTION_REMOVE_PREFIX
-  //              | COLLECTION_MERGE_PREFIX
-  //             )+
-  //            )
-  //             | (  FIELD_VALUE_IGNORE
-  //                | FIELD_VALUE_NULL
-  //            )
+  // value_dec+
+  //     | (FIELD_VALUE_IGNORE | FIELD_VALUE_NULL)
   public static boolean value(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "value")) return false;
     boolean r;
@@ -1549,49 +1533,46 @@ public class ImpexParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // (  FIELD_VALUE
-  //              | FIELD_VALUE_URL
-  //              | BOOLEAN
-  //              | DIGIT
-  //              | string
-  //              | macro_usage_dec
-  //              | FIELD_LIST_ITEM_SEPARATOR
-  //              | DEFAULT_PATH_DELIMITER
-  //              | DEFAULT_KEY_VALUE_DELIMITER
-  //              | ALTERNATIVE_MAP_DELIMITER
-  //              | COLLECTION_APPEND_PREFIX
-  //              | COLLECTION_REMOVE_PREFIX
-  //              | COLLECTION_MERGE_PREFIX
-  //             )+
+  // value_dec+
   private static boolean value_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "value_0")) return false;
     boolean r;
     Marker m = enter_section_(b);
-    r = value_0_0(b, l + 1);
+    r = value_dec(b, l + 1);
     while (r) {
       int c = current_position_(b);
-      if (!value_0_0(b, l + 1)) break;
+      if (!value_dec(b, l + 1)) break;
       if (!empty_element_parsed_guard_(b, "value_0", c)) break;
     }
     exit_section_(b, m, null, r);
     return r;
   }
 
+  // FIELD_VALUE_IGNORE | FIELD_VALUE_NULL
+  private static boolean value_1(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "value_1")) return false;
+    boolean r;
+    r = consumeToken(b, FIELD_VALUE_IGNORE);
+    if (!r) r = consumeToken(b, FIELD_VALUE_NULL);
+    return r;
+  }
+
+  /* ********************************************************** */
   // FIELD_VALUE
-  //              | FIELD_VALUE_URL
-  //              | BOOLEAN
-  //              | DIGIT
-  //              | string
-  //              | macro_usage_dec
-  //              | FIELD_LIST_ITEM_SEPARATOR
-  //              | DEFAULT_PATH_DELIMITER
-  //              | DEFAULT_KEY_VALUE_DELIMITER
-  //              | ALTERNATIVE_MAP_DELIMITER
-  //              | COLLECTION_APPEND_PREFIX
-  //              | COLLECTION_REMOVE_PREFIX
-  //              | COLLECTION_MERGE_PREFIX
-  private static boolean value_0_0(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "value_0_0")) return false;
+  //     | FIELD_VALUE_URL
+  //     | BOOLEAN
+  //     | DIGIT
+  //     | string
+  //     | macro_usage_dec
+  //     | FIELD_LIST_ITEM_SEPARATOR
+  //     | DEFAULT_PATH_DELIMITER
+  //     | DEFAULT_KEY_VALUE_DELIMITER
+  //     | ALTERNATIVE_MAP_DELIMITER
+  //     | COLLECTION_APPEND_PREFIX
+  //     | COLLECTION_REMOVE_PREFIX
+  //     | COLLECTION_MERGE_PREFIX
+  static boolean value_dec(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "value_dec")) return false;
     boolean r;
     r = consumeToken(b, FIELD_VALUE);
     if (!r) r = consumeToken(b, FIELD_VALUE_URL);
@@ -1606,16 +1587,6 @@ public class ImpexParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, COLLECTION_APPEND_PREFIX);
     if (!r) r = consumeToken(b, COLLECTION_REMOVE_PREFIX);
     if (!r) r = consumeToken(b, COLLECTION_MERGE_PREFIX);
-    return r;
-  }
-
-  // FIELD_VALUE_IGNORE
-  //                | FIELD_VALUE_NULL
-  private static boolean value_1(PsiBuilder b, int l) {
-    if (!recursion_guard_(b, l, "value_1")) return false;
-    boolean r;
-    r = consumeToken(b, FIELD_VALUE_IGNORE);
-    if (!r) r = consumeToken(b, FIELD_VALUE_NULL);
     return r;
   }
 

--- a/resources/META-INF/lang/impex-dependencies.xml
+++ b/resources/META-INF/lang/impex-dependencies.xml
@@ -106,9 +106,6 @@
                                               nameKey="hybris.editor.impex.inlay_provider.default_value.name"
                                               descriptionKey="hybris.editor.impex.inlay_provider.default_value.description"/>
 
-        <projectService serviceInterface="com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor"
-                        serviceImplementation="com.intellij.idea.plugin.hybris.impex.completion.impl.ImpexImplementationClassCompletionContributorImpl"/>
-
         <applicationService serviceInterface="com.intellij.idea.plugin.hybris.impex.assistance.ImpexHeaderNameHighlighterService"
                             serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.DefaultImpexHeaderNameHighlighterService"/>
         <applicationService serviceInterface="com.intellij.idea.plugin.hybris.impex.assistance.ImpexColumnHighlighterService"

--- a/resources/META-INF/optional-java-dependencies.xml
+++ b/resources/META-INF/optional-java-dependencies.xml
@@ -70,6 +70,9 @@
         <applicationService serviceInterface="com.intellij.idea.plugin.hybris.project.configurators.JavaCompilerConfigurator"
                             serviceImplementation="com.intellij.idea.plugin.hybris.project.configurators.impl.DefaultJavaCompilerConfigurator"/>
 
+        <projectService serviceInterface="com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor"
+                        serviceImplementation="com.intellij.idea.plugin.hybris.impex.completion.impl.ImpexImplementationClassCompletionContributorImpl"/>
+
         <projectService serviceInterface="com.intellij.idea.plugin.hybris.project.configurators.PostImportConfigurator"
                         serviceImplementation="com.intellij.idea.plugin.hybris.project.configurators.impl.DefaultPostImportConfigurator"/>
 

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -369,8 +369,6 @@ object HybrisConstants {
 
     @JvmField
     val IMPEX_MODIFIER_BOOLEAN_VALUES = setOf("true", "false")
-    @JvmField
-    val IMPEX_MODIFIER_MODE_VALUES = setOf("append", "remove")
 
     @JvmField
     val DEFAULT_DIRECTORY_NAME_FOR_IDEA_MODULE_FILES = FileUtilRt.toSystemDependentName("/.idea/idea-modules")

--- a/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.java
+++ b/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.java
@@ -180,7 +180,8 @@ public final class HybrisIcons {
     public static final Icon FXS_TABLE_SUFFIX = AllIcons.General.Filter;
     public static final Icon FXS_TABLE_ALIAS_SEPARATOR = getIcon("/icons/flexibleSearch/separator.svg");
 
-    public static final Icon IMX_VALIDATE = getIcon("/icons/impex/validate.svg");
+    public static final Icon IMPEX_VALIDATE = getIcon("/icons/impex/validate.svg");
+    public static final Icon IMPEX_MODE = AllIcons.Nodes.Function;
 
     public static final Icon GUTTER_POPULATOR = getIcon("/icons/gutter/populator.svg");
 

--- a/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
+++ b/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
@@ -226,25 +226,22 @@ value_group ::= FIELD_VALUE_SEPARATOR value?
     methods=[getFullHeaderParameter getColumnNumber getValueLine computeValue]
 }
 
-value ::= (((  FIELD_VALUE
-             | FIELD_VALUE_URL
-             | BOOLEAN
-             | DIGIT
-             | string
-             | macro_usage_dec
-             | FIELD_LIST_ITEM_SEPARATOR
-             | DEFAULT_PATH_DELIMITER
-             | DEFAULT_KEY_VALUE_DELIMITER
-             | ALTERNATIVE_MAP_DELIMITER
-             | COLLECTION_APPEND_PREFIX
-             | COLLECTION_REMOVE_PREFIX
-             | COLLECTION_MERGE_PREFIX
-            )+
-           )
-            | (  FIELD_VALUE_IGNORE
-               | FIELD_VALUE_NULL
-           )
-         )
+value ::= value_dec+
+    | (FIELD_VALUE_IGNORE | FIELD_VALUE_NULL)
+
+private value_dec ::= FIELD_VALUE
+    | FIELD_VALUE_URL
+    | BOOLEAN
+    | DIGIT
+    | string
+    | macro_usage_dec
+    | FIELD_LIST_ITEM_SEPARATOR
+    | DEFAULT_PATH_DELIMITER
+    | DEFAULT_KEY_VALUE_DELIMITER
+    | ALTERNATIVE_MAP_DELIMITER
+    | COLLECTION_APPEND_PREFIX
+    | COLLECTION_REMOVE_PREFIX
+    | COLLECTION_MERGE_PREFIX
 
 macro_usage_dec::=MACRO_USAGE
 {

--- a/src/com/intellij/idea/plugin/hybris/impex/Impex.flex
+++ b/src/com/intellij/idea/plugin/hybris/impex/Impex.flex
@@ -77,7 +77,7 @@ dot           = [.]
 assign_value  = [=]
 //question_mark = [\?]
 
-// See - CollectionValueTranslator
+// see - CollectionValueTranslator
 // value must start with this prefix
 collection_append_prefix = "(+)"
 collection_remove_prefix = "(-)"
@@ -87,7 +87,9 @@ default_path_delimiter      = [:]
 default_key_value_delimiter = "->"
 alternative_map_delimiter   = [|]
 
-boolean = (("true")|("false"))
+// see - AtomicValueTranslator
+boolean = ("true"|"false")
+
 digit   = [-+]?[0-9]+([.][0-9]+)?
 //class_with_package = ({identifier}+[.]{identifier}+)+
 

--- a/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExValidateAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/actions/ImpExValidateAction.kt
@@ -33,7 +33,7 @@ class ImpExValidateAction : AbstractExecuteAction(
         with(templatePresentation) {
             text = "Validate ImpEx"
             description = "Validate ImpEx file via remote SAP Commerce instance"
-            icon = HybrisIcons.IMX_VALIDATE
+            icon = HybrisIcons.IMPEX_VALIDATE
         }
     }
 

--- a/src/com/intellij/idea/plugin/hybris/impex/codeInsight/lookup/ImpExLookupElementFactory.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/codeInsight/lookup/ImpExLookupElementFactory.kt
@@ -1,0 +1,80 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.intellij.idea.plugin.hybris.impex.codeInsight.lookup
+
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.idea.plugin.hybris.codeInsight.completion.AutoPopupInsertHandler
+import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier
+import com.intellij.idea.plugin.hybris.impex.constants.modifier.TypeModifier
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexAttribute
+import com.intellij.idea.plugin.hybris.impex.psi.ImpexTypes
+import com.intellij.idea.plugin.hybris.impex.settings.ImpexCompletionSettings
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
+
+object ImpExLookupElementFactory {
+
+    fun build(element: PsiElement, modifier: TypeModifier, completionSettings: ImpexCompletionSettings) = build(element, modifier.modifierName, completionSettings)
+
+    fun build(element: PsiElement, modifier: AttributeModifier, completionSettings: ImpexCompletionSettings) = build(element, modifier.modifierName, completionSettings)
+
+    fun buildJavaClass(qualifiedName: String, presentableText: String) = LookupElementBuilder.create(qualifiedName)
+        .withPresentableText(presentableText)
+        .withIcon(AllIcons.FileTypes.JavaClass)
+
+    fun buildModifierValue(lookupElement: String) = LookupElementBuilder.create(lookupElement)
+    fun buildModifierValue(lookupElement: String, typeText: String) = LookupElementBuilder.create(lookupElement)
+        .withTypeText(typeText, true)
+
+    fun buildUserRights() = LookupElementBuilder.create(
+        """
+            ${'$'}START_USERRIGHTS
+            Type;UID;MemberOfGroups;Password;Target;read;change;create;remove;change_perm
+                ;   ;              ;        ;      ;    ;      ;      ;      ;
+            ${'$'}END_USERRIGHTS
+        """.trimIndent()
+    )
+        .withPresentableText("\$START_USERRIGHTS")
+        .withIcon(HybrisIcons.MACROS)
+
+    fun buildMacro(lookupElement: String) = LookupElementBuilder.create(lookupElement)
+        .withIcon(HybrisIcons.MACROS)
+
+    fun buildMode(mode: String) = LookupElementBuilder.create("$mode ")
+        .withPresentableText(mode)
+        .withIcon(HybrisIcons.IMPEX_MODE)
+
+    private fun build(element: PsiElement, modifierName: String, completionSettings: ImpexCompletionSettings) =
+        if (completionSettings.addEqualsAfterModifier && !hasAssignValueLeaf(element))
+            LookupElementBuilder.create("$modifierName=")
+                .withPresentableText(modifierName)
+                .withInsertHandler(AutoPopupInsertHandler.INSTANCE)
+        else LookupElementBuilder.create(modifierName)
+            .withPresentableText(modifierName)
+
+    private fun hasAssignValueLeaf(element: PsiElement) = element.parentOfType<ImpexAttribute>()
+        ?.childrenOfType<LeafPsiElement>()
+        ?.any { it.elementType == ImpexTypes.ASSIGN_VALUE }
+        ?: false
+
+}

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/ImpexImplementationClassCompletionContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/ImpexImplementationClassCompletionContributor.kt
@@ -25,7 +25,7 @@ interface ImpexImplementationClassCompletionContributor {
     fun getImplementationsForClass(qualifiedName: String): Set<LookupElement>
 
     companion object {
-        fun getInstance(project: Project): ImpexImplementationClassCompletionContributor =
+        fun getInstance(project: Project): ImpexImplementationClassCompletionContributor? =
             project.getService(ImpexImplementationClassCompletionContributor::class.java)
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/impl/ImpexImplementationClassCompletionContributorImpl.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/impl/ImpexImplementationClassCompletionContributorImpl.kt
@@ -18,8 +18,7 @@
 package com.intellij.idea.plugin.hybris.impex.completion.impl
 
 import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.icons.AllIcons
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
@@ -36,11 +35,10 @@ class ImpexImplementationClassCompletionContributorImpl(val myProject: Project) 
         return ClassInheritorsSearch
             .search(clazz, GlobalSearchScope.allScope(myProject), true)
             .findAll()
-            .filter { it.qualifiedName != null && it.name != null }
-            .map {
-                LookupElementBuilder.create(it.qualifiedName!!)
-                    .withPresentableText(it.name!!)
-                    .withIcon(AllIcons.FileTypes.JavaClass)
+            .mapNotNull {
+                val fqn = it.qualifiedName ?: return@mapNotNull null
+                val name = it.name ?: return@mapNotNull null
+                ImpExLookupElementFactory.buildJavaClass(fqn, name)
             }
             .toSet()
     }

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexHeaderAttributeModifierNameCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexHeaderAttributeModifierNameCompletionProvider.kt
@@ -21,8 +21,9 @@ package com.intellij.idea.plugin.hybris.impex.completion.provider
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.constants.modifier.AttributeModifier
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.ProcessingContext
 
@@ -33,10 +34,13 @@ class ImpexHeaderAttributeModifierNameCompletionProvider : CompletionProvider<Co
         context: ProcessingContext,
         result: CompletionResultSet
     ) {
+        val element = parameters.position
+        val completionSettings = HybrisProjectSettingsComponent.getInstance(element.project).state
+            .impexSettings
+            .completion
         AttributeModifier.entries
-            .map { it.modifierName }
-            .map { LookupElementBuilder.create(it) }
-            .forEach { result.addElement(it) }
+            .map { ImpExLookupElementFactory.build(element, it, completionSettings) }
+            .let { result.addAllElements(it) }
     }
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexHeaderTypeModifierNameCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexHeaderTypeModifierNameCompletionProvider.kt
@@ -21,8 +21,9 @@ package com.intellij.idea.plugin.hybris.impex.completion.provider
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.constants.modifier.TypeModifier
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.ProcessingContext
 
@@ -33,10 +34,13 @@ class ImpexHeaderTypeModifierNameCompletionProvider : CompletionProvider<Complet
         context: ProcessingContext,
         result: CompletionResultSet
     ) {
+        val element = parameters.position
+        val completionSettings = HybrisProjectSettingsComponent.getInstance(element.project).state
+            .impexSettings
+            .completion
         TypeModifier.entries
-            .map { it.modifierName }
-            .map { LookupElementBuilder.create(it) }
-            .forEach { result.addElement(it) }
+            .map { ImpExLookupElementFactory.build(element, it, completionSettings) }
+            .let { result.addAllElements(it) }
     }
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexKeywordMacroCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexKeywordMacroCompletionProvider.kt
@@ -21,31 +21,17 @@ package com.intellij.idea.plugin.hybris.impex.completion.provider
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.ProcessingContext
 
 class ImpexKeywordMacroCompletionProvider : CompletionProvider<CompletionParameters>() {
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
-        val userRightsStart = "\$START_USERRIGHTS"
-        val userRightsEnd = "\$END_USERRIGHTS"
-        result.addElement(LookupElementBuilder.create(
-            """
-            $userRightsStart
-            Type;UID;MemberOfGroups;Password;Target;read;change;create;remove;change_perm
-                ;   ;              ;        ;      ;    ;      ;      ;      ;
-            $userRightsEnd
-        """.trimIndent()
-        )
-            .withPresentableText("\$START_USERRIGHTS")
-            .withIcon(HybrisIcons.MACROS)
-        )
+        result.addElement(ImpExLookupElementFactory.buildUserRights())
     }
 
     companion object {
-        val instance: CompletionProvider<CompletionParameters> =
-            ApplicationManager.getApplication().getService(ImpexKeywordMacroCompletionProvider::class.java)
+        val instance: CompletionProvider<CompletionParameters> = ApplicationManager.getApplication().getService(ImpexKeywordMacroCompletionProvider::class.java)
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexKeywordModeCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexKeywordModeCompletionProvider.kt
@@ -21,29 +21,21 @@ package com.intellij.idea.plugin.hybris.impex.completion.provider
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.icons.AllIcons
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.ProcessingContext
 
-private val keywords = mutableListOf(
-    "INSERT ",
-    "UPDATE ",
-    "INSERT_UPDATE ",
-    "REMOVE "
-)
-
 class ImpexKeywordModeCompletionProvider : CompletionProvider<CompletionParameters>() {
 
-    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
-        keywords
-            .map {
-                LookupElementBuilder.create(it)
-                    .withPresentableText(it.trim())
-                    .withIcon(AllIcons.Nodes.Function)
-            }
-            .forEach { result.addElement(it) }
+    private val keywords = listOf(
+        "INSERT",
+        "UPDATE",
+        "INSERT_UPDATE",
+        "REMOVE"
+    )
 
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        result.addAllElements(keywords.map { ImpExLookupElementFactory.buildMode(it) })
     }
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexMacrosCompletionProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/completion/provider/ImpexMacrosCompletionProvider.kt
@@ -20,8 +20,7 @@ package com.intellij.idea.plugin.hybris.impex.completion.provider
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexMacroDeclaration
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.psi.util.PsiTreeUtil
@@ -38,12 +37,8 @@ class ImpexMacrosCompletionProvider : CompletionProvider<CompletionParameters>()
 
         PsiTreeUtil.findChildrenOfType(originalFile, ImpexMacroDeclaration::class.java)
             .map { it.firstChild }
-            .map { it.text }
-            .map {
-                LookupElementBuilder.create(it)
-                    .withIcon(HybrisIcons.MACROS)
-            }
-            .forEach { result.addElement(it) }
+            .map { ImpExLookupElementFactory.buildMacro(it.text) }
+            .let { result.addAllElements(it) }
     }
 
     companion object {

--- a/src/com/intellij/idea/plugin/hybris/impex/constants/modifier/AttributeModifier.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/constants/modifier/AttributeModifier.kt
@@ -19,8 +19,8 @@
 package com.intellij.idea.plugin.hybris.impex.constants.modifier
 
 import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor
 import com.intellij.openapi.project.Project
 
@@ -29,7 +29,7 @@ import com.intellij.openapi.project.Project
  */
 enum class AttributeModifier(
     override val modifierName: String,
-    modifierValues: Set<String> = emptySet()
+    private val modifierValues: Set<String> = emptySet()
 ) : ImpexModifier {
 
     UNIQUE("unique", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
@@ -38,7 +38,15 @@ enum class AttributeModifier(
     IGNORE_KEY_CASE("ignoreKeyCase", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
     IGNORE_NULL("ignorenull", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
     VIRTUAL("virtual", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
-    MODE("mode", HybrisConstants.IMPEX_MODIFIER_MODE_VALUES),
+    MODE("mode") {
+        override fun getLookupElements(project: Project) = mapOf(
+            "append" to "(+)",
+            "remove" to "(-)",
+            "merge" to "(+?)"
+        )
+            .map { ImpExLookupElementFactory.buildModifierValue(it.key, it.value) }
+            .toSet()
+    },
     ALIAS("alias"),
     COLLECTION_DELIMITER("collection-delimiter"),
     DATE_FORMAT("dateformat"),
@@ -51,18 +59,18 @@ enum class AttributeModifier(
     POS("pos"),
     CELL_DECORATOR("cellDecorator") {
         override fun getLookupElements(project: Project) = ImpexImplementationClassCompletionContributor.getInstance(project)
-            .getImplementationsForClass(HybrisConstants.CLASS_IMPEX_CELL_DECORATOR)
+            ?.getImplementationsForClass(HybrisConstants.CLASS_IMPEX_CELL_DECORATOR)
+            ?: emptySet()
     },
     TRANSLATOR("translator") {
         override fun getLookupElements(project: Project) = ImpexImplementationClassCompletionContributor.getInstance(project)
-            .getImplementationsForClass(HybrisConstants.CLASS_IMPEX_TRANSLATOR)
+            ?.getImplementationsForClass(HybrisConstants.CLASS_IMPEX_TRANSLATOR)
+            ?: emptySet()
     };
 
-    private val lookupElements = modifierValues
-        .map { LookupElementBuilder.create(it) }
+    override fun getLookupElements(project: Project): Set<LookupElement> = modifierValues
+        .map { ImpExLookupElementFactory.buildModifierValue(it) }
         .toSet()
-
-    override fun getLookupElements(project: Project): Set<LookupElement> = lookupElements
 
     companion object {
         private val CACHE = entries.associateBy { it.modifierName }

--- a/src/com/intellij/idea/plugin/hybris/impex/constants/modifier/TypeModifier.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/constants/modifier/TypeModifier.kt
@@ -18,8 +18,8 @@
 package com.intellij.idea.plugin.hybris.impex.constants.modifier
 
 import com.intellij.codeInsight.lookup.LookupElement
-import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.impex.codeInsight.lookup.ImpExLookupElementFactory
 import com.intellij.idea.plugin.hybris.impex.completion.ImpexImplementationClassCompletionContributor
 import com.intellij.openapi.project.Project
 
@@ -30,7 +30,7 @@ import com.intellij.openapi.project.Project
  */
 enum class TypeModifier(
     override val modifierName: String,
-    modifierValues: Set<String> = emptySet()
+    private val modifierValues: Set<String> = emptySet()
 ) : ImpexModifier {
 
     BATCH_MODE("batchmode", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
@@ -39,17 +39,16 @@ enum class TypeModifier(
     IMPEX_LEGACY_MODE("impex.legacy.mode", HybrisConstants.IMPEX_MODIFIER_BOOLEAN_VALUES),
     PROCESSOR("processor") {
         override fun getLookupElements(project: Project) = ImpexImplementationClassCompletionContributor.getInstance(project)
-            .getImplementationsForClass(HybrisConstants.CLASS_IMPEX_PROCESSOR)
+            ?.getImplementationsForClass(HybrisConstants.CLASS_IMPEX_PROCESSOR)
+            ?: emptySet()
     };
 
-    private val lookupElements = modifierValues
-        .map { LookupElementBuilder.create(it) }
+    override fun getLookupElements(project: Project): Set<LookupElement> = modifierValues
+        .map { ImpExLookupElementFactory.buildModifierValue(it) }
         .toSet()
 
-    override fun getLookupElements(project: Project): Set<LookupElement> = lookupElements
-
     companion object {
-        private val CACHE = values().associateBy { it.modifierName }
+        private val CACHE = entries.associateBy { it.modifierName }
 
         fun getByModifierName(modifierName: String) = CACHE[modifierName]
     }

--- a/src/com/intellij/idea/plugin/hybris/impex/lang/documentation/ImpexDocumentationTarget.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/lang/documentation/ImpexDocumentationTarget.kt
@@ -317,9 +317,9 @@ class ImpexDocumentationTarget(val element: PsiElement, private val originalElem
                     )
                     texts("Specifies the modification mode for Collection instances.")
                     list(
-                        "mode=append: In the append mode, references to elements of the Collection value are added to the existing resolved Collection. You can also use (+) instead of mode=append.",
-                        "mode=remove: In the remove mode, references to elements of the Collection value are removed from the resolved Collection. You can also use (-) instead of mode=remove",
-                        "mode=merge: In the merge mode, references to elements of the Collection value are added to the existing resolved Collection only if they already aren't part of the Collection. You can also use (+?) instead of mode=merge",
+                        "mode=append: In the append mode, references to elements of the Collection value are added to the existing resolved Collection.<br>You can also use <strong>(+)</strong instead of mode=append.",
+                        "mode=remove: In the remove mode, references to elements of the Collection value are removed from the resolved Collection.<br>You can also use <strong>(-)</strong? instead of mode=remove",
+                        "mode=merge: In the merge mode, references to elements of the Collection value are added to the existing resolved Collection only if they already aren't part of the Collection.<br>You can also use <strong>(+?)</strong> instead of mode=merge",
                     )
                 }.build()
 

--- a/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettings.kt
@@ -40,4 +40,5 @@ data class ImpexDocumentationSettings(
 class ImpexCompletionSettings : BaseState() {
     var showInlineTypes by property(true)
     var addCommaAfterInlineType by property(true)
+    var addEqualsAfterModifier by property(true)
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/settings/ImpexSettingsConfigurableProvider.kt
@@ -70,10 +70,20 @@ class ImpexSettingsConfigurableProvider(val project: Project) : ConfigurableProv
                     checkBox("Automatically add '.' char after inline type")
                         .comment(
                             """
-                            When enabled and there is '.' char is not present, it will be injected automatically
+                            When enabled and '.' char is not present, it will be injected automatically
                             """.trimIndent()
                         )
                         .bindSelected(state.completion::addCommaAfterInlineType)
+                }
+                row {
+                    checkBox("Automatically add '=' char after type and attribute modifier")
+                        .comment(
+                            """
+                            When enabled and '=' char is not present, it will be injected automatically.<br>
+                            In addition to that, code completion will be automatically triggered for modifier values.
+                            """.trimIndent()
+                        )
+                        .bindSelected(state.completion::addEqualsAfterModifier)
                 }
             }
             group("Documentation") {

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisImpexValidateAction.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/console/actions/HybrisImpexValidateAction.kt
@@ -33,7 +33,7 @@ class HybrisImpexValidateAction(
 ) : AnAction(
     message("action.console.hybris.impex.validate.message.text"),
     message("action.console.hybris.impex.validate.message.title"),
-    HybrisIcons.IMX_VALIDATE
+    HybrisIcons.IMPEX_VALIDATE
 ) {
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/system/type/tree/nodes/TSRootNode.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/system/type/tree/nodes/TSRootNode.kt
@@ -32,7 +32,7 @@ class TSRootNode(tree: TSTree) : TSNode(tree.myProject) {
         presentation.addText(name, SimpleTextAttributes.REGULAR_ATTRIBUTES)
     }
 
-    override fun getNewChildren(): Map<String, TSNode> = TSMetaType.values()
+    override fun getNewChildren(): Map<String, TSNode> = TSMetaType.entries
         .map { TSMetaTypeNode(this, it) }
         .associateBy { it.name }
 


### PR DESCRIPTION

<img width="559" alt="Screenshot 2023-09-03 at 18 56 00" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/0b9db589-7df0-4e26-8349-83fa47823843">
<img width="620" alt="Screenshot 2023-09-03 at 19 15 46" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/045a1da1-6666-4d29-9451-3b22b1765060">
