### PR TITLE
Project Import | Register dependant web extensions after building complete extensions dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Due severe API changes it is highly advised to backup the project and import it 
 - Lazy dependency on `java-el` plugin [#1700](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1700)
 - Register `HMC` Project Library when `hmc` extension present [#1705](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1705)
 - Include resolved extensions once in case of symbolic links under the same root [#1706](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1706)
+- Register dependant web extensions after building complete extensions dependency graph [#1707](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1707), fixes [#579](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/579)
 
 ### `SAP CX Logging` enhancements
 - Support deletion for multiple selected custom nodes [#1695](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1695)

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YWebSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YWebSubModuleDescriptor.kt
@@ -19,9 +19,7 @@
 package sap.commerce.toolset.project.descriptor.impl
 
 import sap.commerce.toolset.project.ProjectConstants
-import sap.commerce.toolset.project.descriptor.ModuleDescriptor
 import sap.commerce.toolset.project.descriptor.SubModuleDescriptorType
-import sap.commerce.toolset.project.descriptor.YModuleDescriptor
 import sap.commerce.toolset.project.descriptor.YRegularModuleDescriptor
 import java.nio.file.Path
 import kotlin.io.path.name
@@ -32,18 +30,4 @@ class YWebSubModuleDescriptor(
     name: String = owner.name + "." + moduleRootPath.name,
     val webRoot: Path = moduleRootPath.resolve(ProjectConstants.Directory.WEB_ROOT),
     override val subModuleDescriptorType: SubModuleDescriptorType = SubModuleDescriptorType.WEB
-) : AbstractYSubModuleDescriptor(owner, moduleRootPath, name) {
-
-    override fun addDirectDependencies(dependencies: Collection<ModuleDescriptor>): Boolean {
-        dependencies
-            .asSequence()
-            .filterIsInstance<YModuleDescriptor>()
-            .flatMap { it.getAllDependencies() }
-            .filterIsInstance<YCustomRegularModuleDescriptor>()
-            .flatMap { it.getSubModules() }
-            .filterIsInstance<YCommonWebSubModuleDescriptor>()
-            .toList()
-            .forEach { it.addDependantWebExtension(this) }
-        return super.addDirectDependencies(dependencies)
-    }
-}
+) : AbstractYSubModuleDescriptor(owner, moduleRootPath, name)

--- a/src/sap/commerce/toolset/project/view/HybrisProjectView.kt
+++ b/src/sap/commerce/toolset/project/view/HybrisProjectView.kt
@@ -37,9 +37,7 @@ import sap.commerce.toolset.isNotHybrisProject
 import sap.commerce.toolset.java.JavaConstants
 import sap.commerce.toolset.project.ProjectConstants
 import sap.commerce.toolset.project.context.ModuleGroup
-import sap.commerce.toolset.project.context.ProjectImportState
 import sap.commerce.toolset.project.descriptor.ModuleDescriptorType
-import sap.commerce.toolset.project.importState
 import sap.commerce.toolset.project.settings.ySettings
 import sap.commerce.toolset.project.view.nodes.ExternalProjectViewNode
 import sap.commerce.toolset.project.view.nodes.HybrisProjectViewProjectNode
@@ -82,7 +80,6 @@ open class HybrisProjectView(val project: Project) : TreeStructureProvider, Dumb
         settings: ViewSettings
     ): Collection<AbstractTreeNode<*>> {
         if (project.isNotHybrisProject) return children
-        if (project.importState != ProjectImportState.IMPORTED) return children
 
         if (parent is ProjectViewProjectNode) {
             children.clear()


### PR DESCRIPTION
Addresses too early evaluation of "allDependencies" which results into incorrect preselection state of extensions.
Can be encountered only for projects with `commonweb` and `web` extensions.

Reference -> #579, @viktor-yengovatov, fyi