### PR TITLE
FlexibleSearch | Removed `Ok` button from the Search Restrictions dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2025.2.4.6]
+
+<cite>Release contributors</cite>
+- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+
+### `FlexibleSearch` enhancements
+- Removed `Ok` button from the Search Restrictions dialog[#1636](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1636)
+
 ## [2025.2.4.5]
 
 <cite>Release contributors</cite>
@@ -2332,8 +2340,8 @@ Due severe API changes it is highly advised to backup the project and import it 
 ## [2023.1.0]
 
 <cite>Release contributors</cite>
-- 3 PR(s) by [Andrei Lisetskii](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2023.1.0+author%3Aabsinthminded+is%3Apr)
 - 23 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2023.1.0+author%3Amlytvyn+is%3Apr)
+- 3 PR(s) by [Andrei Lisetskii](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2023.1.0+author%3Aabsinthminded+is%3Apr)
 
 ### Features
 - Compatibility adjustments [#195](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/195)
@@ -2368,8 +2376,8 @@ Due severe API changes it is highly advised to backup the project and import it 
 ## [2022.3.1]
 
 <cite>Release contributors</cite>
-- 1 PR by [Pawel Boron](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2022.3.1+author%3ARemilo7+is%3Apr)
 - 99 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2022.3.1+author%3Amlytvyn+is%3Apr)
+- 1 PR by [Pawel Boron](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2022.3.1+author%3ARemilo7+is%3Apr)
 
 ### Features - IDEA Ultimate
 - Added navigation to TypeCode Interceptor declaration(s) [#188](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/188)

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ intellij.update.since.until.build=true
 
 intellij.plugin.id=com.intellij.idea.plugin.sap.commerce
 intellij.plugin.name=SAP Commerce Developers Toolset
-intellij.plugin.version=2025.2.4.5
+intellij.plugin.version=2025.2.4.6
 intellij.plugin.since.build=252.23892.409
 intellij.plugin.until.build=252.*
 

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/ui/FlexibleSearchRestrictionsDialog.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/ui/FlexibleSearchRestrictionsDialog.kt
@@ -18,6 +18,7 @@
 
 package sap.commerce.toolset.flexibleSearch.ui
 
+import com.intellij.CommonBundle
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
@@ -71,8 +72,10 @@ class FlexibleSearchRestrictionsDialog(
     init {
         title = "FlexibleSearch Restrictions"
         super.init()
+        setCancelButtonText(CommonBundle.getCloseButtonText())
     }
 
+    override fun createActions() = arrayOf(cancelAction)
     override fun getInitialSize() = JBUI.DialogSizes.large()
     override fun createLeftSideActions() = arrayOf(copyToImpExButton)
 


### PR DESCRIPTION
<img width="862" height="1474" alt="Screenshot 2025-11-01 at 13 53 23" src="https://github.com/user-attachments/assets/70e31a70-0b42-4de6-82be-ce59d72f7891" />
