### PR TITLE
FlexibleSearch | Create a `Scratch` file from the copied FlexibleSearch query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 ## [2025.2.4.6]
 
 <cite>Release contributors</cite>
-- 6 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+- 7 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
 
 ### `Project Import` enhancements
 - Register new `Test Classes` library for OOTB `testsrc` of the Web modules [#1637](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1637)
 
 ### `FlexibleSearch` enhancements
 - Removed `Ok` button from the Search Restrictions dialog [#1636](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1636)
+- Create a `Scratch` file from the copied FlexibleSearch query [#1642](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1642)
 
 ### `hAC` enhancements
 - Introduced possibility to authenticate user manually in hAC [#1638](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1638)

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInsight/daemon/FlexibleSearchQueryLineMarkerProvider.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInsight/daemon/FlexibleSearchQueryLineMarkerProvider.kt
@@ -33,10 +33,12 @@ import com.intellij.psi.PsiVariable
 import com.intellij.psi.codeStyle.CodeStyleManager
 import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.Notifications
+import sap.commerce.toolset.flexibleSearch.FlexibleSearchLanguage
 import sap.commerce.toolset.flexibleSearch.FxSUtils
 import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchElementFactory
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.isNotHybrisProject
+import sap.commerce.toolset.scratch.createScratchFile
 import java.awt.datatransfer.StringSelection
 import java.util.function.Supplier
 import javax.swing.Icon
@@ -80,6 +82,7 @@ class FlexibleSearchQueryLineMarkerProvider : LineMarkerProviderDescriptor() {
 
         Notifications.create(NotificationType.INFORMATION, i18n("hybris.editor.gutter.fsq.notification.title"), formattedExpression)
             .hideAfter(10)
+            .addAction("Open as a Scratch File") { _, _ -> createScratchFile(project, formattedExpression, FlexibleSearchLanguage) }
             .notify(project)
     }
 

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchCopyToClipboardAction.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchCopyToClipboardAction.kt
@@ -26,8 +26,10 @@ import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.DumbAwareAction
 import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.Notifications
+import sap.commerce.toolset.flexibleSearch.FlexibleSearchLanguage
 import sap.commerce.toolset.flexibleSearch.editor.flexibleSearchSplitEditor
 import sap.commerce.toolset.i18n
+import sap.commerce.toolset.scratch.createScratchFile
 import java.awt.datatransfer.StringSelection
 
 class FlexibleSearchCopyToClipboardAction : DumbAwareAction() {
@@ -55,6 +57,7 @@ class FlexibleSearchCopyToClipboardAction : DumbAwareAction() {
 
         Notifications.create(NotificationType.INFORMATION, i18n("hybris.editor.gutter.fsq.notification.title"), textToCopy)
             .hideAfter(10)
+            .addAction("Open as a Scratch File") { _, _ -> createScratchFile(project, textToCopy, FlexibleSearchLanguage) }
             .notify(project)
     }
 

--- a/modules/shared/core/src/sap/commerce/toolset/Notifications.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/Notifications.kt
@@ -28,7 +28,6 @@ import com.intellij.openapi.wm.WindowManager
 import com.intellij.ui.SystemNotifications
 import com.intellij.util.concurrency.AppExecutorUtil
 import java.util.concurrent.TimeUnit
-import java.util.function.BiConsumer
 
 class Notifications private constructor(type: NotificationType, title: String, content: String) {
 
@@ -64,13 +63,13 @@ class Notifications private constructor(type: NotificationType, title: String, c
         return this
     }
 
-    fun addAction(text: String, biConsumer: BiConsumer<AnActionEvent, Notification>): Notifications {
+    fun addAction(text: String, biConsumer: (AnActionEvent, Notification) -> Unit): Notifications {
         notification.addAction(object : NotificationAction(text) {
             override fun actionPerformed(
                 e: AnActionEvent,
                 notification: Notification
             ) {
-                biConsumer.accept(e, notification)
+                biConsumer(e, notification)
             }
         })
         return this

--- a/modules/shared/core/src/sap/commerce/toolset/scratch/Util.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/scratch/Util.kt
@@ -1,0 +1,51 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.scratch
+
+import com.intellij.ide.scratch.ScratchRootType
+import com.intellij.lang.Language
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.edtWriteAction
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+fun createScratchFile(
+    project: Project,
+    text: String,
+    language: Language
+) {
+    CoroutineScope(Dispatchers.Default).launch {
+        val scratchRoot = ScratchRootType.getInstance()
+        val fileType = FileTypeRegistry.getInstance().findFileTypeByLanguage(language)
+            ?: return@launch
+        val fileName = "scratch.${fileType.defaultExtension}"
+
+        val vf = edtWriteAction { scratchRoot.createScratchFile(project, fileName, language, text) }
+            ?: return@launch
+
+        withContext(Dispatchers.EDT) {
+            FileEditorManager.getInstance(project).openFile(vf, true)
+        }
+    }
+}


### PR DESCRIPTION
<img width="588" height="288" alt="Screenshot 2025-11-05 at 20 44 33" src="https://github.com/user-attachments/assets/e6f4c47d-2a69-41ff-ab57-8efb92a29bba" />
<img width="533" height="252" alt="Screenshot 2025-11-05 at 20 44 40" src="https://github.com/user-attachments/assets/85601e18-334a-4bbd-a377-efa90aaae298" />
<img width="391" height="242" alt="Screenshot 2025-11-05 at 20 44 44" src="https://github.com/user-attachments/assets/ad1c360c-196e-4dec-a277-0503617aacd9" />
