### PR TITLE
FlexibleSearch | Improved code formatting for expressions within `WHERE` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### `FlexibleSearch` enhancements
 - Added API to retrieve item type and expression of the bind parameter [#1420](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1420)
+- Improved code formatting for expressions within `WHERE` clause [#1421](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1421)
 
 ## [2025.1.4]
 

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/impl/FlexibleSearchBindParameterMixin.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/psi/impl/FlexibleSearchBindParameterMixin.kt
@@ -44,7 +44,12 @@ abstract class FlexibleSearchBindParameterMixin(node: ASTNode) : ASTWrapperPsiEl
         Function<PsiElement, FlexibleSearchExpression?> {
             it.parent?.asSafely<FlexibleSearchExpression>()
         },
-        Predicate<PsiElement> { it is FlexibleSearchLiteralExpression }
+        Predicate<PsiElement> {
+            it is FlexibleSearchLiteralExpression
+            || it is FlexibleSearchParenExpression
+            || it is FlexibleSearchOrExpression
+            || it is FlexibleSearchAndExpression
+        }
     )
         ?.asSafely<FlexibleSearchExpression>()
 


### PR DESCRIPTION
<img width="451" alt="image" src="https://github.com/user-attachments/assets/bccf7779-3648-4fa2-9a91-a5e0889c1e7c" />
