### PR TITLE
WSL option in Remote Connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [2024.3.4]
 
+### `Integrations` enhancements
+- Added Windows WSL support [#1292](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1292)
+
 ### `ImpEx` enhancements
 - Introduced enum value reference resolution in the Value Lines [#1296](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1296)
 - Added enum value completion in the Value Lines [#1297](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1297)

--- a/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
@@ -43,6 +43,7 @@ class RemoteConnectionSettings : BaseState(), Comparable<RemoteConnectionSetting
     var hostIP by string(HybrisConstants.DEFAULT_HOST_URL)
     var port by string(null)
     var isSsl by property(true)
+    var isWsl by property(false)
     var sslProtocol by string(HybrisConstants.DEFAULT_SSL_PROTOCOL)
 
     var solrWebroot by string("solr")

--- a/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
@@ -44,7 +44,6 @@ class RemoteConnectionSettings : BaseState(), Comparable<RemoteConnectionSetting
     var port by string(null)
     var isSsl by property(true)
     var sslProtocol by string(HybrisConstants.DEFAULT_SSL_PROTOCOL)
-    var isWsl by property(false)
 
     var solrWebroot by string("solr")
     var hacWebroot by string("")
@@ -65,8 +64,8 @@ class RemoteConnectionSettings : BaseState(), Comparable<RemoteConnectionSetting
     val generatedURL: String
         get() {
             return when (type) {
-                RemoteConnectionType.Hybris -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, hacWebroot, isWsl)
-                RemoteConnectionType.SOLR -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, solrWebroot, isWsl)
+                RemoteConnectionType.Hybris -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, hacWebroot)
+                RemoteConnectionType.SOLR -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, solrWebroot)
             }
         }
 

--- a/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
+++ b/src/com/intellij/idea/plugin/hybris/settings/RemoteConnectionSettings.kt
@@ -44,6 +44,7 @@ class RemoteConnectionSettings : BaseState(), Comparable<RemoteConnectionSetting
     var port by string(null)
     var isSsl by property(true)
     var sslProtocol by string(HybrisConstants.DEFAULT_SSL_PROTOCOL)
+    var isWsl by property(false)
 
     var solrWebroot by string("solr")
     var hacWebroot by string("")
@@ -64,8 +65,8 @@ class RemoteConnectionSettings : BaseState(), Comparable<RemoteConnectionSetting
     val generatedURL: String
         get() {
             return when (type) {
-                RemoteConnectionType.Hybris -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, hacWebroot)
-                RemoteConnectionType.SOLR -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, solrWebroot)
+                RemoteConnectionType.Hybris -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, hacWebroot, isWsl)
+                RemoteConnectionType.SOLR -> RemoteConnectionUtil.generateUrl(isSsl, hostIP, port, solrWebroot, isWsl)
             }
         }
 

--- a/src/com/intellij/idea/plugin/hybris/tools/remote/RemoteConnectionUtil.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/remote/RemoteConnectionUtil.kt
@@ -20,24 +20,20 @@ package com.intellij.idea.plugin.hybris.tools.remote
 
 import ai.grazie.utils.toLinkedSet
 import com.intellij.credentialStore.Credentials
