### PR TITLE
Disable reference and code completion for `order` property of the Spring Interceptor bean declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Improved folding for `custom-properties`:`property` tags [#664](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/664)
 
 ### Fixes
+- Disable reference and code completion for `order` property of the Spring Interceptor bean declaration [#697](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/697)
 - Fixed preview of the inlay hint for Dynamic attributes [#668](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/668)
 - Enable custom action toolbars only for SAP Commerce projects [#669](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/669)
 - Fixed `ImpEx` unique value inspection to support multi-line ` \ ` separator [#681](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/681)

--- a/src/com/intellij/idea/plugin/hybris/system/type/psi/TSPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/psi/TSPatterns.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -42,6 +42,7 @@ object TSPatterns {
         .withSuperParent(2,
             XmlPatterns.xmlTag()
                 .withLocalName("property")
+                .withAttributeValue("name", "typeCode")
                 .withParent(
                     XmlPatterns.xmlTag()
                         .withLocalName("bean")


### PR DESCRIPTION
**before**
<img width="366" alt="Screenshot 2023-09-06 at 20 51 05" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/a8f3a401-9b58-4aed-a978-a675c8a8f32e">

**after**
<img width="381" alt="Screenshot 2023-09-07 at 20 10 30" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/18ec3dc1-458d-4355-ab04-c10a64ad564c">
