### PR TITLE
CCv2 | Use different icon for non/deployed builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 <cite>Release contributors</cite>
 
-- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.0+author%3Amlytvyn+is%3Apr)
+- 3 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.0+author%3Amlytvyn+is%3Apr)
 
 ### Other
 - Compatibility release for IDE 2026 [#1741](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1741)
 
 ### `CCv2` enhancements
 - Hide `delete a build` action for deployed builds [#1742](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1742)
+- Use different icon for non/deployed builds [#1743](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1743)
 
 ## [2025.3.3.2]
 

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/dto/CCv2BuildDto.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/dto/CCv2BuildDto.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,6 +19,7 @@
 package sap.commerce.toolset.ccv2.dto
 
 import com.intellij.util.asSafely
+import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.ccv2.CCv2Constants
 import sap.commerce.toolset.ccv2.getTimeDiffInMinutes
 import sap.commerce.toolset.ccv2.model.BuildDetailDTO
@@ -41,6 +42,7 @@ data class CCv2BuildDto(
     val deployed: Boolean,
 ) : CCv2Dto {
     val duration = getTimeDiffInMinutes(startTime, endTime).takeIf { it.toInt() != -1 } ?: "N/A"
+    val statusIcon = if (deployed) HybrisIcons.CCv2.Build.DEPLOYED else status.icon
 
     fun canDelete() = status != CCv2BuildStatus.DELETED && status != CCv2BuildStatus.UNKNOWN && !deployed
     fun canDownloadLogs() = status != CCv2BuildStatus.DELETED

--- a/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/HybrisIcons.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -379,12 +379,13 @@ object HybrisIcons {
             val BRANCH = AllIcons.Vcs.Branch
             val REVISION = AllIcons.Vcs.CommitNode
             val CREATED_BY = AllIcons.General.User
+            val DEPLOYED = AllIcons.RunConfigurations.TestPassed
 
             object Status {
                 val UNKNOWN = AllIcons.RunConfigurations.TestUnknown
                 val SCHEDULED = AllIcons.Actions.Profile
                 val BUILDING = AllIcons.RunConfigurations.TestCustom
-                val SUCCESS = AllIcons.RunConfigurations.TestPassed
+                val SUCCESS = AllIcons.General.InspectionsOKEmpty
                 val FAIL = AllIcons.RunConfigurations.TestFailed
                 val DELETED = AllIcons.Debugger.KillProcess
             }


### PR DESCRIPTION
<img width="89" height="105" alt="Screenshot 2026-02-20 at 22 00 03" src="https://github.com/user-attachments/assets/10f8bee9-b10f-4ef1-be94-7e0c957de2a6" />
