### PR TITLE
FlexibleSearch | Shorten long parameter names in the `In-Editor Parameters` view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Support tabulation for In-Editor parameters [#1444](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1444)
 - Respect an editor for `FlexibleSearch` inlay hints [#1446](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1446)
 - Refresh a parameters panel for all `FlexibleSearch` editors on PSI-elements tree change [#1447](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1447)
+- Shorten long parameter names in the `In-Editor Parameters` view [#1451](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1451)
 
 ### `Groovy` enhancements
 - Introduced `batch` execution mode for Groovy files [#1450](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1450)

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/editor/FlexibleSearchInEditorParametersView.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/editor/FlexibleSearchInEditorParametersView.kt
@@ -148,13 +148,13 @@ object FlexibleSearchInEditorParametersView {
                     when (parameter.type) {
                         "java.lang.Float", "java.lang.Double", "java.lang.Byte", "java.lang.Short", "java.lang.Long", "java.lang.Integer",
                         "float", "double", "byte", "short", "long", "int" -> intTextField()
-                            .label("${parameter.name}:")
+                            .label("${parameter.displayName}:")
                             .align(AlignX.FILL)
                             .text(parameter.value)
                             .onChanged { applyValue(fileEditor, parameter, it.text) { it.text } }
 
                         "boolean",
-                        "java.lang.Boolean" -> checkBox(parameter.name)
+                        "java.lang.Boolean" -> checkBox(parameter.displayName)
                             .align(AlignX.FILL)
                             .selected(parameter.value == "1")
                             .onChanged {
@@ -171,7 +171,7 @@ object FlexibleSearchInEditorParametersView {
                                 SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
                             )
                         )
-                            .label("${parameter.name}:")
+                            .label("${parameter.displayName}:")
                             .align(Align.FILL).apply {
                                 component.also { datePicker ->
                                     val listener = PropertyChangeListener { event ->
@@ -194,13 +194,13 @@ object FlexibleSearchInEditorParametersView {
                         "String",
                         "java.lang.String",
                         "localized:java.lang.String" -> textField()
-                            .label("${parameter.name}:")
+                            .label("${parameter.displayName}:")
                             .align(AlignX.FILL)
                             .text(StringUtil.unquoteString(parameter.value, '\''))
                             .onChanged { applyValue(fileEditor, parameter, "'${it.text}'") { "'${it.text}'" } }
 
                         else -> textField()
-                            .label("${parameter.name}:")
+                            .label("${parameter.displayName}:")
                             .align(AlignX.FILL)
                             .text(parameter.value)
                             .onChanged { applyValue(fileEditor, parameter, it.text) { "${it.text}" } }

--- a/src/com/intellij/idea/plugin/hybris/flexibleSearch/editor/FlexibleSearchQueryParameter.kt
+++ b/src/com/intellij/idea/plugin/hybris/flexibleSearch/editor/FlexibleSearchQueryParameter.kt
@@ -19,6 +19,7 @@
 package com.intellij.idea.plugin.hybris.flexibleSearch.editor
 
 import com.intellij.idea.plugin.hybris.flexibleSearch.psi.FlexibleSearchBindParameter
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.tree.IElementType
 
 data class FlexibleSearchQueryParameter(
@@ -28,6 +29,9 @@ data class FlexibleSearchQueryParameter(
     val type: String? = null,
     val operand: IElementType? = null
 ) {
+    val displayName
+        get() = StringUtil.shortenPathWithEllipsis(name, 20)
+
     companion object {
         fun of(bindParameter: FlexibleSearchBindParameter, currentParameters: Collection<FlexibleSearchQueryParameter>): FlexibleSearchQueryParameter {
             val parameter = bindParameter.value


### PR DESCRIPTION
<img width="2084" height="361" alt="Screenshot 2025-07-13 at 17 35 11" src="https://github.com/user-attachments/assets/5c921067-0b8a-4c01-a5c8-034291e5e007" />
