### PR TITLE
Groovy | Added `Got it Tooltip` for Transaction mode and configurable default state of the respective flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ## [2025.2.4.6]
 
 <cite>Release contributors</cite>
-- 13 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+- 14 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
 
 ### `Groovy` enhancements
 - Introduced `local` Spring context mode within groovy files (slow operation) [#1645](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1645)
 - Added icons for transaction mode toggle [#1647](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1647)
-- Added informative `Got it Tooltip` for new Spring context mode and configurable default state of the respective flag [#1648](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1648)
+- Added `Got it Tooltip` for new Spring context mode and configurable default state of the respective flag [#1648](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1648)
+- Added `Got it Tooltip` for Transaction mode and configurable default state of the respective flag [#1649](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1649)
 
 ### `Spring` enhancements
 - Improve Spring beans resolution in case of `module-less` files, like Scratch-files [#1646](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1646)

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
@@ -33,13 +33,12 @@ import sap.commerce.toolset.settings.DeveloperSettings
 import sap.commerce.toolset.settings.state.SpringContextMode
 import sap.commerce.toolset.triggerAction
 import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
+import javax.swing.JComponent
 
 class GroovySpringContextModeActionGroup : DefaultActionGroup() {
 
-    private val componentProvider = ActionButtonWithTextAndDescriptionComponentProvider(
-        actionGroup = this,
-        gotItTooltipProvider = { component ->
-            val before = """<pre class="code">
+    private val gotItTooltipProvider: (JComponent) -> GotItTooltip? = { component ->
+        val before = """<pre class="code">
                 import de.hybris.platform.core.Registry
                 import de.hybris.platform.product.ProductService
 
@@ -48,36 +47,35 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup() {
 
                 productService.getProduct('test')</pre>
             """.trimIndent()
-            val after = "<pre class=\"code\">productService.getProduct('test')</pre>"
+        val after = "<pre class=\"code\">productService.getProduct('test')</pre>"
 
-            GotItTooltip(
-                id = GotItTooltips.SPRING_CONTEXT_MODE,
-                textSupplier = {
-                    """
+        GotItTooltip(
+            id = GotItTooltips.SPRING_CONTEXT_MODE,
+            textSupplier = {
+                """
                     You can enable Spring Context within your groovy scripts by switching to ${icon(SpringContextMode.LOCAL.icon)} ${code(SpringContextMode.LOCAL.presentationText)} resolution mode.
                     <br>Resolution of the Spring Context is a heavy operation, that's why it is ${icon(SpringContextMode.DISABLED.icon)} ${code(SpringContextMode.DISABLED.presentationText)} by default for every new Editor, but it can be changed via ${
-                        link("Groovy settings") {
-                            DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
-                                ?.triggerAction("hybris.groovy.openSettings")
-                        }
-                    }.
+                    link("Groovy settings") {
+                        DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
+                            ?.triggerAction("hybris.groovy.openSettings")
+                    }
+                }.
                     <br><br>Before:
                     <br>${before}
 
                     <br>After:
                     <br>${after}
                 """.trimIndent()
-                },
-                parentDisposable = null
-            )
-                .withMaxWidth(JBUIScale.scale(420))
-                .withHeader("Welcome Spring Context in Groovy!")
-        }
-    )
+            },
+            parentDisposable = null
+        )
+            .withMaxWidth(JBUIScale.scale(420))
+            .withHeader("Welcome Spring Context in Groovy!")
+    }
 
     init {
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, componentProvider)
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this, gotItTooltipProvider))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
@@ -18,21 +18,47 @@
 
 package sap.commerce.toolset.groovy.actionSystem
 
+import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.ui.GotItTooltip
+import sap.commerce.toolset.GotItTooltips
 import sap.commerce.toolset.groovy.editor.groovyExecContextSettings
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.settings.state.TransactionMode
+import sap.commerce.toolset.triggerAction
 import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponentProvider
+import javax.swing.JComponent
 
 class GroovyTransactionModeActionGroup : DefaultActionGroup() {
 
+    private val gotItTooltipProvider: (JComponent) -> GotItTooltip? = { component ->
+        GotItTooltip(
+            id = GotItTooltips.TRANSACTION_MODE,
+            textSupplier = {
+                """
+                    You can configure the transaction mode individually for each Groovy script.
+                    <br><br>When ${icon(TransactionMode.COMMIT.icon)} ${code(TransactionMode.COMMIT.presentationText)} mode is enabled, all changes made by the script will be permanently applied.
+                    <br>If you want to ensure that no modifications are persisted, switch the mode to ${icon(TransactionMode.ROLLBACK.icon)} ${code(TransactionMode.ROLLBACK.presentationText)}.
+                    <br><br>Rollback is the default for newly opened editors, but this behavior can be adjusted in the ${
+                    link("Groovy settings") {
+                        DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
+                            ?.triggerAction("hybris.groovy.openSettings")
+                    }
+                }.
+                """.trimIndent()
+            },
+            parentDisposable = null
+        )
+            .withHeader("Transaction modes for Groovy!")
+    }
+
     init {
         templatePresentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true)
-        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this,))
+        templatePresentation.putClientProperty(ActionUtil.COMPONENT_PROVIDER, ActionButtonWithTextAndDescriptionComponentProvider(this, gotItTooltipProvider))
     }
 
     override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/options/GroovyProjectSettingsConfigurableProvider.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/options/GroovyProjectSettingsConfigurableProvider.kt
@@ -34,6 +34,7 @@ import sap.commerce.toolset.groovy.actionSystem.GroovyFileToolbarInstaller
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.isHybrisProject
 import sap.commerce.toolset.settings.state.SpringContextMode
+import sap.commerce.toolset.settings.state.TransactionMode
 import sap.commerce.toolset.settings.yDeveloperSettings
 import javax.swing.JCheckBox
 
@@ -59,9 +60,20 @@ class GroovyProjectSettingsConfigurableProvider(private val project: Project) : 
                     .label("Spring context mode:")
                     .comment("""
                         Defines default mode for each new Editor.<br>
-                        <cod>Local</code> mode enables direct resolution of the Spring beans, so it will be possible to enable code completion for such statements <code>productService.getProduct(..)</code>. 
+                        <cod>${SpringContextMode.LOCAL.presentationText}</code> mode enables direct resolution of the Spring beans, so it will be possible to enable code completion for such statements <code>productService.getProduct(..)</code>. 
                     """.trimIndent())
                     .bindItem(mutable::springContextMode.toNullableProperty(SpringContextMode.DISABLED))
+            }
+            row {
+                comboBox(
+                    EnumComboBoxModel(TransactionMode::class.java),
+                    renderer = SimpleListCellRenderer.create("?") { it.presentationText }
+                )
+                    .label("Transaction mode:")
+                    .comment("""
+                        Defines default mode for each new Editor. 
+                    """.trimIndent())
+                    .bindItem(mutable::transactionMode.toNullableProperty(TransactionMode.ROLLBACK))
             }
 
             separator()

