### PR TITLE
Added code completion and reference resolution for `y:property` : `editor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### `Cockpit NG` enhancements
 - Extend config schema namespace with `editors` type [#784](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/784)
+- Added code completion and reference resolution for `y:property` : `editor` [#787](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/787)
 
 ### `Kotlin` enhancements
 - Introduced `ysri` live template for Spring `@Resource` declaration [#780](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/780)

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
@@ -91,6 +91,15 @@ object CngPatterns {
             CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_WIZARD_CONFIG
         )
             .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT))
+            .inFile(cngConfigFile),
+
+        attributeValue(
+            "editor",
+            "property",
+            "editors",
+            CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_HYBRIS
+        )
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT))
             .inFile(cngConfigFile)
     )
 


### PR DESCRIPTION
<img width="1026" alt="Screenshot 2023-11-01 at 23 35 36" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/adb4cf67-8c1a-4754-9db7-de3e300cc40b">
