### PR TITLE
Cockpit NG | Added folding for `simple-search:sort-field`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2025.2.5.1]
 
 <cite>Release contributors</cite>
-- 7 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.5.1+author%3Amlytvyn+is%3Apr)
+- 8 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.2.5.1+author%3Amlytvyn+is%3Apr)
 
 ### `Project Import` enhancements
 - Automatically download 3rd-party library sources [#1669](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1669)
@@ -17,6 +17,9 @@
 
 ### `Type System` enhancements
 - Improved folding for elements without required values [#1666](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1666)
+
+### `Cockpit NG` enhancements
+- Added folding for `simple-search:sort-field` [#1674](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1674)
 
 ### Other
 - Updated Plugin icon [#1667](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1667)

--- a/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/Field.java
+++ b/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/Field.java
@@ -35,12 +35,14 @@ import sap.commerce.toolset.cockpitNG.model.config.hybris.Mergeable;
 @Namespace(HybrisConstants.COCKPIT_NG_NAMESPACE_KEY)
 public interface Field extends DomElement, Mergeable {
 
+	String NAME = "name";
+
 	/**
 	 * Returns the value of the name child.
 	 * @return the value of the name child.
 	 */
 	@NotNull
-	@com.intellij.util.xml.Attribute ("name")
+	@com.intellij.util.xml.Attribute (NAME)
 	@Required
 	GenericAttributeValue<String> getName();
 

--- a/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/SimpleSearch.java
+++ b/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/SimpleSearch.java
@@ -32,6 +32,7 @@ import sap.commerce.toolset.HybrisConstants;
 public interface SimpleSearch extends DomElement {
 
 	String FIELD = "field";
+	String SORT_FIELD = "sort-field";
 
 	/**
 	 * Returns the value of the includeSubtypes child.
@@ -62,7 +63,7 @@ public interface SimpleSearch extends DomElement {
 	 * @return the value of the sort-field child.
 	 */
 	@NotNull
-	@SubTag ("sort-field")
+	@SubTag (SORT_FIELD)
 	SortField getSortField();
 
 

--- a/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/SortField.java
+++ b/modules/cockpitNG/core/gen/sap/commerce/toolset/cockpitNG/model/simpleSearch/SortField.java
@@ -34,12 +34,14 @@ import sap.commerce.toolset.HybrisConstants;
 @Namespace(HybrisConstants.COCKPIT_NG_NAMESPACE_KEY)
 public interface SortField extends DomElement, Field {
 
+	String ASC = "asc";
+
 	/**
 	 * Returns the value of the asc child.
 	 * @return the value of the asc child.
 	 */
 	@NotNull
-	@com.intellij.util.xml.Attribute ("asc")
+	@com.intellij.util.xml.Attribute (ASC)
 	@Required
 	GenericAttributeValue<Boolean> getAsc();
 

--- a/modules/cockpitNG/core/src/sap/commerce/toolset/cockpitNG/lang/folding/CngConfigFoldingBuilder.kt
+++ b/modules/cockpitNG/core/src/sap/commerce/toolset/cockpitNG/lang/folding/CngConfigFoldingBuilder.kt
@@ -32,6 +32,8 @@ import sap.commerce.toolset.cockpitNG.model.itemEditor.Attribute
 import sap.commerce.toolset.cockpitNG.model.itemEditor.Section
 import sap.commerce.toolset.cockpitNG.model.listView.ListColumn
 import sap.commerce.toolset.cockpitNG.model.listView.ListView
+import sap.commerce.toolset.cockpitNG.model.simpleSearch.SimpleSearch
+import sap.commerce.toolset.cockpitNG.model.simpleSearch.SortField
 import sap.commerce.toolset.cockpitNG.model.widgets.*
 import sap.commerce.toolset.cockpitNG.model.wizardConfig.AdditionalParam
 import sap.commerce.toolset.cockpitNG.model.wizardConfig.ComposedHandler
@@ -48,6 +50,7 @@ class CngConfigFoldingBuilder : XmlFoldingBuilderEx<CngFoldingSettingsState, Con
         when (it) {
             is XmlTag -> when (it.localName) {
                 FieldList.FIELD,
+                SimpleSearch.SORT_FIELD,
                 MoldList.MOLD,
                 Section.ATTRIBUTE,
                 ExplorerTree.TYPE_NODE,
@@ -129,6 +132,20 @@ class CngConfigFoldingBuilder : XmlFoldingBuilderEx<CngFoldingSettingsState, Con
                     psi.getAttributeValue(Field.SELECTED)
                         ?.takeIf { it == "true" }
                         ?.let { "pre-selected" }
+                ))
+
+            SimpleSearch.SORT_FIELD -> "sort by: " + fold(psi, SimpleSearch.SORT_FIELD, SortField.NAME,
+                getCachedFoldingSettings(psi)?.tablifySearchFields,
+                computeExtraAttributes(
+                    psi.getAttributeValue(SortField.ASC)
+                        ?.let {
+                            when (it.lowercase()) {
+                                "true" -> "asc"
+                                "false" -> "desc"
+                                else -> it
+                            }
+                        }
+                        ?: "?",
                 ))
 
             ListView.COLUMN -> fold(psi, ListView.COLUMN, ListColumn.QUALIFIER,
@@ -221,6 +238,7 @@ class CngConfigFoldingBuilder : XmlFoldingBuilderEx<CngFoldingSettingsState, Con
     override fun isCollapsedByDefault(node: ASTNode) = when (val psi = node.psi) {
         is XmlTag -> when (psi.localName) {
             FieldList.FIELD,
+            SimpleSearch.SORT_FIELD,
             MoldList.MOLD,
             Section.ATTRIBUTE,
             ExplorerTree.TYPE_NODE,


### PR DESCRIPTION
<img width="415" height="133" alt="Screenshot 2025-11-29 at 22 57 21" src="https://github.com/user-attachments/assets/18b5b908-2843-4437-a9ab-d5a240ab5edf" />
