### PR TITLE
Project Import | New flag to use `Real Path` for symlinked modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2026.0.1]
+
+<cite>Release contributors</cite>
+
+- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.1+author%3Amlytvyn+is%3Apr)
+
+### `Project Import` enhancements
+- New flag to use `Real Path` for symlinked modules [#1750](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1750)
+
 ## [2026.0.0]
 
 <cite>Release contributors</cite>

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ intellij.update.since.until.build=true
 
 intellij.plugin.id=com.intellij.idea.plugin.sap.commerce
 intellij.plugin.name=SAP Commerce Developers Toolset
-intellij.plugin.version=2026.0.0
+intellij.plugin.version=2026.0.1
 intellij.plugin.since.build=253.28294.325
 intellij.plugin.until.build=261.*
 

--- a/modules/project/core/src/sap/commerce/toolset/project/context/ProjectImportSettings.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/context/ProjectImportSettings.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -26,6 +26,7 @@ import sap.commerce.toolset.settings.LibrarySourcesFetchMode
 
 data class ProjectImportSettings(
     val importOOTBModulesInReadOnlyMode: Boolean,
+    val useRealPathForModuleRoot: Boolean,
     val importCustomAntBuildFiles: Boolean,
     val ignoreNonExistingSourceDirectories: Boolean,
     val hideEmptyMiddleFolders: Boolean,
@@ -52,6 +53,7 @@ data class ProjectImportSettings(
 
     fun mutable() = Mutable(
         importOOTBModulesInReadOnlyMode = AtomicBooleanProperty(importOOTBModulesInReadOnlyMode),
+        useRealPathForModuleRoot = AtomicBooleanProperty(useRealPathForModuleRoot),
         importCustomAntBuildFiles = AtomicBooleanProperty(importCustomAntBuildFiles),
         ignoreNonExistingSourceDirectories = AtomicBooleanProperty(ignoreNonExistingSourceDirectories),
         hideEmptyMiddleFolders = AtomicBooleanProperty(hideEmptyMiddleFolders),
@@ -76,6 +78,7 @@ data class ProjectImportSettings(
 
     data class Mutable(
         val importOOTBModulesInReadOnlyMode: AtomicBooleanProperty,
+        val useRealPathForModuleRoot: AtomicBooleanProperty,
         val importCustomAntBuildFiles: AtomicBooleanProperty,
         val ignoreNonExistingSourceDirectories: AtomicBooleanProperty,
         val hideEmptyMiddleFolders: AtomicBooleanProperty,
@@ -99,6 +102,7 @@ data class ProjectImportSettings(
     ) {
         fun immutable() = ProjectImportSettings(
             importOOTBModulesInReadOnlyMode = importOOTBModulesInReadOnlyMode.get(),
+            useRealPathForModuleRoot = useRealPathForModuleRoot.get(),
             importCustomAntBuildFiles = importCustomAntBuildFiles.get(),
             ignoreNonExistingSourceDirectories = ignoreNonExistingSourceDirectories.get(),
             hideEmptyMiddleFolders = hideEmptyMiddleFolders.get(),
@@ -125,6 +129,7 @@ data class ProjectImportSettings(
     companion object {
         fun of(applicationSettings: ApplicationSettings) = ProjectImportSettings(
             importOOTBModulesInReadOnlyMode = applicationSettings.importOOTBModulesInReadOnlyMode,
+            useRealPathForModuleRoot = applicationSettings.useRealPathForModuleRoot,
             importCustomAntBuildFiles = applicationSettings.importCustomAntBuildFiles,
             ignoreNonExistingSourceDirectories = applicationSettings.ignoreNonExistingSourceDirectories,
             hideEmptyMiddleFolders = applicationSettings.hideEmptyMiddleFolders,
@@ -148,6 +153,7 @@ data class ProjectImportSettings(
 
         fun of(applicationSettings: ApplicationSettings, projectSettings: ProjectSettings) = ProjectImportSettings(
             importOOTBModulesInReadOnlyMode = projectSettings.importOotbModulesInReadOnlyMode,
+            useRealPathForModuleRoot = projectSettings.useRealPathForModuleRoot,
             importCustomAntBuildFiles = projectSettings.importCustomAntBuildFiles,
             unusedExtensions = projectSettings.unusedExtensions,
 

--- a/modules/project/core/src/sap/commerce/toolset/project/settings/ProjectSettings.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/settings/ProjectSettings.kt
@@ -89,6 +89,11 @@ class ProjectSettings : SerializablePersistentStateComponent<ProjectSettingsStat
         set(value) {
             updateState { it.copy(importOotbModulesInReadOnlyMode = value) }
         }
+    var useRealPathForModuleRoot
+        get() = state.useRealPathForModuleRoot
+        set(value) {
+            updateState { it.copy(useRealPathForModuleRoot = value) }
+        }
     var importCustomAntBuildFiles
         get() = state.importCustomAntBuildFiles
         set(value) {

--- a/modules/project/core/src/sap/commerce/toolset/project/settings/state/ProjectSettingsState.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/settings/state/ProjectSettingsState.kt
@@ -39,6 +39,7 @@ data class ProjectSettingsState(
     @JvmField @OptionTag val generateCodeOnServerRunConfiguration: Boolean = false,
     @JvmField @OptionTag val generateCodeTimeoutSeconds: Int = 60,
     @JvmField @OptionTag val importOotbModulesInReadOnlyMode: Boolean = true,
+    @JvmField @OptionTag val useRealPathForModuleRoot: Boolean = false,
     @JvmField @OptionTag val importCustomAntBuildFiles: Boolean = false,
     @JvmField @OptionTag val showFullModuleName: Boolean = false,
     @JvmField @OptionTag val removeExternalModulesOnRefresh: Boolean = false,

--- a/modules/project/import-core/src/sap/commerce/toolset/project/configurator/ApplicationSettingsConfigurator.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/configurator/ApplicationSettingsConfigurator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -33,6 +33,7 @@ class ApplicationSettingsConfigurator : ProjectImportConfigurator {
             this.externalDbDriversDirectory = context.externalDbDriversDirectory?.toSystemIndependentName
 
             this.importOOTBModulesInReadOnlyMode = importSettings.importOOTBModulesInReadOnlyMode
+            this.useRealPathForModuleRoot = importSettings.useRealPathForModuleRoot
             this.importCustomAntBuildFiles = importSettings.importCustomAntBuildFiles
             this.ignoreNonExistingSourceDirectories = importSettings.ignoreNonExistingSourceDirectories
             this.hideEmptyMiddleFolders = importSettings.hideEmptyMiddleFolders

--- a/modules/project/import-core/src/sap/commerce/toolset/project/configurator/ProjectSettingsConfigurator.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/configurator/ProjectSettingsConfigurator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -53,6 +53,7 @@ class ProjectSettingsConfigurator : ProjectImportConfigurator {
         val importSettings = context.settings
 
         projectSettings.importOotbModulesInReadOnlyMode = importSettings.importOOTBModulesInReadOnlyMode
+        projectSettings.useRealPathForModuleRoot = importSettings.useRealPathForModuleRoot
         projectSettings.importCustomAntBuildFiles = importSettings.importCustomAntBuildFiles
         projectSettings.useFakeOutputPathForCustomExtensions = importSettings.useFakeOutputPathForCustomExtensions
         projectSettings.withDecompiledOotbSources = importSettings.withDecompiledOotbSources

--- a/modules/project/import-core/src/sap/commerce/toolset/project/module/ModuleRootsScanner.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/module/ModuleRootsScanner.kt
@@ -94,6 +94,10 @@ class ModuleRootsScanner {
                                 }
                             }
 
+                            resolvedPath = if (context.settings.useRealPathForModuleRoot) runCatching { resolvedPath.toRealPath() }
+                                .getOrElse { resolvedPath }
+                            else resolvedPath
+
                             return when {
                                 resolvedPath.isHidden -> {
                                     logger.debug("Skipping hidden directory: $resolvedPath")

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectImportCoreContextStepUi.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectImportCoreContextStepUi.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -270,6 +270,13 @@ internal fun uiCoreStep(context: ProjectImportCoreContext): DialogPanel {
         }
 
         group(i18n("hybris.project.import.projectImportSettings.title")) {
+            row {
+                checkBox(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.label"))
+                    .bindSelected(context.importSettings.useRealPathForModuleRoot)
+                contextHelp(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.description"))
+                    .customize(rightGaps)
+            }
+
             row {
                 checkBox(i18n("hybris.import.wizard.import.ootb.modules.read.only.label"))
                     .bindSelected(context.importSettings.importOOTBModulesInReadOnlyMode)

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectRefreshDialog.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectRefreshDialog.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -72,6 +72,12 @@ class ProjectRefreshDialog(
             }
 
             group(i18n("hybris.project.import.projectImportSettings.title")) {
+                row {
+                    checkBox(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.label"))
+                        .bindSelected(refreshContext.importSettings.useRealPathForModuleRoot)
+                    contextHelp(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.description"))
+                }
+
                 row {
                     checkBox(i18n("hybris.import.wizard.import.ootb.modules.read.only.label"))
                         .bindSelected(refreshContext.importSettings.importOOTBModulesInReadOnlyMode)

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -1,7 +1,7 @@
 #
 # This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
 # Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
-# Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+# Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as
@@ -168,6 +168,8 @@ hybris.solr.search.console.reload.cores.button.tooltip=Reload Solr Cores
 
 hybris.import.wizard.import.ootb.modules.read.only.label=Import OOTB modules in read-only mode
 hybris.import.wizard.import.ootb.modules.read.only.help.description=Extremely improves compilation performance and reduces possible amount of compilation errors but you wont be able to use code assistance in OOTB modules.
+hybris.import.wizard.import.useRealPathForModuleRoot.label=Use real path for module root (symlinked)
+hybris.import.wizard.import.useRealPathForModuleRoot.description=In case of the symlinked module treat its content root as resolved real path
 hybris.import.wizard.source.code.path.label=SAP Commerce Source Code (Optional)
 hybris.import.wizard.source.code.path.tooltip=SAP Commerce source code directory or *.zip file
 hybris.import.wizard.project.icon.label=Custom Intellij Project Icon (Optional)

--- a/modules/shared/core/src/sap/commerce/toolset/settings/ApplicationSettings.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/ApplicationSettings.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -53,6 +53,11 @@ class ApplicationSettings : SerializablePersistentStateComponent<ApplicationSett
         get() = state.defaultPlatformInReadOnly
         set(value) {
             updateState { it.copy(defaultPlatformInReadOnly = value) }
+        }
+    var useRealPathForModuleRoot: Boolean
+        get() = state.useRealPathForModuleRoot
+        set(value) {
+            updateState { it.copy(useRealPathForModuleRoot = value) }
         }
     var ignoreNonExistingSourceDirectories: Boolean
         get() = state.ignoreNonExistingSourceDirectories

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/ApplicationSettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/ApplicationSettingsState.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -30,6 +30,7 @@ data class ApplicationSettingsState(
     @JvmField @OptionTag val groupExternalModules: Boolean = false,
     @JvmField @OptionTag val hideEmptyMiddleFolders: Boolean = true,
     @JvmField @OptionTag val defaultPlatformInReadOnly: Boolean = true,
+    @JvmField @OptionTag val useRealPathForModuleRoot: Boolean = false,
     @JvmField @OptionTag val ignoreNonExistingSourceDirectories: Boolean = false,
     @JvmField @OptionTag val librarySourcesFetchMode: LibrarySourcesFetchMode = LibrarySourcesFetchMode.REMOTE,
     @JvmField @OptionTag val withExternalLibrarySources: Boolean = true,

--- a/modules/shared/ui/src/sap/commerce/toolset/options/ApplicationSettingsConfigurableProvider.kt
+++ b/modules/shared/ui/src/sap/commerce/toolset/options/ApplicationSettingsConfigurableProvider.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -67,6 +67,12 @@ class ApplicationSettingsConfigurableProvider : ConfigurableProvider() {
 
         private val _ui = panel {
             group(i18n("hybris.project.import.projectImportSettings.title")) {
+                row {
+                    checkBox(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.label"))
+                        .bindSelected(applicationSettings::useRealPathForModuleRoot)
+                    contextHelp(i18n("hybris.import.wizard.import.useRealPathForModuleRoot.description"))
+                }
+
                 row {
                     checkBox(i18n("hybris.import.wizard.import.ootb.modules.read.only.label"))
                         .bindSelected(applicationSettings::importOOTBModulesInReadOnlyMode)


### PR DESCRIPTION
<img width="678" height="136" alt="Screenshot 2026-02-27 at 15 39 57" src="https://github.com/user-attachments/assets/29699a63-24d7-45f5-8265-5c03300b8843" />
<img width="918" height="324" alt="Screenshot 2026-02-27 at 15 40 12" src="https://github.com/user-attachments/assets/7c364ee7-5614-423b-89ba-9dced5b69797" />

<img width="269" height="675" alt="image" src="https://github.com/user-attachments/assets/8a695a9e-9f8a-4b41-bd5d-b18384d92e04" />


<img width="1220" height="199" alt="image" src="https://github.com/user-attachments/assets/1e9af363-54cd-47f3-b9c2-1f775bff7059" />
