### PR TITLE
Auto-registration of the XSD namespace for `editor-definition.xsd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [2023.2.12]
 
+### `Project Import` enhancements
+- Auto-registration of the XSD namespace for `editor-definition.xsd` [#804](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/804)
+
 ### `ImpEx` enhancements
 - Added colorization for `odd` and `even` user rights value lines [#802](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/802)
 

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultXsdSchemaConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/impl/DefaultXsdSchemaConfigurator.kt
@@ -35,23 +35,29 @@ class DefaultXsdSchemaConfigurator : XsdSchemaConfigurator {
         hybrisProjectDescriptor: HybrisProjectDescriptor,
         moduleDescriptors: List<ModuleDescriptor>,
     ) {
-        val cockpitConfigurationHybrisXsd = moduleDescriptors
+        val cockpitCoreJarFileSystem = moduleDescriptors
             .firstOrNull { it.name == HybrisConstants.EXTENSION_NAME_BACK_OFFICE }
             ?.moduleRootDirectory
             ?.toPath()
             ?.resolve(Path.of("web", "webroot", "WEB-INF", "lib"))
             ?.takeIf { it.exists() }
             ?.toFile()
-            ?.listFiles { _, name -> name.startsWith("cockpitcore-") }
+            ?.listFiles { _, name -> name.startsWith("cockpitcore-", true) && name.endsWith(".jar", true) }
             ?.firstOrNull()
             ?.absolutePath
-            ?.let { "$it!/schemas/config/hybris/cockpit-configuration-hybris.xsd" }
             ?: return
 
         runWriteAction {
-            ExternalResourceManagerEx.getInstanceEx().addResource(
+            val externalResourceManager = ExternalResourceManagerEx.getInstanceEx()
+
+            externalResourceManager.addResource(
                 CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_HYBRIS,
-                cockpitConfigurationHybrisXsd,
+                "$cockpitCoreJarFileSystem!/schemas/config/hybris/cockpit-configuration-hybris.xsd",
+                project
+            )
+            externalResourceManager.addResource(
+                "http://www.hybris.com/schema/cockpitng/editor-definition.xsd",
+                "$cockpitCoreJarFileSystem!/schemas/editor-definition.xsd",
                 project
             )
         }


### PR DESCRIPTION
**before**
<img width="943" alt="Screenshot 2023-11-15 at 15 21 10" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/f0bec410-e381-4463-a107-e8cf21105b3b">


**after**
<img width="904" alt="Screenshot 2023-11-15 at 15 22 02" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/9412bb36-bef9-4d65-a87f-571511ef94ea">
