### PR TITLE
Adjusted folding for `jar:` file load translator prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Improved Column highlighting logic [#690](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/690)
 - Added folding for `zip:` file load translator prefix [#692](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/692)
 - Added folding for `file:` file load translator prefix [#693](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/693)
+- Adjusted folding for `jar:` file load translator prefix [#694](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/694)
 
 ### `ImpEx` inspection rules
 - Omit usage of the ` \ ` multi-line separator for macro declaration [#677](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/677)

--- a/resources/META-INF/lang/impex-dependencies.xml
+++ b/resources/META-INF/lang/impex-dependencies.xml
@@ -111,10 +111,10 @@
         <applicationService serviceInterface="com.intellij.idea.plugin.hybris.impex.assistance.ImpexColumnHighlighterService"
                             serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.DefaultImpexColumnHighlighterService"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.highlighting.DefaultImpexSyntaxHighlighter"/>
-        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.simple.DefaultImpexFoldingPlaceholderBuilder"/>
-        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.smart.SmartImpexFoldingPlaceholderBuilder"/>
-        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.simple.DefaultFoldingBlocksFilter"/>
-        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.smart.SmartFoldingBlocksFilter"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.util.ImpExSimpleFoldingPlaceholderBuilder"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.util.ImpExSmartFoldingPlaceholderBuilder"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.util.ImpExSimpleFoldingBlocksFilter"/>
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.lang.folding.util.ImpExSmartFoldingBlocksFilter"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.psi.ImpexPsiManager"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexHeaderHighlightingCaretListener"/>
         <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.impex.assistance.event.ImpexColumnHighlightingCaretListener"/>

--- a/src/com/intellij/idea/plugin/hybris/impex/lang/folding/ImpexMacroFoldingBuilder.java
+++ b/src/com/intellij/idea/plugin/hybris/impex/lang/folding/ImpexMacroFoldingBuilder.java
@@ -285,8 +285,8 @@ public class ImpexMacroFoldingBuilder implements FoldingBuilder {
                     final var loaderClass = blocks[0];
                     return "jar:"
                         + loaderClass.substring(loaderClass.lastIndexOf('.') + 1)
-                        + '&'
-                        + blocks[1];
+                        + "&.."
+                        + getFileName(blocks[1]);
                 }
             } else if (resolvedValue.startsWith("zip:")) {
                 final var blocks = resolvedValue.split("&");


### PR DESCRIPTION
**before**
<img width="612" alt="Screenshot 2023-09-05 at 23 05 21" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/10cb1ae9-7c30-45f8-b8b2-2827af99923b">


**after**

<img width="309" alt="Screenshot 2023-09-05 at 23 06 48" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/1e08c2b0-7b1a-4b7b-94f2-1277a19e50b5">
