### PR TITLE
Added reference resolution & code contribution for various `i18n` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### `Cockpit NG` enhancements
 - Incorporated Global Cockpit NG Meta Model into new Meta evaluation approach [#1356](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1356)
+- Added reference resolution & code contribution for various `i18n` attributes [#1357](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1357)
 
 ### `items.xml` inspection rules
 - Item Type `metatype` must be a type extending ComposedType [#1346](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1346)

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/CngPatterns.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2024 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -35,6 +35,44 @@ object CngPatterns {
     private const val CONFIG_CONTEXT = "context"
     private val cngConfigFile = DomPatterns.inDomFile(Config::class.java)
     private val cngWidgetsFile = DomPatterns.inDomFile(Widgets::class.java)
+
+    val I18N_PROPERTY = XmlPatterns.or(
+        attributeValue("label", "attribute", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("name", "section", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("description", "section", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("name", "essentialSection", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("name", "tab", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("name", "panel", "editorArea", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_EDITOR_AREA)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+
+        attributeValue("label", "step", "flow", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_WIZARD_CONFIG)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("sublabel", "step", "flow", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_WIZARD_CONFIG)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("label", "custom", "flow", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_WIZARD_CONFIG)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+
+        attributeValue("label", "column", "list-view", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_CONFIG_SIMPLE_LIST)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+
+        attributeValue("label", "data-quality-group", "summary-view", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_SUMMARY_VIEW)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("label", "custom-attribute", "summary-view", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_SUMMARY_VIEW)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+        attributeValue("name", "section", "summary-view", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_SUMMARY_VIEW)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+
+        attributeValue("label", "option", "value-chooser", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_VALUE_CHOOSER)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+
+        attributeValue("name", "section", "compare-view", CngConfigDomFileDescription.NAMESPACE_COCKPIT_NG_COMPONENT_COMPARE_VIEW)
+            .inside(XmlPatterns.xmlTag().withLocalName(CONFIG_CONTEXT)).inFile(cngConfigFile),
+    )
 
     val WIDGET_SETTING = widgetPattern("key", "setting")
 

--- a/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/cockpitng/psi/contributor/CngReferenceContributor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2024 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -17,8 +17,10 @@
  */
 package com.intellij.idea.plugin.hybris.system.cockpitng.psi.contributor
 
+import com.intellij.idea.plugin.hybris.project.utils.Plugin
 import com.intellij.idea.plugin.hybris.system.cockpitng.psi.CngPatterns
 import com.intellij.idea.plugin.hybris.system.cockpitng.psi.provider.*
+import com.intellij.lang.properties.PropertiesReferenceProvider
 import com.intellij.psi.PsiReferenceContributor
 import com.intellij.psi.PsiReferenceRegistrar
 
@@ -73,5 +75,12 @@ class CngReferenceContributor : PsiReferenceContributor() {
             CngPatterns.WIDGET_SETTING,
             CngWidgetSettingReferenceProvider()
         )
+
+        Plugin.PROPERTIES.ifActive {
+            registrar.registerReferenceProvider(
+                CngPatterns.I18N_PROPERTY,
+                PropertiesReferenceProvider()
+            )
+        }
     }
 }


### PR DESCRIPTION
<img width="936" alt="Screenshot 2025-05-25 at 19 06 36" src="https://github.com/user-attachments/assets/071b0845-f5cd-4a45-8dc3-261faa2511a4" />
