### PR TITLE
Added code completion for `addons` and `storefronts` in the `manifest.json` schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### `CCv2` enhancements
 - Improved CCv2 SAP Commerce Cloud `manifest.json` schema support [#685](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/685)
+- Added code completion for `addons` and `storefronts` in the `manifest.json` schema [#686](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/686)
 
 ### `ImpEx` enhancements
 - Introduced inlay hint to display default value in value lines [#670](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/670)

--- a/src/com/intellij/idea/plugin/hybris/system/manifest/psi/ManifestPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/manifest/psi/ManifestPatterns.kt
@@ -32,41 +32,49 @@ object ManifestPatterns {
     private inline fun <reified T : PsiElement> PsiElementPattern<*, *>.withParent() = this.withParent(T::class.java)
 
     private fun jsonStringValue() = PlatformPatterns.psiElement(JsonElementTypes.DOUBLE_QUOTED_STRING)
-            .withParent<JsonStringLiteral>()
+        .withParent<JsonStringLiteral>()
 
     val EXTENSION_NAME = StandardPatterns.or(
-            jsonStringValue()
-                    .withSuperParent(2,
-                            StandardPatterns.or(
-                                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("addon"),
-                                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefront"),
-                            )
-                    )
-                    .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefrontAddons")),
+        jsonStringValue()
+            .withSuperParent(
+                2,
+                StandardPatterns.or(
+                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("addon"),
+                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefront"),
+                    PlatformPatterns.psiElement(JsonArray::class.java).withParent(
+                        StandardPatterns.or(
+                            PlatformPatterns.psiElement(JsonProperty::class.java).withName("addons"),
+                            PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefronts"),
+                        )
+                    ),
+                )
+            )
+            .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefrontAddons")),
 
-            jsonStringValue()
-                    .withSuperParent(2, PlatformPatterns.psiElement(JsonArray::class.java))
-                    .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("extensions")),
+        jsonStringValue()
+            .withSuperParent(2, PlatformPatterns.psiElement(JsonArray::class.java))
+            .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("extensions")),
 
-            jsonStringValue()
-                    .withSuperParent(2, PlatformPatterns.psiElement(JsonProperty::class.java).withName("name"))
-                    .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("webapps"))
+        jsonStringValue()
+            .withSuperParent(2, PlatformPatterns.psiElement(JsonProperty::class.java).withName("name"))
+            .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("webapps"))
     )
 
     val TEMPLATE_EXTENSION_NAME = StandardPatterns.or(
-            jsonStringValue()
-                    .withSuperParent(2,
-                            StandardPatterns.or(
-                                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("template"),
-                            )
-                    )
-                    .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefrontAddons")),
+        jsonStringValue()
+            .withSuperParent(
+                2,
+                StandardPatterns.or(
+                    PlatformPatterns.psiElement(JsonProperty::class.java).withName("template"),
+                )
+            )
+            .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("storefrontAddons")),
     )
 
     val EXTENSION_PACK_NAME = StandardPatterns.or(
-            jsonStringValue()
-                    .withSuperParent(2, PlatformPatterns.psiElement(JsonProperty::class.java).withName("name"))
-                    .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("extensionPacks"))
+        jsonStringValue()
+            .withSuperParent(2, PlatformPatterns.psiElement(JsonProperty::class.java).withName("name"))
+            .inside(PlatformPatterns.psiElement(JsonProperty::class.java).withName("extensionPacks"))
     )
 
 }


### PR DESCRIPTION
<img width="718" alt="Screenshot 2023-09-04 at 17 51 45" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/a79bdbc8-dcbb-4f8e-b9ab-88651e4e2872">
