### PR TITLE
Added shortcuts `control` + `[` | `]` for move left | right column actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `ImpEx` enhancements
 - Added shortcut `control + shift + alt + backspace` for remove table action [#836](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/836)
 - Added shortcut `control + shift + alt + backslash` for split table action [#837](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/837)
+- Added shortcuts `control` + `[` | `]` for move left | right column actions [#838](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/838)
 
 ### Other
 - Adjust optional dependency on `AntPlugin` during project refresh [#833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/833)

--- a/resources/META-INF/lang/impex-dependencies.xml
+++ b/resources/META-INF/lang/impex-dependencies.xml
@@ -126,8 +126,12 @@
         <group id="hybris.impex.table.actions">
             <reference id="hybris.impex.table.select"/>
             <separator/>
-            <action id="hybris.impex.table.column.move.left" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnMoveLeftAction"/>
-            <action id="hybris.impex.table.column.move.right" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnMoveRightAction"/>
+            <action id="hybris.impex.table.column.move.left" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnMoveLeftAction">
+                <keyboard-shortcut first-keystroke="control OPEN_BRACKET" keymap="$default"/>
+            </action>
+            <action id="hybris.impex.table.column.move.right" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnMoveRightAction">
+                <keyboard-shortcut first-keystroke="control CLOSE_BRACKET" keymap="$default"/>
+            </action>
             <separator/>
             <action id="hybris.impex.table.column.add.left" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnInsertLeftAction"/>
             <action id="hybris.impex.table.column.add.right" class="com.intellij.idea.plugin.hybris.impex.actions.ImpExTableColumnInsertRightAction"/>


### PR DESCRIPTION
<img width="232" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/edac8e6b-5586-4eaf-a960-d19f20e2ed54">
<img width="191" alt="Screenshot 2023-12-09 at 12 47 08" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/94528dcb-6075-4a03-9fe3-a6d16ded14d1">
