### PR TITLE
Improve positioning of '[y] log level' CTA for classes with annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2025.2.3]
 
 ### `SAP CX Logging` enhancements
-- Fix positioning of `[y] log level` CTA for classes with annotations [#1535](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1535)
+- Improve positioning of `[y] log level` CTA for classes with annotations [#1535](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1535)
 
 ### `xDebugger` enhancements
 - Create type renderer: The item type is not present in the *items.xml files [#1531](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1531)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [2025.2.3]
 
+### `SAP CX Logging` enhancements
+- Fix positioning of `[y] log level` CTA for classes with annotations [#1535](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1535)
 
 ### `xDebugger` enhancements
 - Create type renderer: The item type is not present in the *items.xml files [#1531](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1531)

--- a/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
@@ -59,10 +59,10 @@ class LoggerInlayHintsProvider : JavaCodeVisionProviderBase() {
         return PsiTreeUtil.findChildrenOfAnyType(psiFile, PsiClass::class.java, PsiPackageStatement::class.java)
             .mapNotNull { psiElement ->
                 when (psiElement) {
-                    is PsiClass -> {
-                        return@mapNotNull psiElement.nameIdentifier
-                            ?.let { FqnUtil.elementToFqn(psiElement, editor) }
-                            ?.let { psiElement.nameIdentifier!! to it }
+                    is PsiClass -> psiElement.nameIdentifier
+                        ?.let { psiClassIdentifier ->
+                            FqnUtil.elementToFqn(psiElement, editor)
+                                ?.let { fqn -> psiClassIdentifier to fqn }
                     }
 
                     is PsiPackageStatement -> psiElement to psiElement.packageName

--- a/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
@@ -57,13 +57,14 @@ class LoggerInlayHintsProvider : JavaCodeVisionProviderBase() {
         val project = psiFile.project
 
         return PsiTreeUtil.findChildrenOfAnyType(psiFile, PsiClass::class.java, PsiPackageStatement::class.java)
-            .mapNotNull {psiElement -> return@mapNotNull when (psiElement) {
+            .mapNotNull { psiElement ->
+                when (psiElement) {
                     is PsiClass -> {
-                        val fqn = FqnUtil.elementToFqn(psiElement, editor)
-                        return@mapNotNull fqn
-                            ?.let { psiElement.nameIdentifier }
-                            ?.let { it to fqn }
+                        return@mapNotNull psiElement.nameIdentifier
+                            ?.let { FqnUtil.elementToFqn(psiElement, editor) }
+                            ?.let { psiElement.nameIdentifier!! to it }
                     }
+
                     is PsiPackageStatement -> psiElement to psiElement.packageName
                     else -> null
                 }

--- a/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
+++ b/src/com/intellij/idea/plugin/hybris/system/java/codeInsight/hints/LoggerInlayHintsProvider.kt
@@ -60,9 +60,8 @@ class LoggerInlayHintsProvider : JavaCodeVisionProviderBase() {
             .mapNotNull {psiElement -> return@mapNotNull when (psiElement) {
                     is PsiClass -> {
                         val fqn = FqnUtil.elementToFqn(psiElement, editor)
-                        val simpleClassName = psiElement.nameIdentifier?.text
                         return@mapNotNull fqn
-                            ?.let { PsiTreeUtil.findChildrenOfType(psiElement, PsiIdentifier::class.java).firstOrNull { it.text == simpleClassName} }
+                            ?.let { psiElement.nameIdentifier }
                             ?.let { it to fqn }
                     }
                     is PsiPackageStatement -> psiElement to psiElement.packageName


### PR DESCRIPTION
<img width="502" height="607" alt="image" src="https://github.com/user-attachments/assets/f6c634a7-a832-4d7e-abd7-e53151e2c682" />
