### PR TITLE
Use custom icons for `SOLR`, `Tomcat` and `installedSaplicenses.properties` in the Project Tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Other
 - Updated versions of the project dependencies [#1503](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1503)
+- Use custom icons for `SOLR`, `Tomcat` and `installedSaplicenses.properties` in the Project Tree [#1506](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1506)
 
 ## [2025.1.7]
 

--- a/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/HybrisConstants.kt
@@ -110,6 +110,7 @@ object HybrisConstants {
     const val EXTENSIONS_XML = "extensions.xml"
     const val COCKPIT_NG_DEFINITION_XML = "definition.xml"
     const val HYBRIS_LICENCE_JAR = "hybrislicence.jar"
+    const val SAP_LICENCES = "installedSaplicenses.properties"
 
     const val HYBRIS_DIRECTORY = "hybris"
     const val HYBRIS_DATA_DIRECTORY = "data"

--- a/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.kt
+++ b/src/com/intellij/idea/plugin/hybris/common/utils/HybrisIcons.kt
@@ -53,6 +53,11 @@ object HybrisIcons {
         val FACET = LOGO_GREEN
     }
 
+    object Tools {
+        val SOLR = getIcon("/icons/console/solr.svg")
+        val TOMCAT = AllIcons.RunConfigurations.Tomcat
+    }
+
     object UnmanagedDependencies {
         val FILE = getIcon("/icons/unmanagedDependencies.svg")
     }
@@ -320,7 +325,7 @@ object HybrisIcons {
 
     object Console {
         val DESCRIPTOR = AllIcons.Debugger.Console
-        val SOLR = getIcon("/icons/console/solr.svg")
+        val SOLR = Tools.SOLR
 
         object Actions {
             val OPEN = getIcon("/icons/console/open.svg")

--- a/src/com/intellij/idea/plugin/hybris/project/HybrisProjectIconProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/project/HybrisProjectIconProvider.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2024 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -20,22 +20,37 @@ package com.intellij.idea.plugin.hybris.project
 import com.intellij.ide.IconProvider
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
 import com.intellij.idea.plugin.hybris.common.utils.HybrisIcons
+import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import javax.swing.Icon
 
 class HybrisProjectIconProvider : IconProvider() {
 
-    override fun getIcon(element: PsiElement, p1: Int): Icon? {
-        val file = element.containingFile ?: return null
+    override fun getIcon(element: PsiElement, p1: Int) = when (element) {
+        is PsiDirectory -> getIcon(element)
+        is PsiFile -> getIcon(element)
+        else -> null
+    }
 
-        return when {
-            file.name == HybrisConstants.BUILD_CALLBACKS_XML -> HybrisIcons.BuildCallbacks.FILE
-            file.name == HybrisConstants.UNMANAGED_DEPENDENCIES_TXT -> HybrisIcons.UnmanagedDependencies.FILE
-            file.name == HybrisConstants.EXTERNAL_DEPENDENCIES_XML -> HybrisIcons.ExternalDependencies.FILE
-            file.name == HybrisConstants.HYBRIS_LICENCE_JAR -> HybrisIcons.Y.LICENCE
-            file.name == HybrisConstants.EXTENSION_INFO_XML -> HybrisIcons.ExtensionInfo.FILE
-            file.name == HybrisConstants.LOCAL_EXTENSIONS_XML -> HybrisIcons.LocalExtensions.FILE
-            file.name.endsWith(HybrisConstants.IMPORT_OVERRIDE_FILENAME) -> HybrisIcons.PLUGIN_SETTINGS
+    private fun getIcon(file: PsiFile): Icon? = when {
+        file.name == HybrisConstants.BUILD_CALLBACKS_XML -> HybrisIcons.BuildCallbacks.FILE
+        file.name == HybrisConstants.UNMANAGED_DEPENDENCIES_TXT -> HybrisIcons.UnmanagedDependencies.FILE
+        file.name == HybrisConstants.EXTERNAL_DEPENDENCIES_XML -> HybrisIcons.ExternalDependencies.FILE
+        file.name == HybrisConstants.HYBRIS_LICENCE_JAR
+            || file.name == HybrisConstants.SAP_LICENCES -> HybrisIcons.Y.LICENCE
+
+        file.name == HybrisConstants.EXTENSION_INFO_XML -> HybrisIcons.ExtensionInfo.FILE
+        file.name == HybrisConstants.LOCAL_EXTENSIONS_XML -> HybrisIcons.LocalExtensions.FILE
+        file.name.endsWith(HybrisConstants.IMPORT_OVERRIDE_FILENAME) -> HybrisIcons.PLUGIN_SETTINGS
+        else -> null
+    }
+
+    private fun getIcon(directory: PsiDirectory): Icon? {
+        val parentName = directory.parentDirectory?.name
+        return when (directory.name) {
+            "tomcat" if (parentName == HybrisConstants.EXTENSION_NAME_CONFIG || parentName == HybrisConstants.EXTENSION_NAME_PLATFORM) -> HybrisIcons.Tools.TOMCAT
+            "solr" if parentName == HybrisConstants.EXTENSION_NAME_CONFIG -> HybrisIcons.Tools.SOLR
             else -> null
         }
     }


### PR DESCRIPTION
<img width="291" height="279" alt="image" src="https://github.com/user-attachments/assets/5fb4ce14-6d25-4a10-8105-47259df1c2af" />
