### PR TITLE
SAP CX Logging | Reset Loggers cache on connection change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `SAP CX Logging` enhancements
 - Display a log level status from a remote server [1457](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1457)
 - Display an inherited log level status from a remote server [1475](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1475)
+- Reset Loggers cache on connection change [1479](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1479)
 
 ### `items.xml` enhancements
 - Show attribute non-property persistence for contribution results [#1448](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1448)

--- a/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
@@ -62,13 +62,9 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
     init {
         with(project.messageBus.connect(this)) {
             subscribe(RemoteConnectionListener.TOPIC, object : RemoteConnectionListener {
-                override fun onActiveHybrisConnectionChanged(remoteConnection: RemoteConnectionSettings) {
-                    refresh()
-                }
+                override fun onActiveHybrisConnectionChanged(remoteConnection: RemoteConnectionSettings) = refresh()
 
-                override fun onActiveSolrConnectionChanged(remoteConnection: RemoteConnectionSettings) {
-                    refresh()
-                }
+                override fun onActiveSolrConnectionChanged(remoteConnection: RemoteConnectionSettings) = refresh()
 
                 private fun refresh() {
                     loggersCache.clear()

--- a/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
@@ -19,6 +19,8 @@
 package com.intellij.idea.plugin.hybris.tools.logging
 
 import com.intellij.idea.plugin.hybris.notifications.Notifications
+import com.intellij.idea.plugin.hybris.settings.RemoteConnectionListener
+import com.intellij.idea.plugin.hybris.settings.RemoteConnectionSettings
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionService
 import com.intellij.idea.plugin.hybris.tools.remote.RemoteConnectionType
 import com.intellij.idea.plugin.hybris.tools.remote.execution.TransactionMode
@@ -27,6 +29,7 @@ import com.intellij.idea.plugin.hybris.tools.remote.execution.groovy.GroovyExecu
 import com.intellij.idea.plugin.hybris.tools.remote.execution.logging.LoggingExecutionClient
 import com.intellij.idea.plugin.hybris.tools.remote.execution.logging.LoggingExecutionContext
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.edtWriteAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -46,7 +49,7 @@ private const val FETCH_LOGGERS_STATE_GROOVY_SCRIPT = """
 """
 
 @Service(Service.Level.PROJECT)
-class CxLoggerAccess(private val project: Project, private val coroutineScope: CoroutineScope) {
+class CxLoggerAccess(private val project: Project, private val coroutineScope: CoroutineScope) : Disposable {
     private var fetching: Boolean = false
     val loggersCache = CxLoggersStorage()
 
@@ -55,6 +58,34 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
 
     val cacheInitialized: Boolean
         get() = loggersCache.initialized
+
+    init {
+        with(project.messageBus.connect(this)) {
+            subscribe(RemoteConnectionListener.TOPIC, object : RemoteConnectionListener {
+                override fun onActiveHybrisConnectionChanged(remoteConnection: RemoteConnectionSettings) {
+                    refresh()
+                }
+
+                override fun onActiveSolrConnectionChanged(remoteConnection: RemoteConnectionSettings) {
+                    refresh()
+                }
+
+                private fun refresh() {
+                    loggersCache.clear()
+
+                    coroutineScope.launch {
+                        fetching = true
+
+                        edtWriteAction {
+                            PsiDocumentManager.getInstance(project).reparseFiles(emptyList(), true)
+                        }
+
+                        fetching = false
+                    }
+                }
+            })
+        }
+    }
 
     fun logger(loggerIdentifier: String): CxLoggerModel? = if (!cacheInitialized) null else loggersCache.get(loggerIdentifier)
 
@@ -133,6 +164,10 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
         .create(type, title, contentProvider.invoke())
         .hideAfter(5)
         .notify(project)
+
+    override fun dispose() {
+        loggersCache.clear()
+    }
 
     companion object {
         fun getInstance(project: Project): CxLoggerAccess = project.service()

--- a/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggerAccess.kt
@@ -65,20 +65,6 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
                 override fun onActiveHybrisConnectionChanged(remoteConnection: RemoteConnectionSettings) = refresh()
 
                 override fun onActiveSolrConnectionChanged(remoteConnection: RemoteConnectionSettings) = refresh()
-
-                private fun refresh() {
-                    loggersCache.clear()
-
-                    coroutineScope.launch {
-                        fetching = true
-
-                        edtWriteAction {
-                            PsiDocumentManager.getInstance(project).reparseFiles(emptyList(), true)
-                        }
-
-                        fetching = false
-                    }
-                }
             })
         }
     }
@@ -147,6 +133,20 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
         coroutineScope.launch {
 
             loggersCache.update(loggers ?: emptyMap())
+
+            edtWriteAction {
+                PsiDocumentManager.getInstance(project).reparseFiles(emptyList(), true)
+            }
+
+            fetching = false
+        }
+    }
+
+    private fun refresh() {
+        loggersCache.clear()
+
+        coroutineScope.launch {
+            fetching = true
 
             edtWriteAction {
                 PsiDocumentManager.getInstance(project).reparseFiles(emptyList(), true)

--- a/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggersStorage.kt
+++ b/src/com/intellij/idea/plugin/hybris/tools/logging/CxLoggersStorage.kt
@@ -44,6 +44,13 @@ class CxLoggersStorage {
         }
     }
 
+    fun clear() {
+        synchronized(loggers) {
+            this.loggers.clear()
+            _initialized = false
+        }
+    }
+
     private fun createLoggerModel(loggerIdentifier: String): CxLoggerModel {
         val parentLogger = loggerIdentifier.substringBeforeLast('.', "")
             .takeIf { it.isNotBlank() }


### PR DESCRIPTION
### Loggers Cache is initialized
<img width="658" height="682" alt="image" src="https://github.com/user-attachments/assets/4ab69673-ba42-49c7-b01d-d3ec0794ec8b" />

### Loggers Cache is reset on connection change
- cache is reset
- Fetch button is shown

<img width="533" height="754" alt="image" src="https://github.com/user-attachments/assets/0c95140b-5740-4a69-9e45-d1b65baa3476" />

