### PR TITLE
ImpEx | Prefer macro references over `&DocId` or column type specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added support for custom collection delimiter to inject references within _collection_ columns [#1370](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1370)
 - Added reference support for nested `ComposedType` attributes within _item_ columns [#1371](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1371)
 - Added support for multiple Document ID `&DocId` references within `_collection_` columns [#1372](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1372)
+- Prefer macro references over `&DocId` or column type specific [#1373](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1373)
 
 ### `Terminal` integration
 - Added support of the `Terminal` plugin and set default directory to the project root for new Terminal Windows [#1342](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1342)

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -252,6 +252,9 @@ object HybrisConstants {
 
     private const val JAVA_LANG_PREFIX = "java.lang."
 
+    const val IMPEX_PREFIX_DOC_ID = "&"
+    const val IMPEX_PREFIX_MACRO = "$"
+
     const val BS_TYPE_OBJECT = "java.lang.Object"
     const val BS_SIGN_LESS_THAN = "<"
     const val BS_SIGN_GREATER_THAN = ">"

--- a/src/com/intellij/idea/plugin/hybris/impex/lang/refactoring/ImpExRenameInputValidator.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/lang/refactoring/ImpExRenameInputValidator.kt
@@ -17,6 +17,7 @@
  */
 package com.intellij.idea.plugin.hybris.impex.lang.refactoring
 
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexDocumentIdDec
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexDocumentIdUsage
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexMacroNameDec
@@ -41,10 +42,10 @@ class ImpExRenameInputValidator : RenameInputValidator {
 
     override fun isInputValid(newName: String, element: PsiElement, context: ProcessingContext) = when (element) {
         is ImpexDocumentIdDec,
-        is ImpexDocumentIdUsage -> newName.startsWith("&")
+        is ImpexDocumentIdUsage -> newName.startsWith(HybrisConstants.IMPEX_PREFIX_DOC_ID)
 
         is ImpexMacroNameDec,
-        is ImpexMacroUsageDec -> newName.startsWith("$")
+        is ImpexMacroUsageDec -> newName.startsWith(HybrisConstants.IMPEX_PREFIX_MACRO)
 
         else -> false
     }

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExDocumentIdUsageReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExDocumentIdUsageReference.kt
@@ -44,10 +44,6 @@ class ImpExDocumentIdUsageReference(
     override fun getVariants(): Array<LookupElementBuilder> = CachedValuesManager.getManager(element.project)
         .getParameterizedCachedValue(element, KEY_LOOKUP_ELEMENTS, PROVIDER_LOOKUP_ELEMENTS, false, this)
 
-//    override fun resolve(): PsiElement? = multiResolve(false)
-//        .lastOrNull()
-//        ?.element
-
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> = CachedValuesManager.getManager(element.project)
         .getParameterizedCachedValue(element, cacheKeyResolvedResults, PROVIDER_RESOLVED_RESULTS, false, this)
 

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExValueTSClassifierReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExValueTSClassifierReference.kt
@@ -49,10 +49,6 @@ class ImpExValueTSClassifierReference(
         .getCompletions(*allowedTypes.toTypedArray())
         .toTypedArray()
 
-//    override fun resolve(): PsiElement? = multiResolve(false)
-//        .lastOrNull()
-//        ?.element
-
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val indicator = ProgressManager.getInstance().progressIndicator
         if (indicator != null && indicator.isCanceled) return ResolveResult.EMPTY_ARRAY

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExValueTSEnumReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpExValueTSEnumReference.kt
@@ -63,10 +63,6 @@ abstract class ImpExValueTSEnumReference(
         ?.toTypedArray()
         ?: emptyArray()
 
-//    override fun resolve(): PsiElement? = multiResolve(false)
-//        .lastOrNull()
-//        ?.element
-
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val indicator = ProgressManager.getInstance().progressIndicator
         if (indicator != null && indicator.isCanceled) return ResolveResult.EMPTY_ARRAY


### PR DESCRIPTION
### before
<img width="1618" alt="Screenshot 2025-05-30 at 22 05 03" src="https://github.com/user-attachments/assets/460203a4-51fb-45d0-b9e1-42bbbd58e524" />


### after

<img width="1709" alt="Screenshot 2025-05-30 at 22 06 35" src="https://github.com/user-attachments/assets/359c37d7-6d69-4ae1-876d-de70f254e0b9" />
<img width="1635" alt="Screenshot 2025-05-30 at 22 06 57" src="https://github.com/user-attachments/assets/ef040ea8-6b64-448d-95b5-16dc9df3b66a" />
