### PR TITLE
Ensure that dependencies on non-custom extensions are properly configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [2024.3.0]
 
+### `Project Import` enhancements
+- Ensure that dependencies on non-custom extensions are properly configured [#1244](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1244)
+
 ### `CCv2` enhancements
 - Added support for the `enabledRepositories` for `js-storefront` [#1240](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1240)
 

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -166,8 +166,8 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
                 yRegularModuleDescriptor.setInLocalExtensions(true);
                 yRegularModuleDescriptor.getDirectDependencies()
                     .stream()
-                    .filter(YCustomRegularModuleDescriptor.class::isInstance)
-                    .map(YCustomRegularModuleDescriptor.class::cast)
+                    .filter(YRegularModuleDescriptor.class::isInstance)
+                    .map(YRegularModuleDescriptor.class::cast)
                     .forEach(module -> module.setNeededDependency(true));
             }
         }

--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/impl/YWebSubModuleDescriptor.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/impl/YWebSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
- * This file is part of "SAP Commerce Developers Toolset" plugin for Intellij IDEA.
- * Copyright (C) 2019 EPAM Systems <hybrisideaplugin@epam.com>
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2024 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -35,11 +35,11 @@ class YWebSubModuleDescriptor(
 
     override fun addDirectDependencies(dependencies: Set<ModuleDescriptor>): Boolean {
         dependencies
-            .filterIsInstance(YModuleDescriptor::class.java)
+            .filterIsInstance<YModuleDescriptor>()
             .flatMap { it.getAllDependencies() }
-            .filterIsInstance(YCustomRegularModuleDescriptor::class.java)
+            .filterIsInstance<YCustomRegularModuleDescriptor>()
             .flatMap { it.getSubModules() }
-            .filterIsInstance(YCommonWebSubModuleDescriptor::class.java)
+            .filterIsInstance<YCommonWebSubModuleDescriptor>()
             .forEach { it.addDependantWebExtension(this) }
         return super.addDirectDependencies(dependencies)
     }


### PR DESCRIPTION
The problem can be reproduced when new OCC extension is created with dependency on OOTB `commercewebservices`.