### PR TITLE
xDebugger | Introduced customized and informative `toString` for crucial OOTB models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Handle non-property fields, such as `PK` [#1580](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1580)
 - Added `Navigate` to the Class for the model variable [#1583](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1583)
 - Display extension scope specific icons for model [#1584](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1584)
+- Introduced customized and informative `toString` for crucial OOTB models [#1585](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1585)
 
 ### `Type System` enhancements
 - Introduced custom icon for `dynamic` attributes [#1582](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1582)

--- a/modules/debugger/ui/src/sap/commerce/toolset/debugger/engine/managerThread/ModelToStringCommand.kt
+++ b/modules/debugger/ui/src/sap/commerce/toolset/debugger/engine/managerThread/ModelToStringCommand.kt
@@ -1,0 +1,161 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.debugger.engine.managerThread
+
+import com.intellij.debugger.JavaDebuggerBundle
+import com.intellij.debugger.engine.DebuggerUtils
+import com.intellij.debugger.engine.evaluation.EvaluateException
+import com.intellij.debugger.engine.evaluation.EvaluationContext
+import com.intellij.debugger.engine.evaluation.EvaluationContextImpl
+import com.intellij.debugger.impl.descriptors.data.UserExpressionData
+import com.intellij.debugger.ui.impl.watch.UserExpressionDescriptorImpl
+import com.intellij.debugger.ui.impl.watch.ValueDescriptorImpl
+import com.intellij.debugger.ui.tree.ValueDescriptor
+import com.intellij.debugger.ui.tree.render.DescriptorLabelListener
+import com.intellij.debugger.ui.tree.render.ToStringCommand
+import com.intellij.openapi.util.text.StringUtil
+import com.sun.jdi.ObjectReference
+import com.sun.jdi.Type
+
+class ModelToStringCommand(
+    private val valueDescriptor: ValueDescriptor,
+    private val labelListener: DescriptorLabelListener,
+    evaluationContext: EvaluationContext,
+    value: ObjectReference
+) : ToStringCommand(evaluationContext, value) {
+
+    override fun evaluationResult(message: String?) {
+        valueDescriptor.setValueLabel(StringUtil.notNullize(message))
+        labelListener.labelChanged()
+    }
+
+    override fun evaluationError(message: String?) {
+        val msg = "$message " + JavaDebuggerBundle.message(
+            "evaluation.error.cannot.evaluate.tostring",
+            value.type().name()
+        )
+        valueDescriptor.setValueLabelFailed(EvaluateException(msg, null))
+        labelListener.labelChanged()
+    }
+
+    override fun action() {
+        val project = evaluationContext.project
+        val expression = getExpression(value.type())
+        val text = DebuggerUtils.getInstance().createExpressionWithImports(expression.trimIndent())
+
+        val descriptor = UserExpressionData(
+            valueDescriptor as ValueDescriptorImpl,
+            value.type().name(),
+            "toString_renderer_" + value.type().name(),
+            text
+        )
+            .createDescriptor(project) as UserExpressionDescriptorImpl
+
+        try {
+            val calcValue = descriptor.calcValue(evaluationContext as EvaluationContextImpl)
+            val valueAsString = DebuggerUtils.getValueAsString(evaluationContext, calcValue)
+            evaluationResult(valueAsString)
+        } catch (e: EvaluateException) {
+            evaluationError(e.message)
+        }
+    }
+
+    private fun getExpression(type: Type) = when {
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.security.PrincipalModel") -> """
+                    String toString = toString();
+                    String uid = getUid();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+
+                    pk + " | " + uid
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.product.ProductModel") -> """
+                    String toString = toString();
+                    String code = getCode() == null ? "?" : getCode();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+
+                    if (getCatalogVersion() == null) return pk + " | " + code;
+
+                    String catalogId = getCatalogVersion().getCatalog() == null ? "?" : getCatalogVersion().getCatalog().getId();
+                    String version = getCatalogVersion().getVersion() == null ? "?" : getCatalogVersion().getVersion();
+                    
+                    pk + " | " + code + " | " + catalogId + " ("+ version + ")"
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.catalog.model.CatalogVersionModel") -> """
+                    String toString = toString();
+                    String catalogId = getCatalog() == null ? "?" : getCatalog().getId();
+                    String version = getVersion() == null ? "?" : getVersion();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+
+                    pk + " | " + catalogId + " ("+ version + ")"
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.order.AbstractOrderModel") -> """
+                    String toString = toString();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+                    String code = getCode() == null ? "?" : getCode();
+                    String userUid = getUser() == null ? "?" : getUser().getUid();
+
+                    pk + " | " + code + " | " + userUid
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.order.AbstractOrderEntryModel") -> """
+                    String toString = toString();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+                    Long quantity = getQuantity() == null ? "?" : getQuantity();
+                    de.hybris.platform.core.model.product.ProductModel product = getProduct()
+
+                    if (product == null) return pk + " | " + quantity + " ?";
+
+                    String productCode = product.getCode() == null ? "?" : product.getCode();
+                    String catalogId = product.getCatalogVersion().getCatalog() == null ? "?" : product.getCatalogVersion().getCatalog().getId();
+                    String version = product.getCatalogVersion().getVersion() == null ? "?" : product.getCatalogVersion().getVersion();
+                    
+                    pk + " | " + quantity + " " + productCode + " | " + catalogId + " ("+ version + ")"
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.media.MediaModel") -> """
+                    String toString = toString();
+                    String code = getCode() == null ? "?" : getCode();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+
+                    if (getCatalogVersion() == null) return pk + " | " + code;
+
+                    String catalogId = getCatalogVersion().getCatalog() == null ? "?" : getCatalogVersion().getCatalog().getId();
+                    String version = getCatalogVersion().getVersion() == null ? "?" : getCatalogVersion().getVersion();
+
+                    pk + " | " + code + " | " + catalogId + " ("+ version + ")"
+                """
+
+        DebuggerUtils.instanceOf(type, "de.hybris.platform.core.model.c2l.C2LItemModel") -> """
+                    String toString = toString();
+                    String pk = toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+                    String isocode = getIsocode() == null ? "?" : getIsocode();
+
+                    pk + " | " + isocode
+                """
+
+        else -> """
+                    String toString = toString();
+                    toString.substring(toString.indexOf("(") + 1, toString.length()-1);
+                """
+
+    }
+}

--- a/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/LocalizedValueDescriptor.kt
+++ b/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/LocalizedValueDescriptor.kt
@@ -1,0 +1,38 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.debugger.ui.tree
+
+import com.intellij.debugger.ui.tree.render.OnDemandRenderer
+import com.intellij.openapi.project.Project
+import com.sun.jdi.Method
+import com.sun.jdi.ObjectReference
+import javax.swing.Icon
+
+class LocalizedValueDescriptor(
+    parentObject: ObjectReference,
+    method: Method,
+    presentationName: String,
+    project: Project,
+    icon: Icon? = null,
+) : MethodValueDescriptor(parentObject, method, presentationName, project, icon) {
+
+    init {
+        putUserData(OnDemandRenderer.ON_DEMAND_CALCULATED, false)
+    }
+}

--- a/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/render/ModelNodeRenderer.kt
+++ b/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/render/ModelNodeRenderer.kt
@@ -1,0 +1,57 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.debugger.ui.tree.render
+
+import com.intellij.debugger.engine.DebuggerUtils
+import com.intellij.debugger.engine.SuspendContextImpl
+import com.intellij.debugger.engine.evaluation.EvaluationContext
+import com.intellij.debugger.ui.tree.ValueDescriptor
+import com.intellij.debugger.ui.tree.render.DescriptorLabelListener
+import com.intellij.debugger.ui.tree.render.ReferenceRenderer
+import com.intellij.debugger.ui.tree.render.ToStringRenderer
+import com.intellij.debugger.ui.tree.render.ValueLabelRenderer
+import com.intellij.xdebugger.impl.ui.XDebuggerUIConstants
+import com.sun.jdi.ObjectReference
+import sap.commerce.toolset.debugger.engine.managerThread.ModelToStringCommand
+
+internal class ModelNodeRenderer : ReferenceRenderer(), ValueLabelRenderer {
+
+    private val fallbackRenderer by lazy { ToStringRenderer() }
+
+    override fun getUniqueId() = "[y] Model Renderer"
+
+    override fun calcLabel(
+        valueDescriptor: ValueDescriptor,
+        evaluationContext: EvaluationContext,
+        labelListener: DescriptorLabelListener
+    ): String? {
+        val value = valueDescriptor.value as? ObjectReference
+            ?: return fallbackRenderer.calcLabel(valueDescriptor, evaluationContext, labelListener)
+
+        DebuggerUtils.ensureNotInsideObjectConstructor(value, evaluationContext)
+//        BatchEvaluator.getBatchEvaluator(evaluationContext)
+//            .invoke(ModelToStringCommand(valueDescriptor, labelListener, evaluationContext, value))
+
+        val suspendContext = evaluationContext.suspendContext as SuspendContextImpl
+        suspendContext.managerThread.invokeCommand(ModelToStringCommand(valueDescriptor, labelListener, evaluationContext, value))
+
+
+        return XDebuggerUIConstants.getCollectingDataMessage()
+    }
+}

--- a/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/render/ModelRenderer.kt
+++ b/modules/debugger/ui/src/sap/commerce/toolset/debugger/ui/tree/render/ModelRenderer.kt
@@ -26,6 +26,7 @@ import com.intellij.debugger.ui.impl.watch.ValueDescriptorImpl
 import com.intellij.debugger.ui.tree.render.ChildrenRenderer
 import com.intellij.debugger.ui.tree.render.CompoundRendererProvider
 import com.intellij.debugger.ui.tree.render.ValueIconRenderer
+import com.intellij.debugger.ui.tree.render.ValueLabelRenderer
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.readAction
 import com.intellij.util.PsiNavigateUtil
@@ -45,6 +46,7 @@ class ModelRenderer : CompoundRendererProvider() {
     override fun getClassName() = "de.hybris.platform.servicelayer.model.AbstractItemModel"
     override fun isEnabled() = true
     override fun getChildrenRenderer(): ChildrenRenderer = ModelChildrenRenderer()
+    override fun getValueLabelRenderer(): ValueLabelRenderer = ModelNodeRenderer()
     override fun getIconRenderer() = ValueIconRenderer { x, y, t ->
         val typeCode = x.type?.name()?.toTypeCode() ?: return@ValueIconRenderer HybrisIcons.Y.LOGO_GREEN
         val meta = TSMetaModelAccess.getInstance(y.project).findMetaItemByName(typeCode) ?: return@ValueIconRenderer HybrisIcons.Y.LOGO_GREEN
@@ -74,8 +76,6 @@ class ModelRenderer : CompoundRendererProvider() {
 
                         withContext(Dispatchers.EDT) {
                             navigatable.navigate(true)
-//                            PsiNavigateUtil.navigate(navigationElement)
-//                            DebuggerUIUtil.invokeLater { PsiNavigateUtil.navigate(navigationElement) }
                         }
                     }
                 }


### PR DESCRIPTION
### Supported types:

- `de.hybris.platform.core.model.security.PrincipalModel`
- `de.hybris.platform.core.model.product.ProductModel`
- `de.hybris.platform.catalog.model.CatalogVersionModel`
- `de.hybris.platform.core.model.order.AbstractOrderModel`
- `de.hybris.platform.core.model.order.AbstractOrderEntryModel`
- `de.hybris.platform.core.model.media.MediaModel`
- `de.hybris.platform.core.model.c2l.C2LItemModel`
- and fallback to just `PK`

<img width="771" height="305" alt="Screenshot 2025-10-06 at 23 48 56" src="https://github.com/user-attachments/assets/b3de4483-ad47-4a44-8cac-ac283b450e81" />
<img width="508" height="99" alt="Screenshot 2025-10-07 at 14 25 06" src="https://github.com/user-attachments/assets/c325b94f-0b63-4666-8a79-72efd89dc35d" />
<img width="474" height="100" alt="Screenshot 2025-10-07 at 14 24 44" src="https://github.com/user-attachments/assets/eca8c5b4-1216-4f35-a451-ffaebe51a0c4" />
<img width="553" height="132" alt="Screenshot 2025-10-07 at 14 23 38" src="https://github.com/user-attachments/assets/7de813f4-7e3d-4e4c-87ac-2c2aaa3aca63" />
<img width="1091" height="1042" alt="Screenshot 2025-10-07 at 12 58 44" src="https://github.com/user-attachments/assets/09a57b08-5f88-41cf-a0d0-09aa6acbe096" />
<img width="598" height="59" alt="Screenshot 2025-10-07 at 12 57 05" src="https://github.com/user-attachments/assets/4f2c89e4-032e-41de-93db-4c2aacd794e5" />
<img width="700" height="130" alt="Screenshot 2025-10-06 at 23 52 56" src="https://github.com/user-attachments/assets/9fbb9c89-59e3-4705-94c7-02e2535dac25" />
<img width="851" height="223" alt="Screenshot 2025-10-06 at 23 51 45" src="https://github.com/user-attachments/assets/d77b0bdf-4b93-4bde-b19d-3266ca1c112f" />
