### PR TITLE
Project Import | Include resolved extensions once in case of symbolic links under the same root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 Due severe API changes it is highly advised to backup the project and import it from the scratch. Please, report any issues via project's Slack or GitHub.
 
 ### `Project Import` enhancements
-- Project import & refresh 3.0 [#1699](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1699)
-- Project import & refresh 3.1 [#1704](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1704)
+- Project import & refresh 3.0 with 146 commits and ~533 changed files  [#1699](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1699)
+- Project import & refresh 3.1 with 32 commits and ~246 changed files [#1704](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1704)
 - Lazy dependency on `java-el` plugin [#1700](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1700)
 - Register `HMC` Project Library when `hmc` extension present [#1705](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1705)
+- Include resolved extensions once in case of symbolic links under the same root [#1706](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1706)
 
 ### `SAP CX Logging` enhancements
 - Support deletion for multiple selected custom nodes [#1695](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1695)

--- a/modules/project/import-core/src/sap/commerce/toolset/project/module/ModuleRootsScanner.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/module/ModuleRootsScanner.kt
@@ -71,7 +71,12 @@ class ModuleRootsScanner {
 
                             // prevent recursion
                             if (visited.contains(path)) return FileVisitResult.SKIP_SUBTREE
-                            else visited.add(path)
+                            else {
+                                visited.add(path)
+                                if (path.isSymbolicLink()) {
+                                    visited.add(path.readSymbolicLink())
+                                }
+                            }
 
                             return when {
                                 path.isHidden() -> {


### PR DESCRIPTION
1. Symbolic Link: `E:\projects\myproject\hybris\custom` -> `E:\projects\myproject\custom`
2. Import `E:\projects\myproject`
3. Same paths scanned twice due symbolic links resolution and processing of the same real path twice
4. To address this issue, path, if a symbolic link, will be resolved to real path and excluded from the next path scan step


@TatsianaZubrytskaya, I know that it took a lot of time, but it was very strange use case and project was not flexible enough to support such a case, with the latest Project Import 3.0 and huge architecture changes of the plugin it became possible.

----
<img width="663" height="499" alt="image" src="https://github.com/user-attachments/assets/40e9df0f-a788-4b1d-ab57-453921243023" />

<img width="859" height="801" alt="image" src="https://github.com/user-attachments/assets/9b4db60a-df55-4e8c-90e6-429cb80e903d" />
