### PR TITLE
Project Import | Respect custom directory override for `ext-custom`-like directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 <cite>Release contributors</cite>
 
-- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.3.3+author%3Amlytvyn+is%3Apr)
+- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2025.3.3+author%3Amlytvyn+is%3Apr)
+
+### `Project Import` enhancements
+- Respect custom directory override for `ext-custom`-like directories [#1732](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1732) for [#1730](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1730) 
 
 ### `CCv2` enhancements
 - Introduced new authentication mode via Technical User [#1731](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1731)

--- a/modules/project/import-core/src/sap/commerce/toolset/project/module/YOotbModuleRootResolver.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/module/YOotbModuleRootResolver.kt
@@ -37,6 +37,11 @@ class YOotbModuleRootResolver : ModuleRootResolver {
         val parentPathString = path.parent.normalize().pathString
             .replace("\\", "/")
 
+        val overrideCustomDirectory = context.externalExtensionsDirectory?.normalize()?.pathString
+            ?.replace("\\", "/")
+
+        if (overrideCustomDirectory == parentPathString) return false
+
         return parentPathString.contains(HybrisConstants.HYBRIS_OOTB_MODULE_PREFIX_2019)
             || (parentPathString.contains(HybrisConstants.HYBRIS_OOTB_MODULE_PREFIX))
     }


### PR DESCRIPTION
<img width="824" height="801" alt="Screenshot 2026-02-09 at 22 47 13" src="https://github.com/user-attachments/assets/1653088c-7448-4db7-8727-75e6f6ffb45e" />
<img width="824" height="801" alt="Screenshot 2026-02-09 at 22 47 18" src="https://github.com/user-attachments/assets/132e8d93-5da1-4fce-91e9-3dfa9d6d3d8e" />
<img width="525" height="605" alt="Screenshot 2026-02-09 at 22 47 43" src="https://github.com/user-attachments/assets/3bd98902-212f-4ad1-93a8-f31f07b23c0d" />
