### PR TITLE
Include `backoffice.web` classes in the `Backoffice Library`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Improved IDE compilation and navigation in the Platform code [#726](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/726)
 - Change scope to `provided` for `Backoffice Classes` library [#731](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/731)
 - Attach standard sources in the `doc/sources` for web inf libraries [#732](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/732)
+- Include `backoffice.web` classes in the `Backoffice Library` (**depends** on [IDEA-332845](https://youtrack.jetbrains.com/issue/IDEA-332845/Project-Library-ignores-classes-in-the-folders)) [#733](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/733)
 
 ### Fixes
 - `SAP Commerce` tool window sometimes appears without any content [#725](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/725)

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultLibRootsConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultLibRootsConfigurator.kt
@@ -81,6 +81,12 @@ class DefaultLibRootsConfigurator : LibRootsConfigurator {
                     addLibsToModule(modifiableRootModel, modifiableModelsProvider, HybrisConstants.BACKOFFICE_LIBRARY_GROUP, true)
                 }
             }
+            is YWebSubModuleDescriptor -> {
+                if (moduleDescriptor.owner.name == HybrisConstants.EXTENSION_NAME_BACK_OFFICE) {
+                    val path = File(moduleDescriptor.moduleRootDirectory, HybrisConstants.WEBROOT_WEBINF_CLASSES_PATH)
+                    YModuleLibDescriptorUtil.addRootProjectLibrary(modifiableModelsProvider, path, HybrisConstants.BACKOFFICE_LIBRARY_GROUP, false)
+                }
+            }
         }
     }
 

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/YModuleLibDescriptorUtil.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/YModuleLibDescriptorUtil.kt
@@ -34,7 +34,7 @@ object YModuleLibDescriptorUtil {
 
     fun getLibraryDescriptors(descriptor: ModuleDescriptor, allYModules: Map<String, YModuleDescriptor>): List<JavaLibraryDescriptor> = when (descriptor) {
         is YRegularModuleDescriptor -> getLibraryDescriptors(descriptor)
-        is YWebSubModuleDescriptor -> getWebLibraryDescriptors(descriptor, "Web")
+        is YWebSubModuleDescriptor -> getWebLibraryDescriptors(descriptor)
         is YCommonWebSubModuleDescriptor -> getCommonWebSubModuleDescriptor(descriptor)
         is YBackofficeSubModuleDescriptor -> getLibraryDescriptors(descriptor)
         is YAcceleratorAddonSubModuleDescriptor -> getLibraryDescriptors(descriptor, allYModules)
@@ -310,15 +310,17 @@ object YModuleLibDescriptorUtil {
             ?.listFiles { it: File -> it.isDirectory }
             ?.forEach { sourceFiles.add(it) }
 
-        libs.add(
-            JavaLibraryDescriptor(
-                name = "${descriptor.name} - $libName Classes",
-                libraryFile = File(descriptor.moduleRootDirectory, HybrisConstants.WEBROOT_WEBINF_CLASSES_PATH),
-                sourceFiles = sourceFiles,
-                exported = true,
-                directoryWithClasses = true
+        if (descriptor.owner.name != HybrisConstants.EXTENSION_NAME_BACK_OFFICE) {
+            libs.add(
+                JavaLibraryDescriptor(
+                    name = "${descriptor.name} - $libName Classes",
+                    libraryFile = File(descriptor.moduleRootDirectory, HybrisConstants.WEBROOT_WEBINF_CLASSES_PATH),
+                    sourceFiles = sourceFiles,
+                    exported = true,
+                    directoryWithClasses = true
+                )
             )
-        )
+        }
 
         val libFolder = File(descriptor.moduleRootDirectory, HybrisConstants.WEBROOT_WEBINF_LIB_PATH)
 


### PR DESCRIPTION
Related JetBrains issue -> https://youtrack.jetbrains.com/issue/IDEA-332845/Project-Library-ignores-classes-in-the-folders

<img width="1291" alt="Screenshot 2023-09-19 at 22 21 48" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/9658957d-b24a-4987-8a71-e96848f1d030">
