### PR TITLE
Groovy | Added informative `Got it Tooltip` for new Spring context mode and configurable default state of the respective flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## [2025.2.4.6]
 
 <cite>Release contributors</cite>
-- 12 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+- 13 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
 
 ### `Groovy` enhancements
 - Introduced `local` Spring context mode within groovy files (slow operation) [#1645](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1645)
 - Added icons for transaction mode toggle [#1647](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1647)
+- Added informative `Got it Tooltip` for new Spring context mode and configurable default state of the respective flag [#1648](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1648)
 
 ### `Spring` enhancements
 - Improve Spring beans resolution in case of `module-less` files, like Scratch-files [#1646](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1646)

--- a/TECH_NOTES.md
+++ b/TECH_NOTES.md
@@ -46,3 +46,7 @@ invokeLater {
     peer.window?.pack()
 }
 ```
+
+### Notifications
+
+* Use `Reset Got It Tooltips` internal action to simplify testing of the `GotItToolip` 

--- a/modules/groovy/core/src/sap/commerce/toolset/groovy/lang/resolve/GroovySpringBeanNonCodeMembersContributor.kt
+++ b/modules/groovy/core/src/sap/commerce/toolset/groovy/lang/resolve/GroovySpringBeanNonCodeMembersContributor.kt
@@ -25,7 +25,8 @@ import com.intellij.util.asSafely
 import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrImplicitVariableImpl
 import org.jetbrains.plugins.groovy.lang.resolve.NonCodeMembersContributor
 import sap.commerce.toolset.groovy.GroovyConstants
-import sap.commerce.toolset.groovy.SpringContextMode
+import sap.commerce.toolset.settings.DeveloperSettings
+import sap.commerce.toolset.settings.state.SpringContextMode
 import sap.commerce.toolset.spring.SpringHelper
 
 class GroovySpringBeanNonCodeMembersContributor : NonCodeMembersContributor() {
@@ -47,7 +48,7 @@ class GroovySpringBeanNonCodeMembersContributor : NonCodeMembersContributor() {
             ?: return
         val contextMode = containingFile.originalFile.virtualFile
             ?.getUserData(GroovyConstants.KEY_SPRING_CONTEXT_MODE)
-            ?: SpringContextMode.DISABLED
+            ?: DeveloperSettings.getInstance(place.project).groovySettings.springContextMode
 
         if (contextMode == SpringContextMode.DISABLED) return
 

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecutionModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecutionModeActionGroup.kt
@@ -26,13 +26,13 @@ import com.intellij.openapi.actionSystem.ex.ActionUtil
 import sap.commerce.toolset.groovy.editor.groovyExecContextSettings
 import sap.commerce.toolset.groovy.exec.context.GroovyExecContext
 import sap.commerce.toolset.hac.exec.HacExecConnectionService
-import sap.commerce.toolset.ui.ActionButtonWithTextAndDescription
+import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
 class GroovyExecutionModeActionGroup : DefaultActionGroup() {
 
     init {
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescription(this))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextAction.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextAction.kt
@@ -27,8 +27,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import sap.commerce.toolset.groovy.GroovyConstants
-import sap.commerce.toolset.groovy.SpringContextMode
 import sap.commerce.toolset.i18n
+import sap.commerce.toolset.settings.DeveloperSettings
+import sap.commerce.toolset.settings.state.SpringContextMode
 
 abstract class GroovySpringContextAction(private val contextMode: SpringContextMode, description: String) : CheckboxAction(
     contextMode.presentationText, description, null
@@ -39,6 +40,7 @@ abstract class GroovySpringContextAction(private val contextMode: SpringContextM
     override fun isSelected(e: AnActionEvent): Boolean {
         val currentMode = e.getData(CommonDataKeys.VIRTUAL_FILE)
             ?.getUserData(GroovyConstants.KEY_SPRING_CONTEXT_MODE)
+            ?: e.project?.let { DeveloperSettings.getInstance(it).groovySettings.springContextMode }
             ?: SpringContextMode.DISABLED
 
         return currentMode == contextMode

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
@@ -27,10 +27,10 @@ import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.ui.GotItTooltip
 import com.intellij.ui.scale.JBUIScale
 import sap.commerce.toolset.GotItTooltips
-import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.groovy.GroovyConstants
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.settings.DeveloperSettings
+import sap.commerce.toolset.settings.state.SpringContextMode
 import sap.commerce.toolset.triggerAction
 import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
@@ -54,8 +54,8 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup() {
                 id = GotItTooltips.SPRING_CONTEXT_MODE,
                 textSupplier = {
                     """
-                    You can enable Spring Context within your groovy scripts by switching to ${icon(HybrisIcons.Spring.LOCAL)} local resolution mode.
-                    <br>Resolution of the Spring Context is a heavy operation, that's why it is ${icon(HybrisIcons.Spring.DISABLED)} disabled by default for every new Editor, but it can be changed via ${
+                    You can enable Spring Context within your groovy scripts by switching to ${icon(SpringContextMode.LOCAL.icon)} ${code(SpringContextMode.LOCAL.presentationText)} resolution mode.
+                    <br>Resolution of the Spring Context is a heavy operation, that's why it is ${icon(SpringContextMode.DISABLED.icon)} ${code(SpringContextMode.DISABLED.presentationText)} by default for every new Editor, but it can be changed via ${
                         link("Groovy settings") {
                             DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
                                 ?.triggerAction("hybris.groovy.openSettings")

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
@@ -18,29 +18,75 @@
 
 package sap.commerce.toolset.groovy.actionSystem
 
+import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.ui.GotItTooltip
+import com.intellij.ui.scale.JBUIScale
+import sap.commerce.toolset.GotItTooltips
+import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.groovy.GroovyConstants
-import sap.commerce.toolset.groovy.SpringContextMode
 import sap.commerce.toolset.i18n
-import sap.commerce.toolset.ui.ActionButtonWithTextAndDescription
+import sap.commerce.toolset.settings.DeveloperSettings
+import sap.commerce.toolset.triggerAction
+import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
 class GroovySpringContextModeActionGroup : DefaultActionGroup() {
 
+    private val componentProvider = ActionButtonWithTextAndDescriptionComponentProvider(
+        actionGroup = this,
+        gotItTooltipProvider = { component ->
+            val before = """<pre class="code">
+                import de.hybris.platform.core.Registry
+                import de.hybris.platform.product.ProductService
+
+                def productService = Registry.applicationContext
+                    .getBean('productService', ProductService.class)
+
+                productService.getProduct('test')</pre>
+            """.trimIndent()
+            val after = "<pre class=\"code\">productService.getProduct('test')</pre>"
+
+            GotItTooltip(
+                id = GotItTooltips.SPRING_CONTEXT_MODE,
+                textSupplier = {
+                    """
+                    You can enable Spring Context within your groovy scripts by switching to ${icon(HybrisIcons.Spring.LOCAL)} local resolution mode.
+                    <br>Resolution of the Spring Context is a heavy operation, that's why it is ${icon(HybrisIcons.Spring.DISABLED)} disabled by default for every new Editor, but it can be changed via ${
+                        link("Groovy settings") {
+                            DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
+                                ?.triggerAction("hybris.groovy.openSettings")
+                        }
+                    }.
+                    <br><br>Before:
+                    <br>${before}
+
+                    <br>After:
+                    <br>${after}
+                """.trimIndent()
+                },
+                parentDisposable = null
+            )
+                .withMaxWidth(JBUIScale.scale(420))
+                .withHeader("Welcome Spring Context in Groovy!")
+        }
+    )
+
     init {
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescription(this))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, componentProvider)
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT
 
     override fun update(e: AnActionEvent) {
         val vf = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val project = e.project ?: return
         val currentMode = vf.getUserData(GroovyConstants.KEY_SPRING_CONTEXT_MODE)
-            ?: SpringContextMode.DISABLED
+            ?: DeveloperSettings.getInstance(project).groovySettings.springContextMode
 
         e.presentation.icon = currentMode.icon
         e.presentation.text = i18n("hybris.groovy.actions.springContext.mode", currentMode.presentationText)

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
@@ -26,13 +26,13 @@ import com.intellij.openapi.actionSystem.ex.ActionUtil
 import sap.commerce.toolset.groovy.editor.groovyExecContextSettings
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.settings.state.TransactionMode
-import sap.commerce.toolset.ui.ActionButtonWithTextAndDescription
+import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
 class GroovyTransactionModeActionGroup : DefaultActionGroup() {
 
     init {
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescription(this))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this,))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/options/GroovyProjectSettingsConfigurableProvider.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/options/GroovyProjectSettingsConfigurableProvider.kt
@@ -21,14 +21,19 @@ package sap.commerce.toolset.groovy.options
 import com.intellij.openapi.options.BoundSearchableConfigurable
 import com.intellij.openapi.options.ConfigurableProvider
 import com.intellij.openapi.project.Project
+import com.intellij.ui.EnumComboBoxModel
+import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.toNullableProperty
 import com.intellij.ui.layout.selected
 import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.Plugin
 import sap.commerce.toolset.groovy.actionSystem.GroovyFileToolbarInstaller
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.isHybrisProject
+import sap.commerce.toolset.settings.state.SpringContextMode
 import sap.commerce.toolset.settings.yDeveloperSettings
 import javax.swing.JCheckBox
 
@@ -46,28 +51,41 @@ class GroovyProjectSettingsConfigurableProvider(private val project: Project) : 
         private lateinit var enableActionToolbar: JCheckBox
 
         override fun createPanel() = panel {
-            group("Language") {
-                row {
-                    enableActionToolbar = checkBox("Enable actions toolbar for each Groovy file")
-                        .bindSelected(mutable::enableActionsToolbar)
-                        .comment("Actions toolbar enables possibility to change current remote SAP Commerce session and perform operations on current file, such as `Execute on remote server`")
-                        .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
-                        .component
-                }
-                row {
-                    checkBox("Enable actions toolbar for a Test Groovy file")
-                        .bindSelected(mutable::enableActionsToolbarForGroovyTest)
-                        .comment("Enables Actions toolbar for the groovy files located in the <strong>${HybrisConstants.TEST_SRC_DIRECTORY}</strong> or <strong>${HybrisConstants.GROOVY_TEST_SRC_DIRECTORY}</strong> directory.")
-                        .enabledIf(enableActionToolbar.selected)
-                        .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
-                }
-                row {
-                    checkBox("Enable actions toolbar for a IDE Groovy scripts")
-                        .bindSelected(mutable::enableActionsToolbarForGroovyIdeConsole)
-                        .comment("Enables Actions toolbar for the groovy files located in the <strong>${HybrisConstants.IDE_CONSOLES_PATH}</strong> (In Project View, Scratches and Consoles -> IDE Consoles).")
-                        .enabledIf(enableActionToolbar.selected)
-                        .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
-                }
+            row {
+                comboBox(
+                    EnumComboBoxModel(SpringContextMode::class.java),
+                    renderer = SimpleListCellRenderer.create("?") { it.presentationText }
+                )
+                    .label("Spring context mode:")
+                    .comment("""
+                        Defines default mode for each new Editor.<br>
+                        <cod>Local</code> mode enables direct resolution of the Spring beans, so it will be possible to enable code completion for such statements <code>productService.getProduct(..)</code>. 
+                    """.trimIndent())
+                    .bindItem(mutable::springContextMode.toNullableProperty(SpringContextMode.DISABLED))
+            }
+
+            separator()
+
+            row {
+                enableActionToolbar = checkBox("Enable actions toolbar for each Groovy file")
+                    .bindSelected(mutable::enableActionsToolbar)
+                    .comment("Actions toolbar enables possibility to change current remote SAP Commerce session and perform operations on current file, such as `Execute on remote server`")
+                    .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
+                    .component
+            }
+            row {
+                checkBox("Enable actions toolbar for a Test Groovy file")
+                    .bindSelected(mutable::enableActionsToolbarForGroovyTest)
+                    .comment("Enables Actions toolbar for the groovy files located in the <strong>${HybrisConstants.TEST_SRC_DIRECTORY}</strong> or <strong>${HybrisConstants.GROOVY_TEST_SRC_DIRECTORY}</strong> directory.")
+                    .enabledIf(enableActionToolbar.selected)
+                    .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
+            }
+            row {
+                checkBox("Enable actions toolbar for a IDE Groovy scripts")
+                    .bindSelected(mutable::enableActionsToolbarForGroovyIdeConsole)
+                    .comment("Enables Actions toolbar for the groovy files located in the <strong>${HybrisConstants.IDE_CONSOLES_PATH}</strong> (In Project View, Scratches and Consoles -> IDE Consoles).")
+                    .enabledIf(enableActionToolbar.selected)
+                    .onApply { GroovyFileToolbarInstaller.getInstance().toggleToolbarForAllEditors(project) }
             }
         }
 

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ChooseHacConnectionAction.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ChooseHacConnectionAction.kt
@@ -29,14 +29,14 @@ import sap.commerce.toolset.console.ConsoleUiConstants
 import sap.commerce.toolset.console.HybrisConsoleService
 import sap.commerce.toolset.hac.exec.HacExecConnectionService
 import sap.commerce.toolset.hac.exec.settings.state.HacConnectionSettingsState
-import sap.commerce.toolset.ui.ActionButtonWithTextAndDescription
+import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
 class ChooseHacConnectionAction : DefaultActionGroup() {
 
     init {
         templatePresentation.icon = HybrisIcons.Y.REMOTE
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescription(this))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/modules/shared/core/src/sap/commerce/toolset/GotItTooltips.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/GotItTooltips.kt
@@ -16,11 +16,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package sap.commerce.toolset.groovy
+package sap.commerce.toolset
 
-import com.intellij.openapi.util.Key
-import sap.commerce.toolset.settings.state.SpringContextMode
+object GotItTooltips {
 
-object GroovyConstants {
-    val KEY_SPRING_CONTEXT_MODE = Key<SpringContextMode>("sap.cx.groovy.spring.context.mode")
+    private const val PREFIX = "sap.cx.gotIt."
+
+    const val SPRING_CONTEXT_MODE = PREFIX + "springContextMode"
 }

--- a/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
@@ -39,7 +39,6 @@ object HybrisIcons {
     val MONITORING = getIcon("/icons/monitoring.svg")
 
     val CODE_NOT_GENERATED = AllIcons.General.ExclMark
-    val SPRING_BEAN = getIcon("icons/springBean.svg")
     val GUTTER_POPULATOR = getIcon("/icons/gutter/populator.svg")
 
     object Y {

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/GroovySettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/GroovySettingsState.kt
@@ -26,22 +26,26 @@ data class GroovySettingsState(
     @JvmField @OptionTag val enableActionsToolbar: Boolean = true,
     @JvmField @OptionTag val enableActionsToolbarForGroovyTest: Boolean = false,
     @JvmField @OptionTag val enableActionsToolbarForGroovyIdeConsole: Boolean = false,
+    @JvmField @OptionTag val springContextMode: SpringContextMode = SpringContextMode.DISABLED,
 ) {
     fun mutable() = Mutable(
         enableActionsToolbar = enableActionsToolbar,
         enableActionsToolbarForGroovyTest = enableActionsToolbarForGroovyTest,
         enableActionsToolbarForGroovyIdeConsole = enableActionsToolbarForGroovyIdeConsole,
+        springContextMode = springContextMode,
     )
 
     data class Mutable(
         var enableActionsToolbar: Boolean,
         var enableActionsToolbarForGroovyTest: Boolean,
         var enableActionsToolbarForGroovyIdeConsole: Boolean,
+        var springContextMode: SpringContextMode,
     ) {
         fun immutable() = GroovySettingsState(
             enableActionsToolbar = enableActionsToolbar,
             enableActionsToolbarForGroovyTest = enableActionsToolbarForGroovyTest,
             enableActionsToolbarForGroovyIdeConsole = enableActionsToolbarForGroovyIdeConsole,
+            springContextMode = springContextMode,
         )
     }
 }

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/SpringContextMode.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/SpringContextMode.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package sap.commerce.toolset.groovy
+package sap.commerce.toolset.settings.state
 
 import sap.commerce.toolset.HybrisIcons
 import javax.swing.Icon
@@ -24,5 +24,5 @@ import javax.swing.Icon
 enum class SpringContextMode(val icon: Icon, val presentationText: String) {
     DISABLED(HybrisIcons.Spring.DISABLED, "Disabled"),
     LOCAL(HybrisIcons.Spring.LOCAL, "Local"),
-    REMOTE(HybrisIcons.Spring.REMOTE, "Remote"),
+//    REMOTE(HybrisIcons.Spring.REMOTE, "Remote"),
 }

--- a/modules/shared/ui/src/sap/commerce/toolset/ui/ActionButtonWithTextAndDescriptionComponentProvider.kt
+++ b/modules/shared/ui/src/sap/commerce/toolset/ui/ActionButtonWithTextAndDescriptionComponentProvider.kt
@@ -23,8 +23,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction
 import com.intellij.openapi.actionSystem.impl.ActionButtonWithText
-import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.GotItTooltip
 import com.intellij.ui.popup.PopupFactoryImpl
 import com.intellij.util.asSafely
 import java.awt.Dimension
@@ -34,15 +34,23 @@ import javax.swing.JList
 import javax.swing.SwingConstants
 import javax.swing.event.ListSelectionEvent
 
-class ActionButtonWithTextAndDescription(private val actionGroup: ActionGroup) : CustomComponentAction {
+class ActionButtonWithTextAndDescriptionComponentProvider(
+    private val actionGroup: ActionGroup,
+    private val gotItTooltipProvider: (JComponent) -> GotItTooltip? = { null }
+) : CustomComponentAction {
 
-    override fun createCustomComponent(presentation: Presentation, place: String): JComponent = object : ActionButtonWithText(
-        actionGroup, presentation, place, Dimension()
-    ) {
-        @Serial
-        private val serialVersionUID: Long = 5346829716506322630L
+    override fun createCustomComponent(presentation: Presentation, place: String) = CustomComponent(actionGroup, presentation, place).apply {
+        gotItTooltipProvider(this)
+            ?.show(this, GotItTooltip.BOTTOM_MIDDLE)
+    }
 
-        override fun createAndShowActionGroupPopup(actionGroup: ActionGroup, event: AnActionEvent): JBPopup = JBPopupFactory.getInstance()
+    class CustomComponent(
+        actionGroup: ActionGroup,
+        presentation: Presentation,
+        place: String,
+    ) : ActionButtonWithText(actionGroup, presentation, place, Dimension()) {
+
+        override fun createAndShowActionGroupPopup(actionGroup: ActionGroup, event: AnActionEvent) = JBPopupFactory.getInstance()
             .createActionGroupPopup(null, actionGroup, event.dataContext, null, true)
             .also { listPopup ->
                 listPopup.listStep.values.firstOrNull()
@@ -63,5 +71,10 @@ class ActionButtonWithTextAndDescription(private val actionGroup: ActionGroup) :
 
                 listPopup.showUnderneathOf(this)
             }
+
+        companion object {
+            @Serial
+            private val serialVersionUID: Long = 5346829716506322630L
+        }
     }
 }

--- a/modules/solr/ui/src/sap/commerce/toolset/solr/actionSystem/ChooseSolrConnectionAction.kt
+++ b/modules/solr/ui/src/sap/commerce/toolset/solr/actionSystem/ChooseSolrConnectionAction.kt
@@ -27,14 +27,14 @@ import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.console.HybrisConsoleService
 import sap.commerce.toolset.solr.exec.SolrExecConnectionService
 import sap.commerce.toolset.solr.exec.settings.state.SolrConnectionSettingsState
-import sap.commerce.toolset.ui.ActionButtonWithTextAndDescription
+import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
 
 class ChooseSolrConnectionAction : DefaultActionGroup() {
 
     init {
         templatePresentation.icon = HybrisIcons.Y.REMOTE
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescription(this))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT


### PR DESCRIPTION

<img width="684" height="550" alt="image" src="https://github.com/user-attachments/assets/0d8ed21c-e6ef-495d-adab-6c3f18276dd9" />

<img width="1094" height="834" alt="Screenshot 2025-11-08 at 19 50 59" src="https://github.com/user-attachments/assets/f4616d7e-770a-48a5-a99f-1e050aaf93cb" />
