### PR TITLE
hAC | Display website access errors in the Browser for `manual` authentication mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2025.2.4.6]
 
 <cite>Release contributors</cite>
-- 5 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+- 6 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
 
 ### `Project Import` enhancements
 - Register new `Test Classes` library for OOTB `testsrc` of the Web modules [#1637](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1637)
@@ -13,6 +13,7 @@
 - Introduced possibility to authenticate user manually in hAC [#1638](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1638)
 - Added support of the _proxy_ authentication for `manual` authentication mode [#1639](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1639)
 - Respect basic authorization for proxy authentication of the `manual` authentication mode [#1640](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1640)
+- Display website access errors in the Browser for `manual` authentication mode [#1641](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1641)
 
 ## [2025.2.4.5]
 

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/ui/HacManualAuthenticationDialog.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/ui/HacManualAuthenticationDialog.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.util.Ref
 import com.intellij.ui.jcef.*
 import com.intellij.util.ui.JBUI
 import kotlinx.coroutines.*
+import org.cef.handler.CefLoadHandler
 import sap.commerce.toolset.hac.auth.HacAuthenticationContext
 import sap.commerce.toolset.hac.auth.ProxyAuthCefRequestHandlerAdapter
 import sap.commerce.toolset.hac.exec.settings.state.HacConnectionSettingsState
@@ -55,6 +56,11 @@ class HacManualAuthenticationDialog(
 
             setProperty(JBCefBrowser.Properties.FOCUS_ON_SHOW, true)
             jbCefClient.setProperty(JBCefClient.Properties.JS_QUERY_POOL_SIZE, 20)
+
+            setErrorPage { errorCode, errorText, failedUrl ->
+                if (errorCode == CefLoadHandler.ErrorCode.ERR_ABORTED) null
+                else JBCefBrowserBase.ErrorPage.DEFAULT.create(errorCode, errorText, failedUrl)
+            }
 
             if (settings.proxyAuthentication) {
                 jbCefClient.addRequestHandler(


### PR DESCRIPTION
<img width="1112" height="812" alt="Screenshot 2025-11-05 at 20 16 57" src="https://github.com/user-attachments/assets/fcbff82a-33b7-4c87-8627-19987d6e6ec6" />
