### PR TITLE
ImpEx | Added code completion & reference resolution for User Rights `Type` column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added new configurable setting _First row is header_ for `Data Edit` mode [#1394](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1394)
 - Added new configurable setting _Trim whitespace_ for `Data Edit` mode [#1395](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1395)
 - Added folding for macros usages in the header line [#1401](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1401)
+- Added code completion & reference resolution for User Rights `Type` column [#1402](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1402)
 
 ### `Access Control Lists` enhancements
 - Create Type/attributes references only within `Target` column [#1400](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1400)

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -280,6 +280,8 @@ object HybrisConstants {
     const val TS_TYPE_ENUMERATION_VALUE = "EnumerationValue"
     const val TS_TYPE_ATTRIBUTE_DESCRIPTOR = "AttributeDescriptor"
     const val TS_TYPE_RELATION_DESCRIPTOR = "RelationDescriptor"
+    const val TS_TYPE_USER = "User"
+    const val TS_TYPE_USER_GROUP = "UserGroup"
     const val TS_META_VIEW_TYPE = "ViewType"
     const val TS_COMPOSED_TYPE = "ComposedType"
     const val TS_JAVA_LANG_PREFIX = JAVA_LANG_PREFIX

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexUserRightsSingleValueMixin.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/impl/ImpexUserRightsSingleValueMixin.kt
@@ -21,11 +21,14 @@ package com.intellij.idea.plugin.hybris.impex.psi.impl
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexTypes
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexUserRightsAttributeValue
 import com.intellij.idea.plugin.hybris.impex.psi.ImpexUserRightsSingleValue
+import com.intellij.idea.plugin.hybris.impex.psi.references.ImpexAclTypeReference
 import com.intellij.idea.plugin.hybris.impex.psi.references.ImpexTSItemReference
 import com.intellij.idea.plugin.hybris.impex.psi.references.ImpexUserRightsTSAttributeReference
 import com.intellij.idea.plugin.hybris.psi.impl.ASTWrapperReferencePsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.removeUserData
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.firstLeaf
@@ -33,8 +36,11 @@ import java.io.Serial
 
 abstract class ImpexUserRightsSingleValueMixin(astNode: ASTNode) : ASTWrapperReferencePsiElement(astNode), ImpexUserRightsSingleValue {
 
-    override fun createReference() = if (headerParameter?.firstLeaf()?.elementType == ImpexTypes.TARGET) ImpexTSItemReference(this)
-    else null
+    override fun createReference(): PsiReferenceBase<out PsiElement>? = when (headerParameter?.firstLeaf()?.elementType) {
+        ImpexTypes.TYPE -> ImpexAclTypeReference(this)
+        ImpexTypes.TARGET -> ImpexTSItemReference(this)
+        else -> null
+    }
 
     override fun subtreeChanged() {
         removeUserData(ImpexTSItemReference.CACHE_KEY)

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexAclTypeReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexAclTypeReference.kt
@@ -77,7 +77,7 @@ class ImpexAclTypeReference(owner: PsiElement) : TSReferenceBase<PsiElement>(own
                 findMetaItemByName(HybrisConstants.TS_TYPE_USER_GROUP),
                 findMetaItemByName(HybrisConstants.TS_TYPE_USER)
             )
-                .flatMap { it.allChildren }
+                .flatMap { it.hierarchy }
         }
     }
 }

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexAclTypeReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexAclTypeReference.kt
@@ -1,0 +1,83 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.intellij.idea.plugin.hybris.impex.psi.references
+
+import com.intellij.codeInsight.highlighting.HighlightedReference
+import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.psi.reference.TSReferenceBase
+import com.intellij.idea.plugin.hybris.psi.util.PsiUtils
+import com.intellij.idea.plugin.hybris.system.type.codeInsight.lookup.TSLookupElementFactory
+import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
+import com.intellij.idea.plugin.hybris.system.type.meta.TSModificationTracker
+import com.intellij.idea.plugin.hybris.system.type.meta.model.TSGlobalMetaItem
+import com.intellij.idea.plugin.hybris.system.type.psi.reference.result.ItemResolveResult
+import com.intellij.openapi.components.service
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.ParameterizedCachedValue
+import com.intellij.psi.util.ParameterizedCachedValueProvider
+
+class ImpexAclTypeReference(owner: PsiElement) : TSReferenceBase<PsiElement>(owner), HighlightedReference {
+
+    override fun getVariants() = getAllowedVariants(element)
+        .mapNotNull { TSLookupElementFactory.build(it) }
+        .toTypedArray()
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val indicator = ProgressManager.getInstance().progressIndicator
+        if (indicator != null && indicator.isCanceled) return ResolveResult.EMPTY_ARRAY
+
+        return CachedValuesManager.getManager(project)
+            .getParameterizedCachedValue(element, CACHE_KEY, provider, false, this)
+            .let { PsiUtils.getValidResults(it) }
+    }
+
+    companion object {
+        private val CACHE_KEY = Key.create<ParameterizedCachedValue<Array<ResolveResult>, ImpexAclTypeReference>>("HYBRIS_TS_CACHED_REFERENCE")
+
+        private val provider = ParameterizedCachedValueProvider<Array<ResolveResult>, ImpexAclTypeReference> { ref ->
+            val lookingForName = ref.value
+            val project = ref.project
+
+            val results: Array<ResolveResult> = TSMetaModelAccess.getInstance(project).findMetaItemByName(lookingForName)
+                ?.takeIf { getAllowedVariants(ref.element).contains(it) }
+                ?.declarations
+                ?.map { meta -> ItemResolveResult(meta) }
+                ?.toTypedArray()
+                ?: ResolveResult.EMPTY_ARRAY
+
+            // no need to track with PsiModificationTracker.MODIFICATION_COUNT due manual cache reset via custom Mixin
+            CachedValueProvider.Result.create(
+                results,
+                project.service<TSModificationTracker>()
+            )
+        }
+
+        private fun getAllowedVariants(element: PsiElement): Collection<TSGlobalMetaItem> = with(TSMetaModelAccess.getInstance(element.project)) {
+            listOfNotNull(
+                findMetaItemByName(HybrisConstants.TS_TYPE_USER_GROUP),
+                findMetaItemByName(HybrisConstants.TS_TYPE_USER)
+            )
+                .flatMap { it.allChildren }
+        }
+    }
+}

--- a/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexTSSubTypeItemReference.kt
+++ b/src/com/intellij/idea/plugin/hybris/impex/psi/references/ImpexTSSubTypeItemReference.kt
@@ -76,7 +76,7 @@ class ImpexTSSubTypeItemReference(owner: ImpexSubTypeName) : TSReferenceBase<Imp
         private fun getAllowedVariants(element: ImpexSubTypeName): Collection<TSGlobalMetaItem> = element.headerTypeName
             ?.text
             ?.let { TSMetaModelAccess.getInstance(element.project).findMetaItemByName(it) }
-            ?.allChildren
+            ?.hierarchy
             ?: emptyList()
 
     }

--- a/src/com/intellij/idea/plugin/hybris/system/type/codeInsight/completion/TSCompletionService.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/codeInsight/completion/TSCompletionService.kt
@@ -108,7 +108,7 @@ class TSCompletionService(private val project: Project) {
         }
 
         return TSMetaModelAccess.getInstance(project).findMetaItemByName(referenceItemTypeName)
-            ?.allChildren
+            ?.hierarchy
             ?.mapNotNull {
                 TSLookupElementFactory.build(it, suffix)
                     ?.withTypeText(" child of $referenceItemTypeName", true)

--- a/src/com/intellij/idea/plugin/hybris/system/type/meta/TSMetaModelMerger.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/meta/TSMetaModelMerger.kt
@@ -78,14 +78,15 @@ object TSMetaModelMerger {
             }
             .forEach { metaItems.remove(it) }
 
+        // init hierarchy for Meta Items
         metaItems.values.forEach { meta ->
-            val allChildren = metaItems.values.filter { otherMeta ->
+            val itemHierarchy = metaItems.values.filter { otherMeta ->
                 otherMeta.allExtends.find { it.name == meta.name } != null
                     // or itself, it will be highlighted as unnecessary via Inspection
                     || otherMeta.name == meta.name
             }
 
-            meta.addChildren(allChildren)
+            meta.addMetasToHierarchy(itemHierarchy)
         }
     }
 

--- a/src/com/intellij/idea/plugin/hybris/system/type/meta/model/TSMetaItem.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/meta/model/TSMetaItem.kt
@@ -86,9 +86,9 @@ interface TSGlobalMetaItem : TSMetaItem, TSGlobalMetaClassifier<ItemType>, TSTyp
     val allCustomProperties: List<TSMetaCustomProperty>
     val allRelationEnds: List<TSMetaRelation.TSMetaRelationElement>
     val allExtends: Set<TSGlobalMetaItem>
-    val allChildren: Set<TSGlobalMetaItem>
+    val hierarchy: Set<TSGlobalMetaItem>
 
-    abstract fun addChildren(children: Collection<TSGlobalMetaItem>)
+    fun addMetasToHierarchy(metas: Collection<TSGlobalMetaItem>)
 
     override fun documentation() = hybrisDoc {
         title("Item type", name ?: "?")

--- a/src/com/intellij/idea/plugin/hybris/system/type/meta/model/impl/TSMetaItemImpl.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/type/meta/model/impl/TSMetaItemImpl.kt
@@ -122,7 +122,7 @@ internal class TSGlobalMetaItemImpl(localMeta: TSMetaItem) : TSGlobalMetaItemSel
     override val allCustomProperties = LinkedList<TSMetaCustomProperty>()
     override val allRelationEnds = LinkedList<TSMetaRelation.TSMetaRelationElement>()
     override val allExtends = linkedSetOf<TSGlobalMetaItem>()
-    override val allChildren = linkedSetOf<TSGlobalMetaItem>()
+    override val hierarchy = linkedSetOf<TSGlobalMetaItem>()
 
     override var domAnchor = localMeta.domAnchor
     override var moduleName = localMeta.moduleName
@@ -145,8 +145,8 @@ internal class TSGlobalMetaItemImpl(localMeta: TSMetaItem) : TSGlobalMetaItemSel
         mergeCustomProperties(localMeta)
     }
 
-    override fun addChildren(children: Collection<TSGlobalMetaItem>) {
-        allChildren.addAll(children)
+    override fun addMetasToHierarchy(metas: Collection<TSGlobalMetaItem>) {
+        this.hierarchy.addAll(metas)
     }
 
     override fun toString() = "Item(module=$extensionName, name=$name, isCustom=$isCustom)"


### PR DESCRIPTION
> Take a note that only User and UserGroup hierarchy is supported.
> See: de.hybris.platform.jalo.security.ImportExportUserRightsHelper#addDataSetToPlatform

<img width="387" alt="Screenshot 2025-06-11 at 16 03 09" src="https://github.com/user-attachments/assets/62bc6fc6-fee7-4c79-9b04-c074c5ea7e66" />
<img width="465" alt="Screenshot 2025-06-11 at 16 03 16" src="https://github.com/user-attachments/assets/9f654f1f-86dc-4cca-ae2a-1bd9f5e8c1c9" />
<img width="481" alt="Screenshot 2025-06-11 at 16 03 24" src="https://github.com/user-attachments/assets/bf44f5f1-879a-4940-95f5-71c1b56ab6c6" />
