### PR TITLE
Improved Groovy language injection based on control markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added reference resolution for not quoted value of the `disable.interceptor.types` [#894](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/894)
 - Added reference resolution for not quoted value of the `disable.UniqueAttributesValidator.for.types` [#895](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/895)
 - Customized folding for `User Rights` permission flags [#897](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/897)
+- Improved Groovy language injection based on control markers [#912](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/912)
 
 ### `ImpEx` inspection rules
 - Inspect type set for `disable.UniqueAttributesValidator.for.types` type modifier [#896](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/896)

--- a/src/com/intellij/idea/plugin/hybris/psi/injector/GroovyLanguageInjector.kt
+++ b/src/com/intellij/idea/plugin/hybris/psi/injector/GroovyLanguageInjector.kt
@@ -56,7 +56,13 @@ class GroovyLanguageInjector : LanguageInjector {
 
         val hostString = StringUtil.unquoteString(impexString.text).lowercase()
         if (StringUtil.trim(hostString).replaceFirst("\"", "").startsWith(groovyMarker)) {
-            injectLanguage(injectionPlacesRegistrar, impexString.textLength - offset - quoteSymbolLength, offset)
+            val markerOffset = setOf("beforeeach:", "aftereach:", "if:")
+                .map { it to impexString.text.indexOf(it, 0, true) }
+                .firstOrNull { it.second > -1 }
+                ?.let { it.first.length + it.second }
+                ?: offset
+
+            injectLanguage(injectionPlacesRegistrar, impexString.textLength - markerOffset - quoteSymbolLength, markerOffset)
         } else if (LanguageInjectionUtil.getLanguageForInjection(impexString) == ScriptType.GROOVY) {
             injectLanguage(injectionPlacesRegistrar, impexString.textLength - quoteSymbolLength - 1, quoteSymbolLength)
         }


### PR DESCRIPTION
https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/aa417173fe4a4ba5a473c93eb730a417/640172cbde9149ab8eb818180544020a.html?locale=en-US

markers defined here:
- `de.hybris.platform.impex.jalo.ScriptCodeLineFactory`
- `de.hybris.platform.impex.jalo.ImpExReader`

<img width="705" alt="Screenshot 2024-01-04 at 21 42 58" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/52f8fd4d-0894-4a66-ab74-848693538e41">
