### PR TITLE
fix #1428 Integration Test running through IntelliJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [2025.2.3]
 
+### Fixes
+- Enhance JVM Parameters only with Standalone JDK Module Exports during Integrationtestse [1529](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1529)
+
 ### `Other` enhancements
 - Migrated to immutable Settings [#1527](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1527)
 

--- a/src/com/intellij/idea/plugin/hybris/properties/PropertyService.kt
+++ b/src/com/intellij/idea/plugin/hybris/properties/PropertyService.kt
@@ -19,9 +19,6 @@
 package com.intellij.idea.plugin.hybris.properties
 
 import com.intellij.idea.plugin.hybris.common.HybrisConstants
-import com.intellij.idea.plugin.hybris.common.HybrisConstants.DEFAULT_WRAPPER_FILENAME
-import com.intellij.idea.plugin.hybris.common.HybrisConstants.PLATFORM_TOMCAT_DIRECTORY
-import com.intellij.idea.plugin.hybris.common.HybrisConstants.TOMCAT_WRAPPER_CONFIG_DIR
 import com.intellij.idea.plugin.hybris.common.yExtensionName
 import com.intellij.idea.plugin.hybris.project.utils.HybrisRootUtil
 import com.intellij.lang.properties.IProperty
@@ -30,11 +27,9 @@ import com.intellij.lang.properties.psi.PropertiesFile
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
@@ -47,9 +42,7 @@ import com.intellij.psi.util.CachedValuesManager
 import com.intellij.util.application
 import com.intellij.util.asSafely
 import com.intellij.util.concurrency.AppExecutorUtil
-import java.io.BufferedReader
 import java.io.File
-import java.io.InputStreamReader
 import java.util.*
 import java.util.regex.Pattern
 
@@ -183,56 +176,6 @@ class PropertyService(private val project: Project) {
 
     fun getPlatformHome(): String? {
         return HybrisRootUtil.findPlatformRootDirectory(project)?.path
-    }
-
-    fun getTomcatWrapperProperties(executionId: String? = null): Properties {
-        val platformModule = obtainPlatformModule()
-            ?: throw IllegalStateException("Platform module not found")
-
-        val tomcatDir = findTomcatDirectory(platformModule)
-
-        val configFileName = when (executionId) {
-            null -> DEFAULT_WRAPPER_FILENAME
-            else -> "wrapper-$executionId.conf"
-        }
-
-        val confFile = tomcatDir.findFileByRelativePath("$TOMCAT_WRAPPER_CONFIG_DIR/$configFileName")
-        return loadProperties(confFile)
-    }
-
-    private fun findTomcatDirectory(platformModule: Module): VirtualFile {
-        return ModuleRootManager.getInstance(platformModule)
-            .contentRoots
-            .asSequence()
-            .mapNotNull { it.findFileByRelativePath(PLATFORM_TOMCAT_DIRECTORY) }
-            .firstOrNull()
-            ?: throw IllegalStateException("Tomcat directory not found")
-    }
-
-    private fun loadProperties(confFile: VirtualFile?): Properties {
-        val properties = Properties()
-
-        try {
-            confFile?.inputStream?.let { inputStream ->
-                // Create a BufferedReader to read the input stream line by line
-                BufferedReader(InputStreamReader(inputStream)).use { reader ->
-                    val modifiedContent = StringBuilder()
-
-                    // Read each line, replace backslashes with forward slashes, and append to StringBuilder
-                    reader.forEachLine { line ->
-                        val modifiedLine = line.replace("\\", "\\\\")
-                        modifiedContent.appendLine(modifiedLine)
-                    }
-
-                    // Now load the modified content into the Properties object
-                    properties.load(InputStreamReader(modifiedContent.toString().byteInputStream()))
-                }
-            }
-        } catch (e: Exception) {
-            thisLogger().error(e)
-        }
-
-        return properties
     }
 
     private fun replacePlaceholder(result: LinkedHashMap<String, String>, key: String, visitedProperties: MutableSet<String>) {


### PR DESCRIPTION
Tomcat Settings will no longer be used when running Integration Tests.
Only the Standalone JDK Module Exports will be used, as this is also done by SAP.

Signed-off-by: Stefan Kruk <Stefan.Kruk@gmx.net>
