### PR TITLE
Refresh type renderer: The item type is not present in the *items.xml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### `xDebugger` enhancements
 - Create type renderer: The item type is not present in the *items.xml files [#1531](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1531)
 - Create type renderer: The class for the item type was not found [#1532](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1532)
-- Refresh type renderer: The item type $typeCode is not present in the *items.xml files [#1533](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1533)
+- Refresh type renderer: The item type is not present in the *items.xml files [#1533](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1533)
 
 ### `Other` enhancements
 - Migrated to immutable Settings [#1527](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1527)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### `xDebugger` enhancements
 - Create type renderer: The item type is not present in the *items.xml files [#1531](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1531)
 - Create type renderer: The class for the item type was not found [#1532](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1532)
+- Refresh type renderer: The item type $typeCode is not present in the *items.xml files [#1533](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1533)
 
 ### `Other` enhancements
 - Migrated to immutable Settings [#1527](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1527)

--- a/src/com/intellij/idea/plugin/hybris/debugger/TypeRendererUtils.kt
+++ b/src/com/intellij/idea/plugin/hybris/debugger/TypeRendererUtils.kt
@@ -27,7 +27,12 @@ import java.awt.MouseInfo
 
 object TypeRendererUtils {
 
+    val ITEM_TYPE_TS_MISSING = { typeCode: String -> "The item type $typeCode is not present in the *items.xml files." }
+    val ITEM_TYPE_CLASS_NOT_FOUND = { typeCode: String -> "The class for the item type $typeCode was not found. Rebuild the project and try again." }
+
     fun toTypeCode(className: String) = className.substringAfterLast('.').removeSuffix("Model")
+
+    fun notifyError(typeCode: String, messageFunc: (String) -> String) = notifyError(messageFunc(typeCode))
 
     fun notifyError(errorMessage: String) {
         application.invokeLater {

--- a/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/DefaultModelRenderer.kt
+++ b/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/DefaultModelRenderer.kt
@@ -53,7 +53,7 @@ class DefaultModelRenderer : CompoundRendererProvider() {
     override fun getIsApplicableChecker(): Function<Type?, CompletableFuture<Boolean>> {
         return Function { t ->
             CompletableFuture.completedFuture(
-                 DebuggerUtils.instanceOf(t, className)
+                DebuggerUtils.instanceOf(t, className)
             )
         }
     }
@@ -74,13 +74,13 @@ class DefaultModelRenderer : CompoundRendererProvider() {
                         val meta = metaAccess.findMetaItemByName(typeCode)
 
                         if (meta == null) {
-                            TypeRendererUtils.notifyError("The item type $typeCode is not present in the *items.xml files.")
+                            TypeRendererUtils.notifyError(typeCode, TypeRendererUtils.ITEM_TYPE_TS_MISSING)
                             return@runReadAction
                         }
 
                         val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project))
                         if (psiClass == null) {
-                            TypeRendererUtils.notifyError("The class for the item type $typeCode was not found. Rebuild the project and try again.")
+                            TypeRendererUtils.notifyError(typeCode, TypeRendererUtils.ITEM_TYPE_CLASS_NOT_FOUND)
                             return@runReadAction
                         }
                     }

--- a/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
@@ -47,7 +47,7 @@ object ModelEnumerationChildrenRendererInfoProvider {
                 TypeRendererUtils.notifyError("The item type $typeCode is not present in the *items.xml files.")
                 return@runReadAction
             }
-            val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project))
+            val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project)) ?: return@runReadAction
 
             val infos = psiClass.allFields
                 .filterNot { it.name.startsWith("_") }

--- a/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
@@ -44,7 +44,7 @@ object ModelEnumerationChildrenRendererInfoProvider {
             val metaAccess = TSMetaModelAccess.getInstance(project)
             val meta = metaAccess.findMetaItemByName(typeCode)
             if (meta == null) {
-                TypeRendererUtils.notifyError("The item type $typeCode is not present in the *items.xml files.")
+                TypeRendererUtils.notifyError(typeCode, TypeRendererUtils.ITEM_TYPE_TS_MISSING)
                 return@runReadAction
             }
             val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project)) ?: return@runReadAction

--- a/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/debugger/ui/tree/render/ModelEnumerationChildrenRendererInfoProvider.kt
@@ -22,7 +22,7 @@ import com.intellij.debugger.engine.DebuggerUtils
 import com.intellij.debugger.settings.NodeRendererSettings
 import com.intellij.debugger.ui.tree.render.EnumerationChildrenRenderer
 import com.intellij.debugger.ui.tree.render.EnumerationChildrenRenderer.ChildInfo
-import com.intellij.idea.plugin.hybris.common.HybrisConstants
+import com.intellij.idea.plugin.hybris.debugger.TypeRendererUtils
 import com.intellij.idea.plugin.hybris.system.type.meta.TSMetaModelAccess
 import com.intellij.idea.plugin.hybris.system.type.meta.model.TSGlobalMetaItem
 import com.intellij.idea.plugin.hybris.system.type.meta.model.TSMetaRelation
@@ -40,12 +40,14 @@ object ModelEnumerationChildrenRendererInfoProvider {
     ) {
         application.runReadAction {
             val debuggerUtils = DebuggerUtils.getInstance()
-            val typeCode = className
-                .substringAfterLast(".")
-                .substringBeforeLast(HybrisConstants.MODEL_SUFFIX)
+            val typeCode = TypeRendererUtils.toTypeCode(className)
             val metaAccess = TSMetaModelAccess.getInstance(project)
-            val meta = metaAccess.findMetaItemByName(typeCode) ?: return@runReadAction
-            val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project)) ?: return@runReadAction
+            val meta = metaAccess.findMetaItemByName(typeCode)
+            if (meta == null) {
+                TypeRendererUtils.notifyError("The item type $typeCode is not present in the *items.xml files.")
+                return@runReadAction
+            }
+            val psiClass = DebuggerUtils.findClass(className, project, GlobalSearchScope.allScope(project))
 
             val infos = psiClass.allFields
                 .filterNot { it.name.startsWith("_") }


### PR DESCRIPTION
### The item type $typeCode is not present in the *items.xml files
<img width="990" height="217" alt="image" src="https://github.com/user-attachments/assets/2cbb7fc7-6f34-432c-bce1-5962b4f54efc" />