### PR TITLE
xDebugger | Enhanced support of the `localized` fields by showing the values in all locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fallback to JDI `toString` when there is no model class available [#1587](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1587)
 - Auto-generate `toString` for atomic unique attributes for non-preconfigured models [#1588](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1588)
 - Inform about obsolete and not available anymore Item Types [#1589](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1589)
+- Enhanced support of the `localized` fields by showing the values in all locales [#1590](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1590)
 
 ### `Type System` enhancements
 - Introduced custom icon for `dynamic` attributes [#1582](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1582)

--- a/modules/typeSystem/core/src/sap/commerce/toolset/typeSystem/meta/TSMetaHelper.kt
+++ b/modules/typeSystem/core/src/sap/commerce/toolset/typeSystem/meta/TSMetaHelper.kt
@@ -61,7 +61,7 @@ object TSMetaHelper {
             type = type.replace(HybrisConstants.TS_ATTRIBUTE_LOCALIZED_PREFIX, "")
         }
         var flattenType = allTypes[type]?.flattenType ?: plainType
-        flattenType = if (localized) HybrisConstants.TS_ATTRIBUTE_LOCALIZED_PREFIX + flattenType
+        flattenType = if (localized && !flattenType.startsWith(HybrisConstants.TS_ATTRIBUTE_LOCALIZED_PREFIX)) HybrisConstants.TS_ATTRIBUTE_LOCALIZED_PREFIX + flattenType
         else flattenType
 
         return escapeType(flattenType)


### PR DESCRIPTION
<img width="958" height="568" alt="Screenshot 2025-10-08 at 20 28 59" src="https://github.com/user-attachments/assets/133dbd6a-5a06-4ef7-a02b-9e9db40d4237" />
<img width="836" height="280" alt="Screenshot 2025-10-08 at 20 00 09" src="https://github.com/user-attachments/assets/2d81759e-4e50-4a30-b9b1-ae3a748c336c" />
<img width="470" height="618" alt="Screenshot 2025-10-08 at 19 59 02" src="https://github.com/user-attachments/assets/01a36695-01da-488f-880a-491109dbe099" />