--- a/modules/shared/core/src/sap/commerce/toolset/GotItTooltips.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/GotItTooltips.kt
@@ -23,4 +23,5 @@ object GotItTooltips {
     private const val PREFIX = "sap.cx.gotIt."
 
     const val SPRING_CONTEXT_MODE = PREFIX + "springContextMode"
+    const val TRANSACTION_MODE = PREFIX + "transactionMode"
 }

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/GroovySettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/GroovySettingsState.kt
@@ -27,12 +27,14 @@ data class GroovySettingsState(
     @JvmField @OptionTag val enableActionsToolbarForGroovyTest: Boolean = false,
     @JvmField @OptionTag val enableActionsToolbarForGroovyIdeConsole: Boolean = false,
     @JvmField @OptionTag val springContextMode: SpringContextMode = SpringContextMode.DISABLED,
+    @JvmField @OptionTag val transactionMode: TransactionMode = TransactionMode.ROLLBACK,
 ) {
     fun mutable() = Mutable(
         enableActionsToolbar = enableActionsToolbar,
         enableActionsToolbarForGroovyTest = enableActionsToolbarForGroovyTest,
         enableActionsToolbarForGroovyIdeConsole = enableActionsToolbarForGroovyIdeConsole,
         springContextMode = springContextMode,
+        transactionMode = transactionMode,
     )
 
     data class Mutable(
@@ -40,12 +42,14 @@ data class GroovySettingsState(
         var enableActionsToolbarForGroovyTest: Boolean,
         var enableActionsToolbarForGroovyIdeConsole: Boolean,
         var springContextMode: SpringContextMode,
+        var transactionMode: TransactionMode,
     ) {
         fun immutable() = GroovySettingsState(
             enableActionsToolbar = enableActionsToolbar,
             enableActionsToolbarForGroovyTest = enableActionsToolbarForGroovyTest,
             enableActionsToolbarForGroovyIdeConsole = enableActionsToolbarForGroovyIdeConsole,
             springContextMode = springContextMode,
+            transactionMode = transactionMode,
         )
     }
 }


### PR DESCRIPTION
<img width="714" height="434" alt="Screenshot 2025-11-09 at 12 02 49" src="https://github.com/user-attachments/assets/71e4d6fc-4d69-4978-bcfa-e14fd4916bc6" />
<img width="1094" height="834" alt="image" src="https://github.com/user-attachments/assets/72f5846c-0394-427f-b3fa-d016a031ec44" />
