### PR TITLE
WSL Stuck on Import/Refresh

### DIFF
--- a/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
+++ b/src/com/intellij/idea/plugin/hybris/project/descriptors/DefaultHybrisProjectDescriptor.java
@@ -20,6 +20,8 @@
 package com.intellij.idea.plugin.hybris.project.descriptors;
 
 import com.google.common.collect.Sets;
+import com.intellij.execution.wsl.WSLDistribution;
+import com.intellij.execution.wsl.WslDistributionManager;
 import com.intellij.idea.plugin.hybris.common.HybrisConstants;
 import com.intellij.idea.plugin.hybris.project.descriptors.impl.*;
 import com.intellij.idea.plugin.hybris.project.exceptions.HybrisConfigurationException;
@@ -49,6 +51,7 @@ import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,6 +71,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.intellij.idea.plugin.hybris.common.utils.HybrisI18NBundleUtils.message;
 import static com.intellij.idea.plugin.hybris.project.descriptors.DefaultHybrisProjectDescriptor.DIRECTORY_TYPE.*;
@@ -560,7 +564,7 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
             LOG.info("Scanning for higher priority modules");
             for (final File nonHybrisDir : moduleRootMap.get(NON_HYBRIS)) {
                 final Map<DIRECTORY_TYPE, Set<File>> nonHybrisModuleRootMap = newModuleRootMap();
-                scanSubdirectories(nonHybrisModuleRootMap, excludedFromScanning, true, nonHybrisDir.toPath(), progressListenerProcessor);
+                scanForSubdirectories(nonHybrisModuleRootMap, excludedFromScanning, true, nonHybrisDir.toPath(), progressListenerProcessor);
                 final Set<File> hybrisModuleSet = nonHybrisModuleRootMap.get(HYBRIS);
                 if (hybrisModuleSet.isEmpty()) {
                     LOG.info("Confirmed module " + nonHybrisDir);
@@ -723,14 +727,23 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
             }
         }
 
-        scanSubdirectories(
-            moduleRootMap,
-            excludedFromScanning,
-            acceptOnlyHybrisModules,
-            rootProjectDirectory.toPath(),
-            progressListenerProcessor
-        );
+        scanForSubdirectories(moduleRootMap, excludedFromScanning, acceptOnlyHybrisModules, rootProjectDirectory.toPath(), progressListenerProcessor);
+    }
 
+    private void scanForSubdirectories(final Map<DIRECTORY_TYPE, Set<File>> moduleRootMap, final Set<File> excludedFromScanning, final boolean acceptOnlyHybrisModules, final Path rootProjectDirectory, final TaskProgressProcessor<File> progressListenerProcessor) {
+        if (isPathInWSLDistribution(rootProjectDirectory)) {
+            try {
+                scanSubdirectoriesWSL(moduleRootMap, excludedFromScanning, acceptOnlyHybrisModules, rootProjectDirectory, progressListenerProcessor);
+            } catch (IOException | InterruptedException e) {
+                LOG.error("Error while scanning subdirectories in wsl", e);
+            }
+        } else {
+            try {
+                scanSubdirectories(moduleRootMap, excludedFromScanning, acceptOnlyHybrisModules, rootProjectDirectory, progressListenerProcessor);
+            } catch (IOException | InterruptedException e) {
+                LOG.error("Error while scanning subdirectories", e);
+            }
+        }
     }
 
     private void scanSubdirectories(
@@ -761,6 +774,45 @@ public class DefaultHybrisProjectDescriptor implements HybrisProjectDescriptor {
                 findModuleRoots(moduleRootMap, excludedFromScanning, acceptOnlyHybrisModules, file.toFile(), progressListenerProcessor);
             }
             files.close();
+        }
+    }
+
+    private void scanSubdirectoriesWSL(@NotNull final Map<DIRECTORY_TYPE, Set<File>> moduleRootMap, final Set<File> excludedFromScanning, final boolean acceptOnlyHybrisModules, @NotNull final Path rootProjectDirectory, @Nullable final TaskProgressProcessor<File> progressListenerProcessor) throws InterruptedException, IOException {
+        if (!Files.isDirectory(rootProjectDirectory)) {
+            return;
+        }
+
+        try (final Stream<Path> stream = Files.list(rootProjectDirectory)) {
+            stream.filter(file -> {
+                try {
+                    return Objects.nonNull(file) && Files.isDirectory(file) && !isDirectoryExcluded(file) && (!Files.isSymbolicLink(file) || followSymlink);
+                } catch (Exception e) {
+                    LOG.error("Error while filtering directories", e);
+                    return false;
+                }
+            }).forEach(file -> {
+                try {
+                    findModuleRoots(moduleRootMap, excludedFromScanning, acceptOnlyHybrisModules, file.toFile(), progressListenerProcessor);
+                } catch (IOException | InterruptedException e) {
+                    LOG.error("Error while processing directories", e);
+                }
+            });
+        }
+    }
+
+
+    public static boolean isPathInWSLDistribution(@NotNull final Path rootProjectDirectory) {
+        try {
+            for (WSLDistribution distribution : WslDistributionManager.getInstance().getInstalledDistributions()) {
+                String wslRoot = String.valueOf(distribution.getUNCRootPath());
+                if (StringUtils.isNotBlank(wslRoot) && rootProjectDirectory.toString().startsWith(wslRoot)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            LOG.error("Error while checking if path is in WSL distribution", e);
+            return false;
         }
     }
 


### PR DESCRIPTION
WSL Stuck on Import/Refresh
* added isPathInWSLDistribution function for checking if importing project directory is in WSL
* with isPathInWSLDistribution if function return true scanSubdirectories will use wsl function for it will use Files.list instead of Files.newDirectoryStream

Signed-off-by: Burak Gürler gurlerburak9@gmail.com
