### PR TITLE
Project Import | Exclude decompiled sources from module content roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <cite>Release contributors</cite>
 
 - 6 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.3.2+author%3Amlytvyn+is%3Apr)
-- 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.3.2+author%3AMihaiSprinceana+is%3Apr)
+- 2 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.3.2+author%3AMihaiSprinceana+is%3Apr)
 
 ### `Project Import` enhancements
 - Update language level in BGT write thread [#1719](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1719)
@@ -12,6 +12,7 @@
 - Show detailed progress of the decompilation progress [#1727](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1727)
 - Show all detected modules if `platform` is not found [#1725](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1725)
 - Preselect only first conflicting extension according to load order [#1726](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1726)
+- Excludes decompiled sources output (doc/decompiledsrc) from module content roots. [#1727](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1727)
 
 ### `WSL` enhancements
 - Support resolution of the relative symbolic links on WSL [#1724](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1724)

--- a/modules/java/core/resources/META-INF/sap.commerce.toolset-java-core.xml
+++ b/modules/java/core/resources/META-INF/sap.commerce.toolset-java-core.xml
@@ -46,6 +46,7 @@
                                            implementation="sap.commerce.toolset.java.configurator.JavaModuleContentRootsConfigurator"/>
 
         <project.module.contentRootEntryConfigurator implementation="sap.commerce.toolset.java.configurator.contentEntry.ExcludeAcceleratorAddonWebContentRootEntryConfigurator"/>
+        <project.module.contentRootEntryConfigurator implementation="sap.commerce.toolset.java.configurator.contentEntry.ExcludeDecompiledSourcesContentRootEntryConfigurator"/>
         <project.module.contentRootEntryConfigurator implementation="sap.commerce.toolset.java.configurator.contentEntry.ExcludeClassesContentRootEntryConfigurator"/>
         <project.module.contentRootEntryConfigurator implementation="sap.commerce.toolset.java.configurator.contentEntry.ExcludeCommonsContentRootEntryConfigurator"/>
         <project.module.contentRootEntryConfigurator implementation="sap.commerce.toolset.java.configurator.contentEntry.ExcludeResourcesContentRootEntryConfigurator"/>

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeDecompiledSourcesContentRootEntryConfigurator.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeDecompiledSourcesContentRootEntryConfigurator.kt
@@ -1,0 +1,54 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.java.configurator.contentEntry
+
+import com.intellij.platform.workspace.jps.entities.ContentRootEntityBuilder
+import sap.commerce.toolset.java.configurator.contentEntry.util.excludeDirectories
+import sap.commerce.toolset.project.configurator.ModuleContentRootEntryConfigurator
+import sap.commerce.toolset.project.context.ProjectImportContext
+import sap.commerce.toolset.project.context.ProjectModuleConfigurationContext
+import sap.commerce.toolset.project.descriptor.ModuleDescriptor
+import java.nio.file.Path
+
+/**
+ * Excludes decompiled sources output (doc/decompiledsrc) from module content roots.
+ *
+ * Decompiled sources are attached back as *library sources*, so excluding the physical folder prevents
+ * IntelliJ inspections/indexing from treating them as project sources, while still allowing navigation.
+ */
+class ExcludeDecompiledSourcesContentRootEntryConfigurator : ModuleContentRootEntryConfigurator {
+
+    override val name: String
+        get() = "Decompiled sources (exclusion)"
+
+    override fun isApplicable(context: ProjectImportContext, moduleDescriptor: ModuleDescriptor) = true
+
+    override suspend fun configure(
+        context: ProjectModuleConfigurationContext<ModuleDescriptor>,
+        contentRootEntity: ContentRootEntityBuilder,
+        pathsToIgnore: Collection<Path>
+    ) {
+        val virtualFileUrlManager = context.importContext.workspace.getVirtualFileUrlManager()
+        val excludePaths = listOf(
+            context.moduleDescriptor.moduleRootPath.resolve("doc").resolve("decompiledsrc")
+        )
+
+        contentRootEntity.excludeDirectories(context.importContext, virtualFileUrlManager, excludePaths)
+    }
+}

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeDecompiledSourcesContentRootEntryConfigurator.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeDecompiledSourcesContentRootEntryConfigurator.kt
@@ -20,6 +20,7 @@ package sap.commerce.toolset.java.configurator.contentEntry
 
 import com.intellij.platform.workspace.jps.entities.ContentRootEntityBuilder
 import sap.commerce.toolset.java.configurator.contentEntry.util.excludeDirectories
+import sap.commerce.toolset.project.ProjectConstants
 import sap.commerce.toolset.project.configurator.ModuleContentRootEntryConfigurator
 import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.context.ProjectModuleConfigurationContext
@@ -46,7 +47,7 @@ class ExcludeDecompiledSourcesContentRootEntryConfigurator : ModuleContentRootEn
     ) {
         val virtualFileUrlManager = context.importContext.workspace.getVirtualFileUrlManager()
         val excludePaths = listOf(
-            context.moduleDescriptor.moduleRootPath.resolve("doc").resolve("decompiledsrc")
+            context.moduleDescriptor.moduleRootPath.resolve(ProjectConstants.Paths.DOC_DECOMPILED_SOURCES)
         )
 
         contentRootEntity.excludeDirectories(context.importContext, virtualFileUrlManager, excludePaths)

--- a/modules/java/decompiler/resources/META-INF/sap.commerce.toolset-java-decompiler.xml
+++ b/modules/java/decompiler/resources/META-INF/sap.commerce.toolset-java-decompiler.xml
@@ -17,6 +17,7 @@
   -->
 
 <idea-plugin>
+    <depends>org.jetbrains.java.decompiler</depends>
     <resource-bundle>i18n.HybrisBundle</resource-bundle>
 
     <extensions defaultExtensionNs="sap.commerce.toolset">

--- a/modules/java/decompiler/src/sap/commerce/toolset/java/decompilation/configurator/DecompileOotbBinariesConfigurator.kt
+++ b/modules/java/decompiler/src/sap/commerce/toolset/java/decompilation/configurator/DecompileOotbBinariesConfigurator.kt
@@ -45,6 +45,7 @@ import sap.commerce.toolset.java.decompilation.DecompilerConsent
 import sap.commerce.toolset.java.decompilation.DecompilerService
 import sap.commerce.toolset.java.decompilation.JarDecompileContext
 import sap.commerce.toolset.java.decompilation.JarDecompileResult
+import sap.commerce.toolset.project.ProjectConstants
 import sap.commerce.toolset.project.configurator.ProjectPostImportConfigurator
 import sap.commerce.toolset.project.context.ProjectPostImportContext
 import sap.commerce.toolset.project.descriptor.ModuleDescriptorType
@@ -264,8 +265,7 @@ class DecompileOotbBinariesConfigurator : ProjectPostImportConfigurator {
     }
 
     private fun JarDecompileContext.outputRoot(): Path = moduleDescriptor.moduleRootPath
-        .resolve("doc")
-        .resolve("decompiledsrc")
+        .resolve(ProjectConstants.Paths.DOC_DECOMPILED_SOURCES)
         .resolve(jar.name.substringBeforeLast('.', jar.name))
 
     private suspend fun attachDecompiledSources(

--- a/modules/project/core/src/sap/commerce/toolset/project/ProjectConstants.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/ProjectConstants.kt
@@ -112,7 +112,6 @@ object ProjectConstants {
     object Paths {
         val IDEA_MODULES = Path(".idea", "idea-modules")
 
-        val RELATIVE_DOC_SOURCES = Path("..", "doc", "sources")
         val RELATIVE_CONFIG = Path("..", "..", "config")
 
         val PLATFORM_BOOTSTRAP = Path("platform", "bootstrap")
@@ -133,6 +132,7 @@ object ProjectConstants {
         val TOMCAT_6_LIB = Path("tomcat-6", "lib")
 
         val DOC_SOURCES = Path("doc", "sources")
+        val DOC_DECOMPILED_SOURCES = Path("doc", "decompiledsrc")
         val ACCELERATOR_ADDON_WEB = Path("acceleratoraddon", "web")
 
         val WEBROOT_WEB_INF_LIB = Path("webroot", "WEB-INF", "lib")


### PR DESCRIPTION
Exclude decompiled sources from module content roots to prevent IDE misclassification as project sources.

Signed-off-by: Mihai Sprinceana sprinceana.mihai87@gmail.com
