### PR TITLE
Added ability to change the output directory for custom modules from …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Show globe icon for localized attributes in the code completion pane [#999](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/999)
 - Added custom icon for `hybrislicence.jar` [#1000](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1000)
 
+### `Project Build` enhancements
+- Added ability to change the output directory for custom modules from `classes` to `eclipsebin` [#1012](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1012)
+
 ### `items.xml` enhancements
 - Improved folding, show '!' for mandatory properties and relations [#1009](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1009)
 

--- a/src/com/intellij/idea/plugin/hybris/project/configurators/CompilerOutputPathsConfigurator.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/configurators/CompilerOutputPathsConfigurator.kt
@@ -37,10 +37,14 @@ class CompilerOutputPathsConfigurator {
         modifiableRootModel: ModifiableRootModel,
         moduleDescriptor: ModuleDescriptor
     ) {
+
         indicator.text2 = HybrisI18NBundleUtils.message("hybris.project.import.module.outputpath")
 
-        val outputDirectory = if (moduleDescriptor.descriptorType == ModuleDescriptorType.CUSTOM) File(moduleDescriptor.moduleRootDirectory, HybrisConstants.JAVA_COMPILER_OUTPUT_PATH)
-        else File(moduleDescriptor.moduleRootDirectory, HybrisConstants.JAVA_COMPILER_FAKE_OUTPUT_PATH)
+        val useFakeOutputPathForCustomExtensions = moduleDescriptor.rootProjectDescriptor.isUseFakeOutputPathForCustomExtensions
+        val outputDirectory = if (moduleDescriptor.descriptorType == ModuleDescriptorType.CUSTOM && !useFakeOutputPathForCustomExtensions)
+            File(moduleDescriptor.moduleRootDirectory, HybrisConstants.JAVA_COMPILER_OUTPUT_PATH)
+        else
+            File(moduleDescriptor.moduleRootDirectory, HybrisConstants.JAVA_COMPILER_FAKE_OUTPUT_PATH)
 
         with (modifiableRootModel.getModuleExtension(CompilerModuleExtension::class.java)) {
             setCompilerOutputPath(VfsUtilCore.pathToUrl(outputDirectory.absolutePath))

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -116,6 +116,8 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     protected boolean scanThroughExternalModule;
     private boolean withStandardProvidedSources;
     private boolean ignoreNonExistingSourceDirectories;
+    private boolean useFakeOutputPathForCustomExtensions;
+
     @NotNull
     private ConfigModuleDescriptor configHybrisModuleDescriptor;
     @NotNull
@@ -1079,6 +1081,16 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
     @Override
     public void setIgnoreNonExistingSourceDirectories(final boolean ignoreNonExistingSourceDirectories) {
         this.ignoreNonExistingSourceDirectories = ignoreNonExistingSourceDirectories;
+    }
+
+    @Override
+    public boolean isUseFakeOutputPathForCustomExtensions() {
+        return useFakeOutputPathForCustomExtensions;
+    }
+
+    @Override
+    public void setUseFakeOutputPathForCustomExtensions(final boolean useFakeOutputPathForCustomExtensions) {
+        this.useFakeOutputPathForCustomExtensions = useFakeOutputPathForCustomExtensions;
     }
 
     @Nullable

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/HybrisProjectDescriptor.java
@@ -119,6 +119,10 @@ public interface HybrisProjectDescriptor {
 
     void setIgnoreNonExistingSourceDirectories(boolean ignoreNonExistingSourceDirectories);
 
+    boolean isUseFakeOutputPathForCustomExtensions();
+
+    void setUseFakeOutputPathForCustomExtensions(boolean useFakeOutputPathForCustomExtensions);
+
     @Nullable
     String getJavadocUrl();
 

--- a/src/com/intellij/idea/plugin/hybris/project/wizard/ProjectImportWizardRootStep.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/wizard/ProjectImportWizardRootStep.kt
@@ -78,6 +78,7 @@ class ProjectImportWizardRootStep(context: WizardContext) : ProjectImportWizardS
     private lateinit var sourceCodeCheckBox: JBCheckBox
     private lateinit var storeModuleFilesInCheckBox: JBCheckBox
     private lateinit var excludedFromScanningCheckBox: JBCheckBox
+    private lateinit var useFakeOutputPathForCustomExtensionsCheckbox: JBCheckBox
 
     private val excludedFromScanningList = CRUDListPanel(
         "hybris.import.settings.excludedFromScanning.directory.popup.add.title",
@@ -191,9 +192,13 @@ class ProjectImportWizardRootStep(context: WizardContext) : ProjectImportWizardS
                     .enabledIf(sourceCodeCheckBox.selected)
                     .component
             }.layout(RowLayout.PARENT_GRID)
-
             row {
-                importOotbModulesInReadOnlyModeCheckBox = checkBox("Import OOTB modules in read-only mode")
+                useFakeOutputPathForCustomExtensionsCheckbox = checkBox("Use fake output path for custom extensions")
+                    .comment("When enabled the `eclipsebin’ folder will be used as an output path for both custom and OOTB extensions")
+                    .component
+            }.layout(RowLayout.PARENT_GRID)
+            row {
+                importOotbModulesInReadOnlyModeCheckBox = checkBox("Import OOTB modules in read-only mode test")
                     .component
             }.layout(RowLayout.PARENT_GRID)
 
@@ -303,6 +308,7 @@ class ProjectImportWizardRootStep(context: WizardContext) : ProjectImportWizardS
             this.isExcludeTestSources = excludeTestSourcesCheckBox.isSelected
             this.isImportCustomAntBuildFiles = importCustomAntBuildFilesCheckBox.isSelected
             this.isScanThroughExternalModule = scanThroughExternalModuleCheckbox.isSelected
+            this.isUseFakeOutputPathForCustomExtensions = useFakeOutputPathForCustomExtensionsCheckbox.isSelected
 
             this.setExcludedFromScanning(excludedFromScanningList.data)
 
@@ -456,6 +462,7 @@ class ProjectImportWizardRootStep(context: WizardContext) : ProjectImportWizardS
             this.isExcludeTestSources = settings.excludeTestSources
             this.isImportCustomAntBuildFiles = settings.importCustomAntBuildFiles
             this.isScanThroughExternalModule = settings.scanThroughExternalModule
+            this.isUseFakeOutputPathForCustomExtensions = settings.useFakeOutputPathForCustomExtensions
 
             val appSettings = HybrisApplicationSettingsComponent.getInstance().state
             this.isIgnoreNonExistingSourceDirectories = appSettings.ignoreNonExistingSourceDirectories

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettings.kt
@@ -50,4 +50,5 @@ class HybrisProjectSettings : BaseState() {
     var availableExtensions by property(TreeMap<String, ExtensionDescriptor> { a, b -> a.compareTo(b, true) }) { it.isEmpty() }
     var excludedFromScanning by stringSet()
     var remoteConnectionSettingsList by list<HybrisRemoteConnectionSettings>()
+    var useFakeOutputPathForCustomExtensions by property(false)
 }

--- a/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettingsConfigurableProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/HybrisProjectSettingsConfigurableProvider.kt
@@ -105,6 +105,11 @@ class HybrisProjectSettingsConfigurableProvider(val project: Project) : Configur
                         .bindSelected(state::removeExternalModulesOnRefresh)
                 }
                 row {
+                    checkBox("Use fake output path for custom extensions")
+                        .comment("When enabled the ‘eclipsebin’ folder will be used as an output path for both custom and OOTB extensions.")
+                        .bindSelected(state::useFakeOutputPathForCustomExtensions)
+                }
+                row {
                     checkBox(message("hybris.import.wizard.import.ootb.modules.read.only.label"))
                         .comment(message("hybris.import.wizard.import.ootb.modules.read.only.tooltip"))
                         .bindSelected(state::importOotbModulesInReadOnlyMode)


### PR DESCRIPTION
Added ability to change the output directory for custom modules from `classes` to `eclipsebin`
**Project settings:**
<img width="991" alt="image" src="https://github.com/epam/sap-commerce-intellij-idea-plugin/assets/7203327/d2003bfc-87d9-4814-af3f-eb56d679310f">

**Import widget**

