### PR TITLE
Automatically download missing external dependencies via `Ant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Load Properties from Files and Environment [#864](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/864)
 
 ### `External Dependencies` enhancements
-- Automatically download missing external dependencies via `Ant` [#874](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/874)
+- Automatically download missing external dependencies via `Ant` [#876](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/876)
 
 ### `Ant` enhancements
 - Allow common targets for custom extensions [#873](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/873)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add JDK Export Properties to JUnit Tests to run Integration Tests [#864](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/864)
 - Load Properties from Files and Environment [#864](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/864)
 
+### `External Dependencies` enhancements
+- Automatically download missing external dependencies via `Ant` [#874](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/874)
+
 ### `Ant` enhancements
 - Allow common targets for custom extensions [#873](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/873)
 

--- a/resources/META-INF/dependencies/com.intellij.idea.plugin.sap.commerce-ant.xml
+++ b/resources/META-INF/dependencies/com.intellij.idea.plugin.sap.commerce-ant.xml
@@ -20,10 +20,10 @@
 <idea-plugin>
 
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceImplementation="com.intellij.idea.plugin.hybris.project.configurators.AntConfigurator"/>
 
-        <applicationService serviceInterface="com.intellij.idea.plugin.hybris.project.configurators.AntConfigurator"
-                            serviceImplementation="com.intellij.idea.plugin.hybris.project.configurators.AntConfigurator"/>
-
+        <editorNotificationProvider id="antUpdateMavenDependenciesNotificationProvider"
+                                    implementation="com.intellij.idea.plugin.hybris.ant.ui.AntUpdateMavenDependenciesNotificationProvider"/>
     </extensions>
 
 </idea-plugin>

--- a/src/com/intellij/idea/plugin/hybris/ant/ui/AntUpdateMavenDependenciesNotificationProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/ant/ui/AntUpdateMavenDependenciesNotificationProvider.kt
@@ -1,0 +1,72 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
+ * Copyright (C) 2019-2023 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.ant.ui
+
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.idea.plugin.hybris.settings.HybrisProjectSettingsComponent
+import com.intellij.lang.ant.config.AntBuildFileBase
+import com.intellij.lang.ant.config.AntConfiguration
+import com.intellij.lang.ant.config.execution.ExecutionHandler
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.removeUserData
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.EditorNotificationPanel
+import com.intellij.ui.EditorNotificationProvider
+import com.intellij.ui.EditorNotifications
+import java.util.function.Function
+import javax.swing.JComponent
+
+class AntUpdateMavenDependenciesNotificationProvider : EditorNotificationProvider {
+
+    override fun collectNotificationData(project: Project, file: VirtualFile): Function<in FileEditor, out JComponent?>? {
+        val settings = HybrisProjectSettingsComponent.getInstance(project)
+        if (!settings.isHybrisProject()) return null
+        if (file.name != HybrisConstants.EXTERNAL_DEPENDENCIES_XML) return null
+
+        val showPanel = file
+            .getUserData(HybrisConstants.KEY_ANT_UPDATE_MAVEN_DEPENDENCIES)
+            ?: false
+
+        if (!showPanel) return null
+
+        return Function { fileEditor ->
+            val panel = EditorNotificationPanel(fileEditor, EditorNotificationPanel.Status.Warning)
+            panel.icon(HybrisIcons.Y_LOGO_BLUE)
+            panel.text = "[y] Download missing external dependencies via Ant"
+            panel.createActionLabel("Download") {
+                AntConfiguration.getInstance(project).buildFiles
+                    .firstOrNull { it.virtualFile?.path?.endsWith("hybris/bin/platform/build.xml") ?: false }
+                    ?.let { it as? AntBuildFileBase }
+                    ?.let { buildFile ->
+                        val targets = listOf(HybrisConstants.ANT_TARGET_UPDATE_MAVEN_DEPENDENCIES)
+                        ExecutionHandler.runBuild(buildFile, targets, null, DataContext.EMPTY_CONTEXT, emptyList())
+                        { _, _ ->
+                            EditorNotifications.getInstance(project).updateNotifications(this)
+                            file.removeUserData(HybrisConstants.KEY_ANT_UPDATE_MAVEN_DEPENDENCIES)
+                        }
+                        ToolWindowManager.getInstance(project).activateEditorComponent()
+                    }
+            }
+            panel
+        }
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -338,6 +338,8 @@ object HybrisConstants {
     const val SCHEMA_COCKPIT_NG_WIDGETS = "http://www.hybris.com/schema/cockpitng/widgets.xsd"
     const val SCHEMA_COCKPIT_NG_CONFIG = "http://www.hybris.com/cockpit/config"
 
+    const val ANT_TARGET_UPDATE_MAVEN_DEPENDENCIES = "updateMavenDependencies"
+
     val DEFAULT_JUNK_FILE_NAMES = listOf(
         ".classpath",
         ".directory",
@@ -610,7 +612,7 @@ object HybrisConstants {
 
     @JvmStatic
     val KEY_FINALIZE_PROJECT_IMPORT: Key<Triple<HybrisProjectDescriptor, List<ModuleDescriptor>, Boolean>> = Key.create("hybrisProjectImportFinalize")
-
+    val KEY_ANT_UPDATE_MAVEN_DEPENDENCIES = Key.create<Boolean>("notification_update_external-dependencies.xml")
 
     const val FXS_DUMMY_IDENTIFIER = CompletionUtilCore.DUMMY_IDENTIFIER_TRIMMED
     val FXS_SUPPORTED_ELEMENT_TYPES = setOf(


### PR DESCRIPTION
<img width="1210" alt="Screenshot 2023-12-25 at 23 20 04" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/2619feeb-3dac-4b65-841e-e3f26922fd27">
<img width="804" alt="Screenshot 2023-12-25 at 23 20 47" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/72f464b6-21e6-42e4-83af-41f7957df529">