-import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.properties.PropertyService
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.settings.components.DeveloperSettingsComponent
 import com.intellij.idea.plugin.hybris.settings.components.ProjectSettingsComponent
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.project.ProjectManager
-import org.apache.commons.lang3.StringUtils
 import java.util.*
 
 object RemoteConnectionUtil {
 
-    fun generateUrl(ssl: Boolean, host: String?, port: String?, webroot: String?, wsl: Boolean) = buildString {
+    fun generateUrl(ssl: Boolean, host: String?, port: String?, webroot: String?) = buildString {
         if (ssl) append(HybrisConstants.HTTPS_PROTOCOL)
         else append(HybrisConstants.HTTP_PROTOCOL)
-        if (wsl) append(findWslIpUsingProjectPath(host)?.trim() ?: "")
-        else append(host?.trim() ?: "")
+        append(host?.trim() ?: "")
         port
             ?.takeIf { it.isNotBlank() }
             ?.takeUnless { "443" == it && ssl }
@@ -60,22 +56,6 @@ object RemoteConnectionUtil {
             ?: ""
     }
 
-    fun findWslIpUsingProjectPath(host: String?): String? {
-        val projectPath = ProjectManager.getInstance().getOpenProjects().firstOrNull()?.basePath;
-        if (StringUtils.isEmpty(projectPath)) return host
-        val normalizedProjectPath = projectPath?.replace("/", "\\")
-        val installedDistros = WslDistributionManager.getInstance().installedDistributions
-        val matchingDistro = installedDistros.firstOrNull{ normalizedProjectPath.toString().startsWith(it.getUNCRootPath().toString()) }
-        return matchingDistro?.let { distro ->
-            try {
-                val readWslIpMethod = distro::class.java.getDeclaredMethod("readWslIp")
-                readWslIpMethod.isAccessible = true
-                readWslIpMethod.invoke(distro)?.toString()
-            } catch (e: Exception) {
-                host
-            }
-        } ?: host
-    }
 
     fun getActiveRemoteConnectionSettings(project: Project, type: RemoteConnectionType): RemoteConnectionSettings {
         val instances = getRemoteConnections(project, type)

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
@@ -48,6 +48,8 @@ import javax.swing.Action
 import javax.swing.JEditorPane
 import javax.swing.JLabel
 
+const val WSL_PROXY_CONNECT_LOCALHOST = "wsl.proxy.connect.localhost"
+
 abstract class AbstractRemoteConnectionDialog(
     protected val project: Project,
     parentComponent: Component,

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
@@ -167,9 +167,5 @@ abstract class AbstractRemoteConnectionDialog(
         hostTextField.text,
         portTextField.text,
         webrootTextField.text,
-        isWslCheckBox.isSelected
     )
-
-    protected fun generateWslIp() = RemoteConnectionUtil.findWslIpUsingProjectPath(hostTextField.text)
-
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
@@ -21,6 +21,7 @@ package com.intellij.idea.plugin.hybris.toolwindow
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
 import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionUtil
@@ -32,23 +33,20 @@ import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
-import com.intellij.ui.dsl.builder.Cell
-import com.intellij.ui.dsl.builder.text
+import com.intellij.ui.dsl.builder.*
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.ui.JBUI
 import java.awt.Component
 import java.awt.event.ActionEvent
 import java.io.Serial
 import java.util.*
-import javax.swing.Action
-import javax.swing.JComboBox
-import javax.swing.JEditorPane
-import javax.swing.JLabel
+import javax.swing.*
 
 const val WSL_PROXY_CONNECT_LOCALHOST = "wsl.proxy.connect.localhost"
 
@@ -71,7 +69,10 @@ abstract class AbstractRemoteConnectionDialog(
     protected lateinit var testConnectionLabel: Cell<JLabel>
     protected lateinit var testConnectionComment: Cell<JEditorPane>
     protected lateinit var isWslCheckBox: JBCheckBox
-    lateinit var wslDistributionComboBox: JComboBox<String>
+    private lateinit var wslDistributionComboBox: JComboBox<String>
+    private lateinit var wslProxyCheckBox: JBCheckBox
+    private lateinit var wslProxyWarningComment: JEditorPane
+    private lateinit var wslDistributionText: Cell<JLabel>
     private var testConnectionButton: Action = object : DialogWrapperAction("Test Connection") {
 
         @Serial
@@ -184,5 +185,62 @@ abstract class AbstractRemoteConnectionDialog(
     }
 
     fun isWindows() = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
+
+    fun Panel.wslHostConfiguration() {
+        val distributions = WslDistributionManager.getInstance().installedDistributions
+        row {
+            isWslCheckBox = checkBox("WSL")
+                .bindSelected(settings::isWsl)
+                .selected(false)
+                .visible(distributions.isNotEmpty())
+                .onChanged {
+                    val selected = isWslCheckBox.isSelected
+                    val multipleDistros = distributions.isNotEmpty()
+                    wslDistributionComboBox.isVisible = selected && multipleDistros
+                    wslDistributionText.visible(selected)
+                    wslProxyCheckBox.isVisible = selected
+                    wslProxyWarningComment.isVisible = selected
+                    urlPreviewLabel.text = generateUrl()
+                }
+                .component
+        }.layout(RowLayout.PARENT_GRID)
+        val installedDistros = distributions.map { it.msId }
+        if (installedDistros.isNotEmpty()) {
+            row {
+                wslDistributionText = label("WSL distribution:").visible(false)
+                wslDistributionComboBox = comboBox(DefaultComboBoxModel(installedDistros.toTypedArray()))
+                    .align(AlignX.FILL)
+                    .visible(false)
+                    .onChanged {
+                        updateWslIp(distributions)
+                    }
+                    .component
+            }.layout(RowLayout.PARENT_GRID)
+        } else {
+            row {
+                comment("No WSL distributions are installed.")
+                    .visible(false)
+                    .component
+            }.layout(RowLayout.PARENT_GRID)
+        }
+        row {
+            wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
+                .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
+                .visible(false)
+                .selected(Registry.`is`(WSL_PROXY_CONNECT_LOCALHOST))
+                .onChanged {
+                    Registry.run { get(WSL_PROXY_CONNECT_LOCALHOST).setValue(!`is`(WSL_PROXY_CONNECT_LOCALHOST)) }
+                    updateWslIp(distributions)
+                }
+                .component
+        }.layout(RowLayout.PARENT_GRID)
+        row {
+            wslProxyWarningComment =
+                comment("<strong>Warning:</strong> Connect to 127.0.0.1 on WSLProxy instead of public WSL IP which might be inaccessible due to routing issues.")
+                    .visible(false)
+                    .component
+        }.layout(RowLayout.PARENT_GRID)
+    }
+
 
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
@@ -20,6 +20,7 @@ package com.intellij.idea.plugin.hybris.toolwindow
 
 import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.Credentials
+import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionUtil
@@ -45,6 +46,7 @@ import java.awt.event.ActionEvent
 import java.io.Serial
 import java.util.*
 import javax.swing.Action
+import javax.swing.JComboBox
 import javax.swing.JEditorPane
 import javax.swing.JLabel
 
@@ -69,6 +71,7 @@ abstract class AbstractRemoteConnectionDialog(
     protected lateinit var testConnectionLabel: Cell<JLabel>
     protected lateinit var testConnectionComment: Cell<JEditorPane>
     protected lateinit var isWslCheckBox: JBCheckBox
+    lateinit var wslDistributionComboBox: JComboBox<String>
     private var testConnectionButton: Action = object : DialogWrapperAction("Test Connection") {
 
         @Serial
@@ -170,4 +173,16 @@ abstract class AbstractRemoteConnectionDialog(
         portTextField.text,
         webrootTextField.text,
     )
+
+    fun updateWslIp(distributions: List<WSLDistribution>) {
+        val wslIp = distributions.find { it.msId == wslDistributionComboBox.selectedItem as? String }
+            ?.wslIpAddress
+            ?.toString()
+            ?.replace("/", "")
+            ?: ""
+        hostTextField.text = wslIp
+    }
+
+    fun isWindows() = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")
+
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/AbstractRemoteConnectionDialog.kt
@@ -66,6 +66,7 @@ abstract class AbstractRemoteConnectionDialog(
     protected lateinit var passwordTextField: JBPasswordField
     protected lateinit var testConnectionLabel: Cell<JLabel>
     protected lateinit var testConnectionComment: Cell<JEditorPane>
+    protected lateinit var isWslCheckBox: JBCheckBox
     private var testConnectionButton: Action = object : DialogWrapperAction("Test Connection") {
 
         @Serial
@@ -165,7 +166,10 @@ abstract class AbstractRemoteConnectionDialog(
         sslProtocolCheckBox.isSelected,
         hostTextField.text,
         portTextField.text,
-        webrootTextField.text
+        webrootTextField.text,
+        isWslCheckBox.isSelected
     )
+
+    protected fun generateWslIp() = RemoteConnectionUtil.findWslIpUsingProjectPath(hostTextField.text)
 
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
@@ -19,26 +19,17 @@
 package com.intellij.idea.plugin.hybris.toolwindow
 
 import com.intellij.credentialStore.Credentials
-import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionScope
 import com.intellij.idea.plugin.hybris.tools.remote.http.HybrisHacHttpClient
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
-import com.intellij.openapi.util.registry.Registry
 import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.SimpleListCellRenderer
-import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.layout.selected
 import java.awt.Component
-import java.util.*
-import javax.swing.DefaultComboBoxModel
-import javax.swing.JComboBox
-import javax.swing.JEditorPane
-import javax.swing.JLabel
 
 class RemoteHacConnectionDialog(
     project: Project,
@@ -47,9 +38,6 @@ class RemoteHacConnectionDialog(
 ) : AbstractRemoteConnectionDialog(project, parentComponent, settings, "Remote SAP Commerce Instance") {
 
     private lateinit var sslProtocolComboBox: ComboBox<String>
-    private lateinit var wslProxyCheckBox: JBCheckBox
-    private lateinit var wslProxyWarningComment: JEditorPane
-    private lateinit var wslDistributionText: Cell<JLabel>
 
 
     override fun createTestSettings() = with(RemoteConnectionSettings()) {
@@ -159,59 +147,7 @@ class RemoteHacConnectionDialog(
                     .component
             }.layout(RowLayout.PARENT_GRID)
             if (isWindows()) {
-                val distributions = WslDistributionManager.getInstance().installedDistributions
-                row {
-                    isWslCheckBox = checkBox("WSL")
-                        .bindSelected(settings::isWsl)
-                        .selected(false)
-                        .visible(distributions.isNotEmpty())
-                        .onChanged {
-                            val selected = isWslCheckBox.isSelected
-                            val multipleDistros = distributions.isNotEmpty()
-                            wslDistributionComboBox.isVisible = selected && multipleDistros
-                            wslDistributionText.visible(selected)
-                            wslProxyCheckBox.isVisible = selected
-                            wslProxyWarningComment.isVisible = selected
-                            urlPreviewLabel.text = generateUrl()
-                        }
-                        .component
-                }.layout(RowLayout.PARENT_GRID)
-                val installedDistros = distributions.map { it.msId }
-                if (installedDistros.isNotEmpty()) {
-                    row {
-                        wslDistributionText = label("WSL distribution:").visible(false)
-                        wslDistributionComboBox = comboBox(DefaultComboBoxModel(installedDistros.toTypedArray()))
-                            .align(AlignX.FILL)
-                            .visible(false)
-                            .onChanged {
-                                updateWslIp(distributions)
-                            }
-                            .component
-                    }.layout(RowLayout.PARENT_GRID)
-                } else {
-                    row {
-                        comment("No WSL distributions are installed.")
-                            .visible(false)
-                            .component
-                    }.layout(RowLayout.PARENT_GRID)
-                }
-                row {
-                    wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
-                        .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
-                        .visible(false)
-                        .selected(Registry.`is`(WSL_PROXY_CONNECT_LOCALHOST))
-                        .onChanged {
-                            Registry.run { get(WSL_PROXY_CONNECT_LOCALHOST).setValue(!`is`(WSL_PROXY_CONNECT_LOCALHOST)) }
-                            updateWslIp(distributions)
-                        }
-                        .component
-                }.layout(RowLayout.PARENT_GRID)
-                row {
-                    wslProxyWarningComment =
-                        comment("<strong>Warning:</strong> Connect to 127.0.0.1 on WSLProxy instead of public WSL IP which might be inaccessible due to routing issues.")
-                            .visible(false)
-                            .component
-                }.layout(RowLayout.PARENT_GRID)
+                wslHostConfiguration()
             }
         }
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
@@ -47,7 +47,6 @@ class RemoteHacConnectionDialog(
 ) : AbstractRemoteConnectionDialog(project, parentComponent, settings, "Remote SAP Commerce Instance") {
 
     private lateinit var sslProtocolComboBox: ComboBox<String>
-    private lateinit var wslDistributionComboBox: JComboBox<String>
     private lateinit var wslProxyCheckBox: JBCheckBox
     private lateinit var wslProxyWarningComment: JEditorPane
     private lateinit var wslDistributionText: Cell<JLabel>
@@ -58,6 +57,7 @@ class RemoteHacConnectionDialog(
         hostIP = hostTextField.text
         port = portTextField.text
         isSsl = sslProtocolCheckBox.isSelected
+        isWsl = isWslCheckBox.isSelected
         sslProtocol = sslProtocolComboBox.selectedItem?.toString() ?: ""
         hacWebroot = webrootTextField.text
         credentials = Credentials(usernameTextField.text, String(passwordTextField.password))
@@ -158,10 +158,11 @@ class RemoteHacConnectionDialog(
                     .onChanged { urlPreviewLabel.text = generateUrl() }
                     .component
             }.layout(RowLayout.PARENT_GRID)
-            if (System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")) {
+            if (isWindows()) {
                 val distributions = WslDistributionManager.getInstance().installedDistributions
                 row {
                     isWslCheckBox = checkBox("WSL")
+                        .bindSelected(settings::isWsl)
                         .selected(false)
                         .visible(distributions.isNotEmpty())
                         .onChanged {
@@ -234,12 +235,4 @@ class RemoteHacConnectionDialog(
             }.layout(RowLayout.PARENT_GRID)
         }
     }
-
-    private fun updateWslIp(distributions: List<WSLDistribution>) {
-        val selected = wslDistributionComboBox.selectedItem as? String
-        val wslIp = distributions.find { it.msId == selected }?.wslIpAddress.toString()
-        hostTextField.text = wslIp?.replace("/", "").orEmpty()
-        urlPreviewLabel.text = generateUrl()
-    }
-
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
@@ -144,6 +144,13 @@ class RemoteHacConnectionDialog(
                     .onChanged { urlPreviewLabel.text = generateUrl() }
                     .component
             }.layout(RowLayout.PARENT_GRID)
+            row {
+                isWslCheckBox = checkBox("WSL")
+                    .selected(settings.isWsl)
+                    .onChanged { urlPreviewLabel.text = generateUrl() }
+                    .onChanged { hostTextField.text = generateWslIp() }
+                    .component
+            }.layout(RowLayout.PARENT_GRID)
         }
 
         group("Credentials") {

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteHacConnectionDialog.kt
@@ -198,9 +198,9 @@ class RemoteHacConnectionDialog(
                     wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
                         .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
                         .visible(false)
-                        .selected(Registry.`is`("wsl.proxy.connect.localhost"))
+                        .selected(Registry.`is`(WSL_PROXY_CONNECT_LOCALHOST))
                         .onChanged {
-                            Registry.run { get("wsl.proxy.connect.localhost").setValue(!`is`("wsl.proxy.connect.localhost")) }
+                            Registry.run { get(WSL_PROXY_CONNECT_LOCALHOST).setValue(!`is`(WSL_PROXY_CONNECT_LOCALHOST)) }
                             updateWslIp(distributions)
                         }
                         .component
@@ -236,9 +236,9 @@ class RemoteHacConnectionDialog(
     }
 
     private fun updateWslIp(distributions: List<WSLDistribution>) {
-        val selected = wslDistributionComboBox.selectedItem as String
+        val selected = wslDistributionComboBox.selectedItem as? String
         val wslIp = distributions.find { it.msId == selected }?.wslIpAddress.toString()
-        hostTextField.text = wslIp.replace("/", "")
+        hostTextField.text = wslIp?.replace("/", "").orEmpty()
         urlPreviewLabel.text = generateUrl()
     }
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
@@ -19,34 +19,21 @@
 package com.intellij.idea.plugin.hybris.toolwindow
 
 import com.intellij.credentialStore.Credentials
-import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionScope
 import com.intellij.idea.plugin.hybris.tools.remote.http.solr.impl.SolrHttpClient
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.registry.Registry
 import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.SimpleListCellRenderer
-import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import java.awt.Component
-import java.util.*
-import javax.swing.DefaultComboBoxModel
-import javax.swing.JComboBox
-import javax.swing.JEditorPane
-import javax.swing.JLabel
 
 class RemoteSolrConnectionDialog(
     project: Project,
     parentComponent: Component,
     settings: RemoteConnectionSettings
 ) : AbstractRemoteConnectionDialog(project, parentComponent, settings, "Remote SOLR Instance") {
-
-    private lateinit var wslProxyCheckBox: JBCheckBox
-    private lateinit var wslProxyWarningComment: JEditorPane
-    private lateinit var wslDistributionText: Cell<JLabel>
 
     override fun panel() = panel {
         row {
@@ -128,59 +115,7 @@ class RemoteSolrConnectionDialog(
                     .component
             }.layout(RowLayout.PARENT_GRID)
             if (isWindows()) {
-                val distributions = WslDistributionManager.getInstance().installedDistributions
-                row {
-                    isWslCheckBox = checkBox("WSL")
-                        .bindSelected(settings::isWsl)
-                        .selected(false)
-                        .visible(distributions.isNotEmpty())
-                        .onChanged {
-                            val selected = isWslCheckBox.isSelected
-                            val multipleDistros = distributions.isNotEmpty()
-                            wslDistributionComboBox.isVisible = selected && multipleDistros
-                            wslDistributionText.visible(selected)
-                            wslProxyCheckBox.isVisible = selected
-                            wslProxyWarningComment.isVisible = selected
-                            urlPreviewLabel.text = generateUrl()
-                        }
-                        .component
-                }.layout(RowLayout.PARENT_GRID)
-                val installedDistros = distributions.map { it.msId }
-                if (installedDistros.isNotEmpty()) {
-                    row {
-                        wslDistributionText = label("WSL distribution:").visible(false)
-                        wslDistributionComboBox = comboBox(DefaultComboBoxModel(installedDistros.toTypedArray()))
-                            .align(AlignX.FILL)
-                            .visible(false)
-                            .onChanged {
-                                updateWslIp(distributions)
-                            }
-                            .component
-                    }.layout(RowLayout.PARENT_GRID)
-                } else {
-                    row {
-                        comment("No WSL distributions are installed.")
-                            .visible(false)
-                            .component
-                    }.layout(RowLayout.PARENT_GRID)
-                }
-                row {
-                    wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
-                        .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
-                        .visible(false)
-                        .selected(Registry.`is`(WSL_PROXY_CONNECT_LOCALHOST))
-                        .onChanged {
-                            Registry.run { get(WSL_PROXY_CONNECT_LOCALHOST).setValue(!`is`(WSL_PROXY_CONNECT_LOCALHOST)) }
-                            updateWslIp(distributions)
-                        }
-                        .component
-                }.layout(RowLayout.PARENT_GRID)
-                row {
-                    wslProxyWarningComment =
-                        comment("<strong>Warning:</strong> Connect to 127.0.0.1 on WSLProxy instead of public WSL IP which might be inaccessible due to routing issues.")
-                            .visible(false)
-                            .component
-                }.layout(RowLayout.PARENT_GRID)
+                wslHostConfiguration()
             }
         }
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
@@ -19,21 +19,35 @@
 package com.intellij.idea.plugin.hybris.toolwindow
 
 import com.intellij.credentialStore.Credentials
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionScope
 import com.intellij.idea.plugin.hybris.tools.remote.http.solr.impl.SolrHttpClient
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import java.awt.Component
+import java.util.*
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JComboBox
+import javax.swing.JEditorPane
+import javax.swing.JLabel
 
 class RemoteSolrConnectionDialog(
     project: Project,
     parentComponent: Component,
     settings: RemoteConnectionSettings
 ) : AbstractRemoteConnectionDialog(project, parentComponent, settings, "Remote SOLR Instance") {
+
+    private lateinit var wslDistributionComboBox: JComboBox<String>
+    private lateinit var wslProxyCheckBox: JBCheckBox
+    private lateinit var wslProxyWarningComment: JEditorPane
+    private lateinit var wslDistributionText: Cell<JLabel>
 
     override fun panel() = panel {
         row {
@@ -114,13 +128,60 @@ class RemoteSolrConnectionDialog(
                     .onChanged { urlPreviewLabel.text = generateUrl() }
                     .component
             }.layout(RowLayout.PARENT_GRID)
-            row {
-                isWslCheckBox = checkBox("WSL")
-                    .selected(settings.isWsl)
-                    .onChanged { urlPreviewLabel.text = generateUrl() }
-                    .onChanged { hostTextField.text = generateWslIp() }
-                    .component
-            }.layout(RowLayout.PARENT_GRID)
+            if (System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")) {
+                val distributions = WslDistributionManager.getInstance().installedDistributions
+                row {
+                    isWslCheckBox = checkBox("WSL")
+                        .selected(false)
+                        .visible(distributions.isNotEmpty())
+                        .onChanged {
+                            val selected = isWslCheckBox.isSelected
+                            val multipleDistros = distributions.isNotEmpty()
+                            wslDistributionComboBox.isVisible = selected && multipleDistros
+                            wslDistributionText.visible(selected)
+                            wslProxyCheckBox.isVisible = selected
+                            wslProxyWarningComment.isVisible = selected
+                            urlPreviewLabel.text = generateUrl()
+                        }
+                        .component
+                }.layout(RowLayout.PARENT_GRID)
+                val installedDistros = distributions.map { it.msId }
+                if (installedDistros.isNotEmpty()) {
+                    row {
+                        wslDistributionText = label("WSL distribution:").visible(false)
+                        wslDistributionComboBox = comboBox(DefaultComboBoxModel(installedDistros.toTypedArray()))
+                            .align(AlignX.FILL)
+                            .visible(false)
+                            .onChanged {
+                                updateWslIp(distributions)
+                            }
+                            .component
+                    }.layout(RowLayout.PARENT_GRID)
+                } else {
+                    row {
+                        comment("No WSL distributions are installed.")
+                            .visible(false)
+                            .component
+                    }.layout(RowLayout.PARENT_GRID)
+                }
+                row {
+                    wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
+                        .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
+                        .visible(false)
+                        .selected(Registry.`is`("wsl.proxy.connect.localhost"))
+                        .onChanged {
+                            Registry.run { get("wsl.proxy.connect.localhost").setValue(!`is`("wsl.proxy.connect.localhost")) }
+                            updateWslIp(distributions)
+                        }
+                        .component
+                }.layout(RowLayout.PARENT_GRID)
+                row {
+                    wslProxyWarningComment =
+                        comment("<strong>Warning:</strong> Connect to 127.0.0.1 on WSLProxy instead of public WSL IP which might be inaccessible due to routing issues.")
+                            .visible(false)
+                            .component
+                }.layout(RowLayout.PARENT_GRID)
+            }
         }
 
         group("Credentials") {
@@ -160,6 +221,13 @@ class RemoteSolrConnectionDialog(
         null
     } catch (e: Exception) {
         e.message ?: ""
+    }
+
+    private fun updateWslIp(distributions: List<WSLDistribution>) {
+        val selected = wslDistributionComboBox.selectedItem as String
+        val wslIp = distributions.find { it.msId == selected }?.wslIpAddress.toString()
+        hostTextField.text = wslIp.replace("/", "")
+        urlPreviewLabel.text = generateUrl()
     }
 
 }

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
@@ -114,6 +114,13 @@ class RemoteSolrConnectionDialog(
                     .onChanged { urlPreviewLabel.text = generateUrl() }
                     .component
             }.layout(RowLayout.PARENT_GRID)
+            row {
+                isWslCheckBox = checkBox("WSL")
+                    .selected(settings.isWsl)
+                    .onChanged { urlPreviewLabel.text = generateUrl() }
+                    .onChanged { hostTextField.text = generateWslIp() }
+                    .component
+            }.layout(RowLayout.PARENT_GRID)
         }
 
         group("Credentials") {

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
@@ -168,9 +168,9 @@ class RemoteSolrConnectionDialog(
                     wslProxyCheckBox = checkBox("Enable wsl.proxy.connect.localhost")
                         .comment("This will use the wsl.proxy.connect.localhost registry setting if available.")
                         .visible(false)
-                        .selected(Registry.`is`("wsl.proxy.connect.localhost"))
+                        .selected(Registry.`is`(WSL_PROXY_CONNECT_LOCALHOST))
                         .onChanged {
-                            Registry.run { get("wsl.proxy.connect.localhost").setValue(!`is`("wsl.proxy.connect.localhost")) }
+                            Registry.run { get(WSL_PROXY_CONNECT_LOCALHOST).setValue(!`is`(WSL_PROXY_CONNECT_LOCALHOST)) }
                             updateWslIp(distributions)
                         }
                         .component
@@ -224,9 +224,9 @@ class RemoteSolrConnectionDialog(
     }
 
     private fun updateWslIp(distributions: List<WSLDistribution>) {
-        val selected = wslDistributionComboBox.selectedItem as String
+        val selected = wslDistributionComboBox.selectedItem as? String
         val wslIp = distributions.find { it.msId == selected }?.wslIpAddress.toString()
-        hostTextField.text = wslIp.replace("/", "")
+        hostTextField.text = wslIp?.replace("/", "").orEmpty()
         urlPreviewLabel.text = generateUrl()
     }
 

--- a/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
+++ b/src/com/intellij/idea/plugin/hybris/toolwindow/RemoteSolrConnectionDialog.kt
@@ -44,7 +44,6 @@ class RemoteSolrConnectionDialog(
     settings: RemoteConnectionSettings
 ) : AbstractRemoteConnectionDialog(project, parentComponent, settings, "Remote SOLR Instance") {
 
-    private lateinit var wslDistributionComboBox: JComboBox<String>
     private lateinit var wslProxyCheckBox: JBCheckBox
     private lateinit var wslProxyWarningComment: JEditorPane
     private lateinit var wslDistributionText: Cell<JLabel>
@@ -128,10 +127,11 @@ class RemoteSolrConnectionDialog(
                     .onChanged { urlPreviewLabel.text = generateUrl() }
                     .component
             }.layout(RowLayout.PARENT_GRID)
-            if (System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win")) {
+            if (isWindows()) {
                 val distributions = WslDistributionManager.getInstance().installedDistributions
                 row {
                     isWslCheckBox = checkBox("WSL")
+                        .bindSelected(settings::isWsl)
                         .selected(false)
                         .visible(distributions.isNotEmpty())
                         .onChanged {
@@ -210,6 +210,7 @@ class RemoteSolrConnectionDialog(
         hostIP = hostTextField.text
         port = portTextField.text
         isSsl = sslProtocolCheckBox.isSelected
+        isWsl = isWslCheckBox.isSelected
         solrWebroot = webrootTextField.text
         credentials = Credentials(usernameTextField.text, String(passwordTextField.password))
         this
@@ -222,12 +223,4 @@ class RemoteSolrConnectionDialog(
     } catch (e: Exception) {
         e.message ?: ""
     }
-
-    private fun updateWslIp(distributions: List<WSLDistribution>) {
-        val selected = wslDistributionComboBox.selectedItem as? String
-        val wslIp = distributions.find { it.msId == selected }?.wslIpAddress.toString()
-        hostTextField.text = wslIp?.replace("/", "").orEmpty()
-        urlPreviewLabel.text = generateUrl()
-    }
-
 }


### PR DESCRIPTION
Signed-off-by: Burak Gürler gurlerburak9@gmail.com

WSL option In Remote Connections.

* Added `isWslCheckBox` to toggle WSL mode in remote connection dialogs.
* Dynamically show/hide WSL-related UI elements when OS is Windows
* Added support for `wsl.proxy.connect.localhost` registry setting
![hac](https://github.com/user-attachments/assets/d5f5eb37-3e07-429f-8e5a-2554430cd3e0)
![solr](https://github.com/user-attachments/assets/b13415d4-7206-4454-bcc9-1d7b25e62820)
