### PR TITLE
Improved navigation to the file located in the virtual `Junk` directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added 2024.3 IntelliJ IDEA support [#1231](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1231)
 - Updated libraries versions [#1235](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1235)
 - MavenProjectBuilder API migration [#1237](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1237)
+- Improved navigation to the file located in the virtual `Junk` directory [#1245](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1245)
 
 ### Deprecated
 - Use `IDE` modality [#1232](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1232)

--- a/src/com/intellij/idea/plugin/hybris/project/view/JunkProjectViewNode.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/view/JunkProjectViewNode.kt
@@ -21,6 +21,7 @@ package com.intellij.idea.plugin.hybris.project.view
 import com.intellij.ide.projectView.PresentationData
 import com.intellij.ide.projectView.ProjectViewNode
 import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.ProjectViewPane
 import com.intellij.ide.util.treeView.AbstractTreeNode
 import com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
@@ -36,10 +37,7 @@ class JunkProjectViewNode(
 
     override fun getChildren(): Collection<AbstractTreeNode<*>> = this.value
 
-    override fun contains(file: VirtualFile) = this.value
-        .filterIsInstance<ProjectViewNode<*>>()
-        .mapNotNull { it.virtualFile }
-        .any { it == file && file.path.startsWith(it.path) }
+    override fun contains(file: VirtualFile) = ProjectViewPane.canBeSelectedInProjectView(myProject, file)
 
     public override fun update(presentation: PresentationData) {
         with(presentation) {


### PR DESCRIPTION
Problem occurs when user tries to navigate to the class file which is part of the library only.