### PR TITLE
Allow multi-line ` \ ` separator for **value groups** as a last character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Added support of the multi-line ` \ ` separator for **macro values** [#678](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/678)
 - Added support of the multi-line ` \ ` separator for **header parameters** [#679](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/679)
 - Added support of the multi-line ` \ ` separator for **value groups** [#680](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/680)
+- Allow multi-line ` \ ` separator for **value groups** as a last character [#714](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/714)
 - Adjusted Table selection logic [#689](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/689)
 - Improved Column highlighting logic [#690](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/690)
 - Added folding for `zip:` file load translator prefix [#692](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/692)

--- a/gen/com/intellij/idea/plugin/hybris/impex/ImpexParser.java
+++ b/gen/com/intellij/idea/plugin/hybris/impex/ImpexParser.java
@@ -1605,7 +1605,7 @@ public class ImpexParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // FIELD_VALUE_SEPARATOR value?
+  // FIELD_VALUE_SEPARATOR value? MULTILINE_SEPARATOR?
   public static boolean value_group(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "value_group")) return false;
     if (!nextTokenIs(b, FIELD_VALUE_SEPARATOR)) return false;
@@ -1613,7 +1613,8 @@ public class ImpexParser implements PsiParser, LightPsiParser {
     Marker m = enter_section_(b, l, _NONE_, VALUE_GROUP, null);
     r = consumeToken(b, FIELD_VALUE_SEPARATOR);
     p = r; // pin = 1
-    r = r && value_group_1(b, l + 1);
+    r = r && report_error_(b, value_group_1(b, l + 1));
+    r = p && value_group_2(b, l + 1) && r;
     exit_section_(b, l, m, r, p, null);
     return r || p;
   }
@@ -1622,6 +1623,13 @@ public class ImpexParser implements PsiParser, LightPsiParser {
   private static boolean value_group_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "value_group_1")) return false;
     value(b, l + 1);
+    return true;
+  }
+
+  // MULTILINE_SEPARATOR?
+  private static boolean value_group_2(PsiBuilder b, int l) {
+    if (!recursion_guard_(b, l, "value_group_2")) return false;
+    consumeToken(b, MULTILINE_SEPARATOR);
     return true;
   }
 

--- a/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
+++ b/src/com/intellij/idea/plugin/hybris/impex/Impex.bnf
@@ -217,7 +217,7 @@ value_line ::= (sub_type_name value_group*) | (value_group+) {
     methods=[getHeaderLine getValueGroup addValueGroups]
 }
 
-value_group ::= FIELD_VALUE_SEPARATOR value?
+value_group ::= FIELD_VALUE_SEPARATOR value? MULTILINE_SEPARATOR?
 {
     pin=1
     methods=[getFullHeaderParameter getColumnNumber getValueLine computeValue]


### PR DESCRIPTION
<img width="451" alt="Screenshot 2023-09-13 at 11 58 49" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/0c271f96-df8a-4300-b012-7a5f630a0ba5">
