### PR TITLE
Fix readonly bug if custom directory is not default "bin/custom"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Fix Path separator to enable Model Item Declaration icons and navigation on Windows [#1054](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1054)
 - Adjusted FlexibleSearch language injection [#1081](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1081)
 - Fix import with custom extension directory override [#1084](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1084)
+- Fix readonly problem for custom extension in a custom path [#1091](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1091)
 
 ### Other
 - Added JetBrains Marketplace error reporting [#1039](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1027) for Issue [1026](https://github.com/epam/sap-commerce-intellij-idea-plugin/issues/1039)

--- a/src/com/intellij/idea/plugin/hybris/project/providers/HybrisWritingAccessProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/providers/HybrisWritingAccessProvider.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.vfs.WritingAccessProvider
 class HybrisWritingAccessProvider(myProject: Project) : WritingAccessProvider() {
 
     private val ootbReadOnlyMode = ProjectSettingsComponent.getInstance(myProject).state.importOotbModulesInReadOnlyMode
+    private val customDirectory = ProjectSettingsComponent.getInstance(myProject).state.customDirectory
 
     override fun requestWriting(files: Collection<VirtualFile>) = files
         .filter { isFileReadOnly(it) }
@@ -37,7 +38,11 @@ class HybrisWritingAccessProvider(myProject: Project) : WritingAccessProvider() 
         if (!ootbReadOnlyMode) return false
         if (!file.isWritable) return true
 
-        return file.path.contains("hybris/bin")
-            && !file.path.contains("hybris/bin/custom")
+        if (file.path.contains("hybris/bin")) {
+            if (file.path.contains("hybris/bin/custom")) return false
+            if (customDirectory != null && file.path.contains(customDirectory)) return false
+            return true
+        }
+        return false
     }
 }


### PR DESCRIPTION
The HybrisWritingAccessProvider will check if a file should be readonly (because it's an OOTB file and should not be overridden). The check should also be done on the customDirectory (if set), to make it work if the custom extensions are not in the default directory "hybris/bin/custom".

Signed-off-by: Jan Bucher <jan@bucher.cloud>