### PR TITLE
hAC | Adjusted UI of the dialog to fit the content better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2025.2.4.6]
 
 <cite>Release contributors</cite>
-- 19 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
+- 20 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.4.6+author%3Amlytvyn+is%3Apr)
 
 ### `CCv2` enhancements
 - Select & configure `hAC` connection from the CCv2 endpoint [#1652](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1652)
@@ -35,6 +35,7 @@
 - Respect basic authorization for proxy authentication of the `manual` authentication mode [#1640](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1640)
 - Display website access errors in the Browser for `manual` authentication mode [#1641](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1641)
 - Added `Got it Tooltip` describing new authentication modes [#1651](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1651)
+- Adjusted UI of the dialog to fit the content better [#1655](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1655)
 
 ## [2025.2.4.5]
 

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2HacConnectionSettingsProviderDialog.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2HacConnectionSettingsProviderDialog.kt
@@ -82,6 +82,8 @@ class CCv2HacConnectionSettingsProviderDialog(
         fetchEnvironments()
     }
 
+    override fun getPreferredFocusedComponent() = subscriptionComboBox
+
     override fun createCenterPanel() = panel {
         row {
             text(

--- a/modules/exec/ui/src/sap/commerce/toolset/exec/ui/ConnectionSettingsDialog.kt
+++ b/modules/exec/ui/src/sap/commerce/toolset/exec/ui/ConnectionSettingsDialog.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import sap.commerce.toolset.exec.settings.state.ExecConnectionSettingsState
+import sap.commerce.toolset.ui.repackDialog
 import java.awt.Component
 import java.awt.event.ActionEvent
 import java.io.Serial
@@ -106,6 +107,8 @@ abstract class ConnectionSettingsDialog<M : ExecConnectionSettingsState.Mutable>
                                 visible(true)
                             }
                         }
+
+                        repackDialog()
                     }
 
                     action.isEnabled = true

--- a/modules/hac/exec/src/sap/commerce/toolset/hac/exec/settings/state/ProxyAuthMode.kt
+++ b/modules/hac/exec/src/sap/commerce/toolset/hac/exec/settings/state/ProxyAuthMode.kt
@@ -18,7 +18,14 @@
 
 package sap.commerce.toolset.hac.exec.settings.state
 
-enum class ProxyAuthMode {
-    NONE,
-    BASIC;
+import sap.commerce.toolset.HybrisIcons
+import javax.swing.Icon
+
+enum class ProxyAuthMode(val title: String, val icon: Icon? = null, val description: String? = null) {
+    NONE("None"),
+    BASIC(
+        "Basic",
+        HybrisIcons.HAC.PROXY_AUTH_BASIC,
+        "Applicable to connections that require additional authentication, e.g., when using an <code>nginx</code> reverse proxy."
+    );
 }

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/ui/HacConnectionSettingsDialog.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/ui/HacConnectionSettingsDialog.kt
@@ -273,13 +273,13 @@ class HacConnectionSettingsDialog(
                     .label("Username:")
                     .visibleIf(
                         mutable.proxyAuthMode.equalsTo(ProxyAuthMode.BASIC)
-                            .and(mutable.authMode.equalsTo(AuthMode.MANUAL))
+                            .and(mutable.authMode.equalsTo(AuthMode.AUTOMATIC))
                     )
                 textField()
                     .label("Password:")
                     .visibleIf(
                         mutable.proxyAuthMode.equalsTo(ProxyAuthMode.BASIC)
-                            .and(mutable.authMode.equalsTo(AuthMode.MANUAL))
+                            .and(mutable.authMode.equalsTo(AuthMode.AUTOMATIC))
                     )
             }
         }

--- a/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
@@ -55,6 +55,7 @@ object HybrisIcons {
     object HAC {
         val AUTH_AUTOMATIC = AllIcons.Actions.SynchronizeScrolling
         val AUTH_MANUAL = AllIcons.Actions.ToggleVisibility
+        val PROXY_AUTH_BASIC = AllIcons.Actions.InlaySecuredShield
     }
 
     object Spring {


### PR DESCRIPTION
> [!NOTE]  
> - Redesigned settings provider selection
> - Credentials blocks
> - Auth mode selector
> - Proxy auth mode selector
> - Repackaging of the dialog of testing connection

----

<img width="722" height="863" alt="Screenshot 2025-11-13 at 16 40 47" src="https://github.com/user-attachments/assets/fe04000f-916c-4c05-81fb-e30291cf94de" />
<img width="704" height="852" alt="Screenshot 2025-11-13 at 16 40 56" src="https://github.com/user-attachments/assets/6c2ffb4c-f7c6-46a6-b8c9-c6c8abe92abd" />
<img width="722" height="903" alt="Screenshot 2025-11-13 at 16 40 54" src="https://github.com/user-attachments/assets/1d67eba8-e418-4c4e-a57d-daadc516be2a" />
