### PR TITLE
Enabled extension name inspection for `addons` and `storefronts` elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `CCv2` enhancements
 - Improved CCv2 SAP Commerce Cloud `manifest.json` schema support [#685](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/685)
 - Added code completion for `addons` and `storefronts` in the `manifest.json` schema [#686](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/686)
+- Enabled extension name inspection for `addons` and `storefronts` elements [#687](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/687)
 
 ### `ImpEx` enhancements
 - Introduced inlay hint to display default value in value lines [#670](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/670)

--- a/src/com/intellij/idea/plugin/hybris/codeInspection/rule/manifest/ManifestCommerceTemplateExtensionInspection.kt
+++ b/src/com/intellij/idea/plugin/hybris/codeInspection/rule/manifest/ManifestCommerceTemplateExtensionInspection.kt
@@ -48,16 +48,22 @@ class ManifestCommerceTemplateExtensionInspection : LocalInspectionTool() {
             val parent = o.parent
             if (isApplicable(parent, o) && !HybrisProjectSettingsComponent.getInstance(o.project).getAvailableExtensions().contains(o.value)) {
                 holder.registerProblem(
-                        o,
-                        HybrisI18NBundleUtils.message("hybris.inspections.fix.manifest.ManifestUnknownTemplateExtensionInspection.message", o.value)
+                    o,
+                    HybrisI18NBundleUtils.message("hybris.inspections.fix.manifest.ManifestUnknownTemplateExtensionInspection.message", o.value)
                 )
             }
         }
 
-        private fun isApplicable(parent: PsiElement?, o: JsonStringLiteral) = parent is JsonProperty
-                && JsonPsiUtil.isPropertyValue(o)
-                && parent.name == "template"
-                && parent.parentOfType<JsonProperty>()?.name == "storefrontAddons"
+        private fun isApplicable(parent: PsiElement, o: JsonStringLiteral) = (parent is JsonProperty
+            && JsonPsiUtil.isPropertyValue(o)
+            && parent.name == "template"
+            && parent.parentOfType<JsonProperty>()?.name == "storefrontAddons")
+            || (JsonPsiUtil.isArrayElement(o)
+            && parent.parentOfType<JsonProperty>()
+            ?.takeIf { it.name == "addons" || it.name == "storefronts" }
+            ?.parentOfType<JsonProperty>()
+            ?.name == "storefrontAddons"
+            )
 
     }
 }


### PR DESCRIPTION
<img width="511" alt="Screenshot 2023-09-04 at 19 01 19" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/da45e009-7d24-45fc-83e7-1afe1ecd48fb">
