### PR TITLE
FlexibleSearch | Added support of the aliases in the `Order` clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Do not register `resources` directory for OOTB extensions in the readonly mode [#1601](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1601)
 - Adjusted default project & application settings [#1602](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1602)
 
+### `FlexibleSearch` enhancements
+- Added support of the aliases in the `Order` clause [#1605](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1605)
+
 ### `CCv2` enhancements
 - Added `S-User` alias for service `modified by` characteristic [#1596](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1596)
 

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/psi/reference/FxSColumnNameReference.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/psi/reference/FxSColumnNameReference.kt
@@ -178,6 +178,12 @@ class FxSColumnNameReference(owner: FlexibleSearchColumnName) : PsiReferenceBase
             ?.parentOfType<FlexibleSearchSelectCoreSelect>()
             ?.resultColumns
             ?.let { PsiTreeUtil.findChildrenOfType(it, FlexibleSearchColumnAliasName::class.java) }
+            ?: PsiTreeUtil.getParentOfType(element, FlexibleSearchOrderClause::class.java)
+                ?.parentOfType<FlexibleSearchSelectStatement>()
+                ?.selectCoreSelectList
+                ?.mapNotNull { it.resultColumns }
+                ?.map { PsiTreeUtil.findChildrenOfType(it, FlexibleSearchColumnAliasName::class.java) }
+                ?.flatten()
     }
 
 }


### PR DESCRIPTION
<img width="612" height="182" alt="Screenshot 2025-10-19 at 19 02 27" src="https://github.com/user-attachments/assets/a7b8d91e-0d45-4fdb-bd82-85d1d186ecb2" />
