### PR TITLE
Use blue logo for custom module groups in the project view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [2024.1.0]
 
 ### Features
-- Group all non-hybris gradle, ant, eclipse and maven modules in project view panel[#967](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/967)
+- Group all non-hybris gradle, ant, eclipse and maven modules in project view panel [#967](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/967)
+- Use blue logo for custom module groups in the project view [#973](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/973)
 
 ### `Remote Connection` enhancements
 - Introduced `Project` and `Personal` scope for remote connections [#971](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/971)

--- a/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.kt
@@ -75,6 +75,7 @@ object HybrisIcons {
     val MODULE_CCV2_GROUP = getIcon("/icons/module/cloudGroup.svg")
     val MODULE_COMMERCE_GROUP = Y_LOGO_GREEN
     val MODULE_PLATFORM_GROUP = Y_LOGO_ORANGE
+    val MODULE_CUSTOM_GROUP = Y_LOGO_BLUE
     val MODULE_EXTERNAL_GROUP = AllIcons.Nodes.ModuleGroup
 
     val EXTENSION_CONFIG = AllIcons.Nodes.ConfigFolder

--- a/src/com/intellij/idea/plugin/hybris/project/view/HybrisProjectView.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/view/HybrisProjectView.kt
@@ -48,7 +48,10 @@ open class HybrisProjectView(val project: Project) : TreeStructureProvider, Dumb
         .firstOrNull()
     private val ccv2GroupName = HybrisApplicationSettingsComponent.toIdeaGroup(hybrisApplicationSettings.groupCCv2)
         .firstOrNull()
+    private val customGroupName = HybrisApplicationSettingsComponent.toIdeaGroup(hybrisApplicationSettings.groupCustom)
+        .firstOrNull()
     private val groupToIcon = mapOf(
+        customGroupName to HybrisIcons.MODULE_CUSTOM_GROUP,
         platformGroupName to HybrisIcons.MODULE_PLATFORM_GROUP,
         commerceGroupName to HybrisIcons.MODULE_COMMERCE_GROUP,
         ccv2GroupName to HybrisIcons.MODULE_CCV2_GROUP,


### PR DESCRIPTION
<img width="172" alt="Screenshot 2024-01-29 at 15 28 02" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/2292510/877ab6f7-bf36-4959-b750-9ca1a14fe7de">
