### PR TITLE
Unified contracts for execution settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Migrated to immutable Settings [#1527](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1527)
 - Added possibility to specify `timeout` per connection settings [#1540](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1540)
 - Add dependency on a newly extracted Jetbrains module `intellij.spellchecker` [#1546](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1546)
+- Unified contracts for execution settings [#1562](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1562)
 
 ### Fixes
 - Enhance JVM Parameters only with Standalone JDK Module Exports during Integration Tests [1529](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1529)

--- a/modules/acl/ui/src/sap/commerce/toolset/acl/actionSystem/AclExecuteAction.kt
+++ b/modules/acl/ui/src/sap/commerce/toolset/acl/actionSystem/AclExecuteAction.kt
@@ -33,6 +33,7 @@ import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.console.ImpExConsole
 import sap.commerce.toolset.impex.editor.impexExecutionContextSettings
 import sap.commerce.toolset.impex.exec.ImpExExecClient
+import sap.commerce.toolset.impex.exec.context.ImpExDialect
 import sap.commerce.toolset.impex.exec.context.ImpExExecContext
 
 class AclExecuteAction : ExecuteStatementAction<ImpExConsole, AclSplitEditorEx>(
@@ -52,7 +53,7 @@ class AclExecuteAction : ExecuteStatementAction<ImpExConsole, AclSplitEditorEx>(
         val context = ImpExExecContext(
             connection = connectionSettings,
             content = content,
-            dialect = ImpExExecContext.Dialect.ACL,
+            dialect = ImpExDialect.ACL,
             settings = settings
         )
 

--- a/modules/acl/ui/src/sap/commerce/toolset/acl/actionSystem/AclValidateAction.kt
+++ b/modules/acl/ui/src/sap/commerce/toolset/acl/actionSystem/AclValidateAction.kt
@@ -31,7 +31,9 @@ import sap.commerce.toolset.hac.actionSystem.ExecuteStatementAction
 import sap.commerce.toolset.hac.exec.HacExecConnectionService
 import sap.commerce.toolset.impex.console.ImpExConsole
 import sap.commerce.toolset.impex.exec.ImpExExecClient
+import sap.commerce.toolset.impex.exec.context.ImpExDialect
 import sap.commerce.toolset.impex.exec.context.ImpExExecContext
+import sap.commerce.toolset.impex.exec.context.ImpExExecutionMode
 
 class AclValidateAction : ExecuteStatementAction<ImpExConsole, AclSplitEditorEx>(
     AclLanguage,
@@ -46,12 +48,11 @@ class AclValidateAction : ExecuteStatementAction<ImpExConsole, AclSplitEditorEx>
     override fun actionPerformed(e: AnActionEvent, project: Project, content: String) {
         val fileEditor = fileEditor(e) ?: return
         val connectionSettings = HacExecConnectionService.getInstance(project).activeConnection
-
         val context = ImpExExecContext(
             connection = connectionSettings,
             content = content,
-            executionMode = ImpExExecContext.ExecutionMode.VALIDATE,
-            dialect = ImpExExecContext.Dialect.ACL,
+            executionMode = ImpExExecutionMode.VALIDATE,
+            dialect = ImpExDialect.ACL,
             settings = ImpExExecContext.defaultSettings(connectionSettings)
         )
 

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
@@ -52,7 +52,7 @@ class FlexibleSearchExecClient(
             .map { BasicNameValuePair(it.key, it.value) }
 
         val response = HacHttpClient.getInstance(project)
-            .post(actionUrl, params, true, context.settings.timeout, connection, null)
+            .post(actionUrl, params, true, context.timeout, connection, null)
         val statusLine = response.statusLine
         val statusCode = statusLine.statusCode
 

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
@@ -30,8 +30,30 @@ data class FlexibleSearchExecContext(
     private val content: String = "",
     private val transactionMode: TransactionMode = TransactionMode.ROLLBACK,
     private val queryMode: QueryMode = QueryMode.FlexibleSearch,
-    val settings: Settings,
+    val maxCount: Int,
+    val locale: String,
+    val dataSource: String,
+    val user: String,
+    val timeout: Int,
 ) : ExecContext {
+
+    constructor(
+        connection: HacConnectionSettingsState,
+        content: String = "",
+        transactionMode: TransactionMode = TransactionMode.ROLLBACK,
+        queryMode: QueryMode = QueryMode.FlexibleSearch,
+        settings: Settings,
+    ) : this(
+        connection = connection,
+        content = content,
+        transactionMode = transactionMode,
+        queryMode = queryMode,
+        maxCount = settings.maxCount,
+        locale = settings.locale,
+        dataSource = settings.dataSource,
+        user = settings.user,
+        timeout = settings.timeout,
+    )
 
     override val executionTitle: String
         get() = "Executing ${queryMode.title} on the remote SAP Commerce instance…"
@@ -39,10 +61,10 @@ data class FlexibleSearchExecContext(
     fun params(): Map<String, String> = buildMap {
         put("scriptType", "flexibleSearch")
         put("commit", BooleanUtils.toStringTrueFalse(transactionMode == TransactionMode.COMMIT))
-        put("maxCount", settings.maxCount.toString())
-        put("user", settings.user)
-        put("dataSource", settings.dataSource)
-        put("locale", settings.locale)
+        put("maxCount", maxCount.toString())
+        put("user", user)
+        put("dataSource", dataSource)
+        put("locale", locale)
 
         if (queryMode == QueryMode.SQL) {
             put("flexibleSearchQuery", "")

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchExecutionContextSettingsAction.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchExecutionContextSettingsAction.kt
@@ -43,10 +43,11 @@ class FlexibleSearchExecutionContextSettingsAction : ExecutionContextSettingsAct
     override fun previewSettings(e: AnActionEvent, project: Project): String = e.flexibleSearchExecutionContextSettings { FlexibleSearchExecContext.defaultSettings() }
         .let {
             """<pre>
- · rows:   ${it.maxCount}
- · user:   ${it.user}
- · locale: ${it.locale}
- · tenant: ${it.dataSource}</pre>
+ · rows:    ${it.maxCount}
+ · user:    ${it.user}
+ · locale:  ${it.locale}
+ · tenant:  ${it.dataSource}
+ · timeout: ${it.timeout} ms</pre>
                 """.trimIndent()
         }
 
@@ -86,6 +87,7 @@ class FlexibleSearchExecutionContextSettingsAction : ExecutionContextSettingsAct
                         if (it.text.toIntOrNull() == null) error(UIBundle.message("please.enter.a.number.from.0.to.1", 1, Int.MAX_VALUE))
                         else null
                     }
+                    .focused()
                     .bindIntText({ settings.maxCount }, { value -> settings.maxCount = value })
             }.layout(RowLayout.PARENT_GRID)
 
@@ -118,6 +120,17 @@ class FlexibleSearchExecutionContextSettingsAction : ExecutionContextSettingsAct
                     .label("Tenant:")
                     .align(AlignX.FILL)
                     .bindItem({ settings.dataSource }, { value -> settings.dataSource = value ?: "master" })
+            }.layout(RowLayout.PARENT_GRID)
+
+            row {
+                textField()
+                    .align(AlignX.FILL)
+                    .label("Timeout (ms):")
+                    .validationOnInput {
+                        if (it.text.toIntOrNull() == null) error(UIBundle.message("please.enter.a.number.from.0.to.1", 1, Int.MAX_VALUE))
+                        else null
+                    }
+                    .bindIntText(settings::timeout)
             }.layout(RowLayout.PARENT_GRID)
         }
             .apply {

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchInEditorParametersView.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchInEditorParametersView.kt
@@ -89,13 +89,8 @@ class FlexibleSearchInEditorParametersView(private val project: Project, private
         }
 
         return panel {
-            notificationPanel()
-
-            if (virtualParameters.isEmpty()) {
-                notResultsPanel()
-            } else {
-                parametersPanel(virtualParameters, fileEditor, parentDisposable)
-            }
+            if (virtualParameters.isEmpty()) notResultsPanel()
+            else parametersPanel(virtualParameters, fileEditor, parentDisposable)
         }
             .apply {
                 border = JBUI.Borders.empty(5, 16, 10, 16)
@@ -108,24 +103,6 @@ class FlexibleSearchInEditorParametersView(private val project: Project, private
                 isFocusCycleRoot = true
             }
     }
-
-    private fun Panel.notificationPanel() = panel {
-        row {
-            cell(
-                InlineBanner(
-                    """
-                            <html><body style='width: 100%'>
-                            <p>This feature may be unstable. Use with caution.</p>
-                            <p>Submit issues or suggestions to project's GitHub <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/issues/new">repository</a>.</p>
-                            </body></html>
-                        """.trimIndent(),
-                    EditorNotificationPanel.Status.Promo
-                )
-            )
-                .align(Align.FILL)
-                .resizableColumn()
-        }.topGap(TopGap.SMALL)
-    }.customize(UnscaledGaps(16, 16, 16, 16))
 
     private fun Panel.notResultsPanel() = panel {
         row {

--- a/modules/groovy/exec/src/sap/commerce/toolset/groovy/console/HybrisGroovyConsole.kt
+++ b/modules/groovy/exec/src/sap/commerce/toolset/groovy/console/HybrisGroovyConsole.kt
@@ -52,10 +52,8 @@ class HybrisGroovyConsole(
     override fun currentExecutionContext(content: String) = GroovyExecContext(
         connection = activeConnection(),
         content = content,
-        settings = GroovyExecContext.defaultSettings(activeConnection()).copy(
-            timeout = activeConnection().timeout,
-            transactionMode = if (commitCheckbox.isSelected) TransactionMode.COMMIT else TransactionMode.ROLLBACK
-        ),
+        transactionMode = if (commitCheckbox.isSelected) TransactionMode.COMMIT else TransactionMode.ROLLBACK,
+        timeout = activeConnection().timeout,
     )
 
     override fun title() = "Groovy Scripting"

--- a/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/GroovyExecClient.kt
+++ b/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/GroovyExecClient.kt
@@ -48,7 +48,7 @@ class GroovyExecClient(project: Project, coroutineScope: CoroutineScope) : Defau
             .map { BasicNameValuePair(it.key, it.value) }
 
         val response = HacHttpClient.getInstance(project)
-            .post(actionUrl, params, true, context.settings.timeout, settings, context.replicaContext)
+            .post(actionUrl, params, true, context.timeout, settings, context.replicaContext)
         val statusLine = response.statusLine
         val statusCode = statusLine.statusCode
 

--- a/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/context/GroovyExecContext.kt
+++ b/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/context/GroovyExecContext.kt
@@ -30,13 +30,29 @@ data class GroovyExecContext(
     val connection: HacConnectionSettingsState,
     override val executionTitle: String = DEFAULT_TITLE,
     private val content: String,
-    val settings: Settings,
+    val timeout: Int,
+    val transactionMode: TransactionMode,
     val replicaContext: ReplicaContext? = null
 ) : ExecContext {
 
+    constructor(
+        connection: HacConnectionSettingsState,
+        executionTitle: String = DEFAULT_TITLE,
+        content: String,
+        replicaContext: ReplicaContext? = null,
+        settings: Settings,
+    ) : this(
+        connection = connection,
+        executionTitle = executionTitle,
+        content = content,
+        timeout = settings.timeout,
+        transactionMode = settings.transactionMode,
+        replicaContext = replicaContext,
+    )
+
     fun params(): Map<String, String> = buildMap {
         put("scriptType", "groovy")
-        put("commit", BooleanUtils.toStringTrueFalse(settings.transactionMode == TransactionMode.COMMIT))
+        put("commit", BooleanUtils.toStringTrueFalse(transactionMode == TransactionMode.COMMIT))
         put("script", content)
     }
 

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecuteAction.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecuteAction.kt
@@ -61,7 +61,7 @@ class GroovyExecuteAction : ExecuteStatementAction<HybrisGroovyConsole, GroovySp
                     executionTitle = "$prefix | ${it.replicaId} | ${GroovyExecContext.DEFAULT_TITLE}",
                     content = content,
                     replicaContext = it,
-                    settings = execContextSettings
+                    settings = execContextSettings,
                 )
             }
             .takeIf { it.isNotEmpty() }
@@ -70,7 +70,7 @@ class GroovyExecuteAction : ExecuteStatementAction<HybrisGroovyConsole, GroovySp
                     connection = connectionSettings,
                     executionTitle = "$prefix | ${GroovyExecContext.DEFAULT_TITLE}",
                     content = content,
-                    settings = execContextSettings
+                    settings = execContextSettings,
                 )
             )
 

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecutionContextSettingsAction.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecutionContextSettingsAction.kt
@@ -20,7 +20,6 @@ package sap.commerce.toolset.groovy.actionSystem
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.UIBundle
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.RowLayout
@@ -38,7 +37,7 @@ class GroovyExecutionContextSettingsAction : ExecutionContextSettingsAction<Groo
     override fun previewSettings(e: AnActionEvent, project: Project): String = e.groovyExecContextSettings { GroovyExecContext.defaultSettings() }
         .let {
             """<pre>
- · timeout:   ${it.timeout}</pre>
+ · timeout: ${it.timeout} ms</pre>
                 """.trimIndent()
         }
 
@@ -55,23 +54,22 @@ class GroovyExecutionContextSettingsAction : ExecutionContextSettingsAction<Groo
         editor.putUserData(GroovyExecContext.KEY_EXECUTION_SETTINGS, settings.immutable())
     }
 
-    override fun settingsPanel(e: AnActionEvent, project: Project, settings: GroovyExecContext.Settings.Mutable): DialogPanel {
-        return panel {
-            row {
-                textField()
-                    .align(AlignX.FILL)
-                    .label("Timeout (ms):")
-                    .validationOnInput {
-                        if (it.text.toIntOrNull() == null) error(UIBundle.message("please.enter.a.number.from.0.to.1", 1, Int.MAX_VALUE))
-                        else null
-                    }
-                    .bindIntText(settings::timeout)
-            }.layout(RowLayout.PARENT_GRID)
-        }
-            .apply {
-                border = JBUI.Borders.empty(8, 16)
-                focusTraversalPolicy = LayoutFocusTraversalPolicy()
-                isFocusCycleRoot = true
-            }
+    override fun settingsPanel(e: AnActionEvent, project: Project, settings: GroovyExecContext.Settings.Mutable) = panel {
+        row {
+            textField()
+                .align(AlignX.FILL)
+                .label("Timeout (ms):")
+                .validationOnInput {
+                    if (it.text.toIntOrNull() == null) error(UIBundle.message("please.enter.a.number.from.0.to.1", 1, Int.MAX_VALUE))
+                    else null
+                }
+                .focused()
+                .bindIntText(settings::timeout)
+        }.layout(RowLayout.PARENT_GRID)
     }
+        .apply {
+            border = JBUI.Borders.empty(8, 16)
+            focusTraversalPolicy = LayoutFocusTraversalPolicy()
+            isFocusCycleRoot = true
+        }
 }

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecutionContextSettingsAction.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecutionContextSettingsAction.kt
@@ -60,7 +60,7 @@ abstract class ExecutionContextSettingsAction<M : ExecContext.Settings.Mutable> 
 
         lateinit var myPopup: JBPopup
 
-        JBPopupFactory.getInstance().createComponentPopupBuilder(settingsPanel, null)
+        JBPopupFactory.getInstance().createComponentPopupBuilder(settingsPanel, settingsPanel.preferredFocusedComponent)
             .setMovable(false)
             .setResizable(false)
             .setRequestFocus(true)
@@ -93,5 +93,4 @@ abstract class ExecutionContextSettingsAction<M : ExecContext.Settings.Mutable> 
                 popup.showUnderneathOf(inputEvent.component)
             }
     }
-
 }

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/console/ImpExConsole.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/console/ImpExConsole.kt
@@ -33,6 +33,8 @@ import sap.commerce.toolset.impex.ImpExConstants
 import sap.commerce.toolset.impex.ImpExLanguage
 import sap.commerce.toolset.impex.exec.ImpExExecClient
 import sap.commerce.toolset.impex.exec.context.ImpExExecContext
+import sap.commerce.toolset.impex.exec.context.ImpExToggle
+import sap.commerce.toolset.impex.exec.context.ImpExValidationMode
 import java.awt.BorderLayout
 import java.io.Serial
 
@@ -47,7 +49,7 @@ class ImpExConsole(project: Project, coroutineScope: CoroutineScope) : HybrisCon
     private lateinit var enableCodeExecutionCheckbox: JBCheckBox
     private lateinit var directPersistenceCheckbox: JBCheckBox
     private lateinit var maxThreadsSpinner: JBIntSpinner
-    private lateinit var importModeComboBox: ComboBox<ImpExExecContext.ValidationMode>
+    private lateinit var importModeComboBox: ComboBox<ImpExValidationMode>
 
     init {
         val myPanel = panel {
@@ -55,12 +57,12 @@ class ImpExConsole(project: Project, coroutineScope: CoroutineScope) : HybrisCon
                 label("UTF-8")
 
                 importModeComboBox = comboBox(
-                    model = EnumComboBoxModel(ImpExExecContext.ValidationMode::class.java),
+                    model = EnumComboBoxModel(ImpExValidationMode::class.java),
                     renderer = SimpleListCellRenderer.create("...") { value -> value.name }
                 )
                     .label("Validation mode:")
                     .component
-                    .apply { selectedItem = ImpExExecContext.ValidationMode.IMPORT_STRICT }
+                    .apply { selectedItem = ImpExValidationMode.IMPORT_STRICT }
 
                 maxThreadsSpinner = spinner(1..Int.MAX_VALUE)
                     .label("Max threads:")
@@ -88,12 +90,12 @@ class ImpExConsole(project: Project, coroutineScope: CoroutineScope) : HybrisCon
         content = content,
         settings = ImpExExecContext.defaultSettings(activeConnection()).mutable()
             .apply {
-                validationMode = importModeComboBox.selectedItem as ImpExExecContext.ValidationMode
+                validationMode = importModeComboBox.selectedItem as ImpExValidationMode
                 maxThreads = maxThreadsSpinner.number
-                legacyMode = if (legacyModeCheckbox.isSelected) ImpExExecContext.Toggle.ON else ImpExExecContext.Toggle.OFF
-                enableCodeExecution = if (enableCodeExecutionCheckbox.isSelected) ImpExExecContext.Toggle.ON else ImpExExecContext.Toggle.OFF
-                sldEnabled = if (directPersistenceCheckbox.isSelected) ImpExExecContext.Toggle.ON else ImpExExecContext.Toggle.OFF
-                distributedMode = ImpExExecContext.Toggle.ON
+                legacyMode = if (legacyModeCheckbox.isSelected) ImpExToggle.ON else ImpExToggle.OFF
+                enableCodeExecution = if (enableCodeExecutionCheckbox.isSelected) ImpExToggle.ON else ImpExToggle.OFF
+                sldEnabled = if (directPersistenceCheckbox.isSelected) ImpExToggle.ON else ImpExToggle.OFF
+                distributedMode = ImpExToggle.ON
             }.immutable()
     )
 

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExDialect.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExDialect.kt
@@ -1,0 +1,24 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.impex.exec.context
+
+enum class ImpExDialect(val title: String) {
+    IMPEX("ImpEx"),
+    ACL("ACL")
+}

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExExecutionMode.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExExecutionMode.kt
@@ -1,0 +1,23 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.impex.exec.context
+
+enum class ImpExExecutionMode {
+    IMPORT, VALIDATE
+}

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExToggle.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExToggle.kt
@@ -1,0 +1,27 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.impex.exec.context
+
+enum class ImpExToggle(val value: String, val booleanValue: Boolean) {
+    ON("on", true), OFF("off", false);
+
+    companion object {
+        fun of(value: Boolean) = if (value) ON else OFF
+    }
+}

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExToggle.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExToggle.kt
@@ -19,7 +19,9 @@
 package sap.commerce.toolset.impex.exec.context
 
 enum class ImpExToggle(val value: String, val booleanValue: Boolean) {
-    ON("on", true), OFF("off", false);
+
+    ON("on", true),
+    OFF("off", false);
 
     companion object {
         fun of(value: Boolean) = if (value) ON else OFF

--- a/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExValidationMode.kt
+++ b/modules/impex/exec/src/sap/commerce/toolset/impex/exec/context/ImpExValidationMode.kt
@@ -1,0 +1,24 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.impex.exec.context
+
+enum class ImpExValidationMode(val title: String) {
+    IMPORT_STRICT("Strict"),
+    IMPORT_RELAXED("Relaxed"),
+}

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ConsoleImpExValidateAction.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ConsoleImpExValidateAction.kt
@@ -30,6 +30,7 @@ import sap.commerce.toolset.hac.exec.HacExecConnectionService
 import sap.commerce.toolset.impex.console.ImpExConsole
 import sap.commerce.toolset.impex.exec.ImpExExecClient
 import sap.commerce.toolset.impex.exec.context.ImpExExecContext
+import sap.commerce.toolset.impex.exec.context.ImpExExecutionMode
 
 class ConsoleImpExValidateAction : AnAction() {
 
@@ -44,7 +45,7 @@ class ConsoleImpExValidateAction : AnAction() {
         val context = ImpExExecContext(
             connection = connectionSettings,
             content = console.content,
-            executionMode = ImpExExecContext.ExecutionMode.VALIDATE,
+            executionMode = ImpExExecutionMode.VALIDATE,
             settings = ImpExExecContext.defaultSettings(connectionSettings)
         )
 

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ImpExValidateAction.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ImpExValidateAction.kt
@@ -32,6 +32,7 @@ import sap.commerce.toolset.impex.editor.impexExecutionContextSettings
 import sap.commerce.toolset.impex.editor.impexSplitEditorEx
 import sap.commerce.toolset.impex.exec.ImpExExecClient
 import sap.commerce.toolset.impex.exec.context.ImpExExecContext
+import sap.commerce.toolset.impex.exec.context.ImpExExecutionMode
 
 class ImpExValidateAction : ExecuteStatementAction<ImpExConsole, ImpExSplitEditorEx>(
     ImpExLanguage,
@@ -50,7 +51,7 @@ class ImpExValidateAction : ExecuteStatementAction<ImpExConsole, ImpExSplitEdito
         val context = ImpExExecContext(
             connection = connectionSettings,
             content = content,
-            executionMode = ImpExExecContext.ExecutionMode.VALIDATE,
+            executionMode = ImpExExecutionMode.VALIDATE,
             settings = settings
         )
 

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/editor/ImpExInEditorParametersView.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/editor/ImpExInEditorParametersView.kt
@@ -73,13 +73,8 @@ class ImpExInEditorParametersView(private val project: Project, private val coro
         }
 
         return panel {
-            notificationPanel()
-
-            if (virtualParameters.isEmpty()) {
-                notResultsPanel()
-            } else {
-                parametersPanel(virtualParameters, fileEditor)
-            }
+            if (virtualParameters.isEmpty()) notResultsPanel()
+            else parametersPanel(virtualParameters, fileEditor)
         }
             .apply {
                 border = JBUI.Borders.empty(5, 16, 10, 16)
@@ -92,24 +87,6 @@ class ImpExInEditorParametersView(private val project: Project, private val coro
                 isFocusCycleRoot = true
             }
     }
-
-    private fun Panel.notificationPanel() = panel {
-        row {
-            cell(
-                InlineBanner(
-                    """
-                            <html><body style='width: 100%'>
-                            <p>This feature is experimental and may be unstable. Use with caution.</p>
-                            <p>Submit issues or suggestions to project's GitHub <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/issues/new">repository</a>.</p>
-                            </body></html>
-                        """.trimIndent(),
-                    EditorNotificationPanel.Status.Promo
-                )
-            )
-                .align(Align.FILL)
-                .resizableColumn()
-        }.topGap(TopGap.SMALL)
-    }.customize(UnscaledGaps(16, 16, 16, 16))
 
     private fun Panel.notResultsPanel() = panel {
         row {
@@ -164,7 +141,7 @@ class ImpExInEditorParametersView(private val project: Project, private val coro
                         .filter { (key, _) -> key.element?.isEquivalentTo(it) ?: false }
                         .map { (pointer, virtualParameter) -> pointer to virtualParameter }
                         .firstOrNull()
-                        ?.takeIf { (_, virtualParameter) -> it.text == virtualParameter.name}
+                        ?.takeIf { (_, virtualParameter) -> it.text == virtualParameter.name }
                         ?: (SmartPointerManager.createPointer(it) to ImpExVirtualParameter.of(it))
                 }
                 ?: emptyMap()

--- a/modules/logging/exec/src/sap/commerce/toolset/logging/CxLoggerAccess.kt
+++ b/modules/logging/exec/src/sap/commerce/toolset/logging/CxLoggerAccess.kt
@@ -118,10 +118,8 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
             connection = server,
             executionTitle = "Fetching Loggers from SAP Commerce [${server.shortenConnectionName}]...",
             content = ExtensionsService.getInstance().findResource(CxLoggersConstants.EXTENSION_STATE_SCRIPT),
-            settings = GroovyExecContext.defaultSettings(server).copy(
-                transactionMode = TransactionMode.ROLLBACK,
-                timeout = server.timeout,
-            )
+            transactionMode = TransactionMode.ROLLBACK,
+            timeout = server.timeout,
         )
 
         executeLoggersGroovyScript(context, server) { _, groovyScriptResult ->
@@ -167,10 +165,8 @@ class CxLoggerAccess(private val project: Project, private val coroutineScope: C
             connection = server,
             executionTitle = "Applying the Loggers Template for SAP Commerce [${server.shortenConnectionName}]...",
             content = groovyScriptContent,
-            settings = GroovyExecContext.defaultSettings(server).copy(
-                transactionMode = TransactionMode.ROLLBACK,
-                timeout = server.timeout
-            )
+            transactionMode = TransactionMode.ROLLBACK,
+            timeout = server.timeout,
         )
 
         executeLoggersGroovyScript(

--- a/modules/polyglotQuery/ui/src/sap/commerce/toolset/polyglotQuery/actionSystem/PolyglotQueryExecuteAction.kt
+++ b/modules/polyglotQuery/ui/src/sap/commerce/toolset/polyglotQuery/actionSystem/PolyglotQueryExecuteAction.kt
@@ -45,6 +45,7 @@ import sap.commerce.toolset.polyglotQuery.editor.PolyglotQuerySplitEditorEx
 import sap.commerce.toolset.polyglotQuery.editor.polyglotQuerySplitEditor
 import sap.commerce.toolset.polyglotQuery.file.PolyglotQueryFile
 import sap.commerce.toolset.polyglotQuery.psi.PolyglotQueryTypeKeyName
+import sap.commerce.toolset.settings.state.TransactionMode
 
 class PolyglotQueryExecuteAction : ExecuteStatementAction<HybrisPolyglotQueryConsole, PolyglotQuerySplitEditorEx>(
     PolyglotQueryLanguage,
@@ -189,9 +190,8 @@ class PolyglotQueryExecuteAction : ExecuteStatementAction<HybrisPolyglotQueryCon
     
                             $scriptOutputLogic
                         """.trimIndent(),
-            settings = GroovyExecContext.Settings(
-                timeout = executionContextSettings.timeout,
-            )
+            transactionMode = TransactionMode.ROLLBACK,
+            timeout = executionContextSettings.timeout,
         )
 
         if (fileEditor.inEditorResults) {

--- a/modules/polyglotQuery/ui/src/sap/commerce/toolset/polyglotQuery/editor/PolyglotQueryInEditorParametersView.kt
+++ b/modules/polyglotQuery/ui/src/sap/commerce/toolset/polyglotQuery/editor/PolyglotQueryInEditorParametersView.kt
@@ -87,13 +87,8 @@ class PolyglotQueryInEditorParametersView(private val project: Project, private 
         }
 
         return panel {
-            notificationPanel()
-
-            if (virtualParameters.isEmpty()) {
-                notResultsPanel()
-            } else {
-                parametersPanel(virtualParameters, fileEditor, parentDisposable)
-            }
+            if (virtualParameters.isEmpty()) notResultsPanel()
+            else parametersPanel(virtualParameters, fileEditor, parentDisposable)
         }
             .apply {
                 border = JBUI.Borders.empty(5, 16, 10, 16)
@@ -106,24 +101,6 @@ class PolyglotQueryInEditorParametersView(private val project: Project, private 
                 isFocusCycleRoot = true
             }
     }
-
-    private fun Panel.notificationPanel() = panel {
-        row {
-            cell(
-                InlineBanner(
-                    """
-                            <html><body style='width: 100%'>
-                            <p>This feature may be unstable. Use with caution.</p>
-                            <p>Submit issues or suggestions to project's GitHub <a href="https://github.com/epam/sap-commerce-intellij-idea-plugin/issues/new">repository</a>.</p>
-                            </body></html>
-                        """.trimIndent(),
-                    EditorNotificationPanel.Status.Promo
-                )
-            )
-                .align(Align.FILL)
-                .resizableColumn()
-        }.topGap(TopGap.SMALL)
-    }.customize(UnscaledGaps(16, 16, 16, 16))
 
     private fun Panel.notResultsPanel() = panel {
         row {


### PR DESCRIPTION
- focus first component on showing settings popup
- same width for template loggers
- use settings for ExecContext, do not use Settings instance directly