### PR TITLE
Bugfix/fix ci issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -341,6 +341,7 @@
 - Fixed deadlock when ItemType name equals to its extends [#513](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/513)
 - Refactored `ImportProjectProgressModalWindow` so that is calls so that project state retrieved only once [#512](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/512)
 - Changed generated `*.iml` file name when grouping is not selected so file name does not start with a dot [#512](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/512)
+- Updated Gradle plugin to 1.16.0 due to the exception NoClassDefFoundError: org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity in Gradle 8.4 [#767](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/767)
 
 ### Other
 - Updated Kotlin to 1.9.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ solrSolrj = "8.11.2"
 # https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
 kotlin = "1.9.0"
 # https://plugins.gradle.org/plugin/org.jetbrains.intellij
-gradleIntelliJPlugin = "1.15.0"
+gradleIntelliJPlugin = "1.16.0"
 # https://plugins.gradle.org/plugin/org.jetbrains.changelog
 changelog = "2.1.2"
 


### PR DESCRIPTION
Updated Gradle plugin to 1.16.0 due to the exception NoClassDefFoundError: org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationIdentity in Gradle 8.4, https://github.com/JetBrains/gradle-intellij-plugin/issues/1469

See release notes for gradle plugin 1.16.0:
https://github.com/JetBrains/gradle-intellij-plugin/releases/tag/v1.16.0