### PR TITLE
Add possibility to disable the Groovy actions toolbar for the groovy files whose path contains 'testsrc'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 ### `ImpEx` inspection rules
 - Omit usage of the ` \ ` multi-line separator for macro declaration [#677](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/677)
 
+### `Groovy Script` enhancements
+- Disable actions toolbar for the test `.groovy` files [#704](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/704)
+
 ### `items.xml` enhancements
 - Improved folding for `persistence`:`columntype` tags [#662](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/662)
 - Improved folding for `index`:`key` tags [#663](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/663)

--- a/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettings.kt
@@ -20,4 +20,5 @@ package com.intellij.idea.plugin.hybris.groovy.settings
 
 data class GroovySettings(
     var enableActionsToolbar: Boolean = true,
+    var enableActionsToolbarForGroovyTest: Boolean = false,
 )

--- a/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
@@ -44,6 +44,11 @@ class GroovySettingsConfigurableProvider(val project: Project) : ConfigurablePro
                         .bindSelected(state::enableActionsToolbar)
                         .comment("Actions toolbar enables possibility to change current remote SAP Commerce session and perform operations on current file, such as `Execute on remote server`")
                 }
+                row {
+                    checkBox("Enable actions toolbar for a Test Groovy file")
+                        .bindSelected(state::enableActionsToolbarForGroovyTest)
+                        .comment("Enables Actions toolbar for the groovy files with 'Test' in the file name or files that uses ManualTest annotation.")
+                }
 
             }
         }

--- a/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
@@ -47,7 +47,7 @@ class GroovySettingsConfigurableProvider(val project: Project) : ConfigurablePro
                 row {
                     checkBox("Enable actions toolbar for a Test Groovy file")
                         .bindSelected(state::enableActionsToolbarForGroovyTest)
-                        .comment("Enables Actions toolbar for the groovy files with 'Test' in the file name or files that uses ManualTest annotation.")
+                        .comment("Enables Actions toolbar for the groovy files located in the testsrc folder.")
                 }
 
             }

--- a/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/groovy/settings/GroovySettingsConfigurableProvider.kt
@@ -25,6 +25,8 @@ import com.intellij.openapi.options.ConfigurableProvider
 import com.intellij.openapi.project.Project
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.layout.selected
+import javax.swing.JCheckBox
 
 class GroovySettingsConfigurableProvider(val project: Project) : ConfigurableProvider() {
 
@@ -36,18 +38,21 @@ class GroovySettingsConfigurableProvider(val project: Project) : ConfigurablePro
     ) {
 
         private val state = HybrisProjectSettingsComponent.getInstance(project).state.groovySettings
+        private lateinit var enableActionToolbar: JCheckBox
 
         override fun createPanel() = panel {
             group("Language") {
                 row {
-                    checkBox("Enable actions toolbar for each Groovy file")
+                    enableActionToolbar = checkBox("Enable actions toolbar for each Groovy file")
                         .bindSelected(state::enableActionsToolbar)
                         .comment("Actions toolbar enables possibility to change current remote SAP Commerce session and perform operations on current file, such as `Execute on remote server`")
+                        .component
                 }
                 row {
                     checkBox("Enable actions toolbar for a Test Groovy file")
                         .bindSelected(state::enableActionsToolbarForGroovyTest)
                         .comment("Enables Actions toolbar for the groovy files located in the testsrc folder.")
+                        .enabledIf(enableActionToolbar.selected)
                 }
 
             }

--- a/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
@@ -44,14 +44,12 @@ class HybrisFileEditorManagerListener(private val project: Project) : FileEditor
 
         val settings = projectSettings.state
 
-        val toolbarInstaller = when (file.fileType) {
-            is FlexibleSearchFileType -> FlexibleSearchFileToolbarInstaller.instance
-            is PolyglotQueryFileType -> PolyglotQueryFileToolbarInstaller.instance
-            is ImpexFileType -> ImpExFileToolbarInstaller.instance
-            else -> {
-                if (isGroovyFileToolbarEnabled(file, settings)) GroovyFileToolbarInstaller.instance
-                else null
-            }
+        val toolbarInstaller = when {
+            file.fileType is FlexibleSearchFileType -> FlexibleSearchFileToolbarInstaller.instance
+            file.fileType is PolyglotQueryFileType -> PolyglotQueryFileToolbarInstaller.instance
+            file.fileType is ImpexFileType -> ImpExFileToolbarInstaller.instance
+            isGroovyFileToolbarEnabled(file, settings) -> GroovyFileToolbarInstaller.instance
+            else -> null
 
         } ?: return
 

--- a/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
@@ -42,12 +42,19 @@ class HybrisFileEditorManagerListener(private val project: Project) : FileEditor
         if (!projectSettings.isHybrisProject()) return
 
         val settings = projectSettings.state
+        val isTestFile = file.name.contains("test") || String(file.contentsToByteArray()).contains("de.hybris.bootstrap.annotations.ManualTest", true)
+        val enabledForGroovyTestOrAllGroovyFiles = settings.groovySettings.enableActionsToolbarForGroovyTest && isTestFile || !isTestFile
         val toolbarInstaller = when (file.fileType) {
             is FlexibleSearchFileType -> FlexibleSearchFileToolbarInstaller.instance
             is PolyglotQueryFileType -> PolyglotQueryFileToolbarInstaller.instance
             is ImpexFileType -> ImpExFileToolbarInstaller.instance
             else -> {
-                if (PluginCommon.isPluginActive(PluginCommon.GROOVY_PLUGIN_ID) && file.fileType is GroovyFileType && settings.groovySettings.enableActionsToolbar) GroovyFileToolbarInstaller.instance
+                if (PluginCommon.isPluginActive(PluginCommon.GROOVY_PLUGIN_ID)
+                    && file.fileType is GroovyFileType
+                    && settings.groovySettings.enableActionsToolbar
+                    && enabledForGroovyTestOrAllGroovyFiles
+                )
+                    GroovyFileToolbarInstaller.instance
                 else null
             }
 

--- a/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
+++ b/src/com/intellij/idea/plugin/hybris/startup/event/HybrisFileEditorManagerListener.kt
@@ -42,7 +42,7 @@ class HybrisFileEditorManagerListener(private val project: Project) : FileEditor
         if (!projectSettings.isHybrisProject()) return
 
         val settings = projectSettings.state
-        val isTestFile = file.name.contains("test") || String(file.contentsToByteArray()).contains("de.hybris.bootstrap.annotations.ManualTest", true)
+        val isTestFile = file.path.contains("testsrc", true)
         val enabledForGroovyTestOrAllGroovyFiles = settings.groovySettings.enableActionsToolbarForGroovyTest && isTestFile || !isTestFile
         val toolbarInstaller = when (file.fileType) {
             is FlexibleSearchFileType -> FlexibleSearchFileToolbarInstaller.instance


### PR DESCRIPTION
Add the configuration checkbox to enable the Groovy actions toolbar for a test groovy file, i.e. a file that contains 'test' in the file name or 'de.hybris.bootstrap.annotations.ManualTest' annotation.
<img width="979" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/f9f15345-b072-49ce-97d3-848b2f85a9fd">
<img width="993" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/70fa9d18-1abb-4bdd-814c-843fe7ccf575">

