### PR TITLE
CCv2 | Adjust authentication via Technical User 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <cite>Release contributors</cite>
 
+- 1 PR(s) by [Sina Bastani](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.3+author%3Asina96+is%3Apr)
+
+### `CCv2` Technical User Authentication enhancements
+- Fixed CCv2 authentication to Technical User via Kyma runtime; deprecate token-based auth [#1756](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1756)
+
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.3+author%3Amlytvyn+is%3Apr)
 
 ### `SAP CX Logging` enhancements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-## Contribution guidelines
+q## Contribution guidelines
 
 * Please read [Contributor License Agreement](http://developercertificate.org)
 * Available tasks are in our [project board](https://github.com/epam/sap-commerce-intellij-idea-plugin/projects) 
@@ -52,3 +52,4 @@
 - Alessandro Antonini
 - Mihai Sprinceana
 - Patrick Gäckle
+- Sina Bastani

--- a/modules/ccv2/core/resources/specs/commerce-cloud-management-api-v2.yaml
+++ b/modules/ccv2/core/resources/specs/commerce-cloud-management-api-v2.yaml
@@ -15,7 +15,7 @@ servers:
     description: Environment URL
     variables:
       uri:
-        default: 'portalrotapi.hana.ondemand.com'
+        default: 'portalapi.commerce.ondemand.com'
         description: Environment URI
 tags:
   - name: build

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Constants.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Constants.kt
@@ -59,7 +59,7 @@ object CCv2Constants {
     )
 
     object Authentication {
-        const val TOKEN_ENDPOINT = "https://ycloudsre.accounts.ondemand.com/oauth2/token"
+        const val TOKEN_ENDPOINT = "https://ycloud.accounts.ondemand.com/oauth2/token"
         const val RESOURCE = "urn:sap:identity:application:provider:name:cp-dependency"
     }
 }

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Constants.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Constants.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -31,7 +31,6 @@ object CCv2Constants {
     const val DATAHUB_NAME = "datahub"
     const val JS_STOREFRONT_NAME = "js-storefront"
 
-    const val SECURE_STORAGE_CCV2_TOKEN = "SAP CX CCv2 Token"
     const val SECURE_STORAGE_CCV2_AUTHENTICATION = "SAP CX CCv2 Authentication"
 
     val DATE_TIME_FORMATTER_LOCAL: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd | HH:mm:ss")

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Service.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/CCv2Service.kt
@@ -52,7 +52,6 @@ import sap.commerce.toolset.ccv2.settings.CCv2DeveloperSettings
 import sap.commerce.toolset.ccv2.settings.CCv2ProjectSettings
 import sap.commerce.toolset.ccv2.settings.state.CCv2ApplicationSettingsState
 import sap.commerce.toolset.ccv2.settings.state.CCv2Authentication
-import sap.commerce.toolset.ccv2.settings.state.CCv2AuthenticationMode
 import sap.commerce.toolset.ccv2.settings.state.CCv2Subscription
 import sap.commerce.toolset.util.directoryExists
 import java.io.Serial
@@ -988,10 +987,7 @@ class CCv2Service(private val project: Project, private val coroutineScope: Coro
     private fun getApiContext(subscription: CCv2Subscription): ApiContext? {
         val appSettings = CCv2ProjectSettings.getInstance()
 
-        val apiContext = if (subscription.authenticationMode == CCv2AuthenticationMode.TOKEN) {
-            (appSettings.getCCv2Token(subscription.uuid) ?: appSettings.getCCv2Token())
-                ?.let { HanaApiContext(appSettings.hanaApiUrl, it) }
-        } else retrieveCCv2ClientToken(subscription, appSettings)
+        val apiContext = retrieveCCv2ClientToken(subscription, appSettings)
 
         if (apiContext != null) return apiContext
 

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/api/ApiContext.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/api/ApiContext.kt
@@ -24,12 +24,6 @@ sealed interface ApiContext {
     val authHeader: String
 }
 
-data class HanaApiContext(
-    override val apiUrl: String,
-    override val authToken: String,
-    override val authHeader: String = "Authorization"
-) : ApiContext
-
 
 data class KymaApiContext(
     override val apiUrl: String,

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/api/CCv1Api.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/api/CCv1Api.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/CCv2ProjectSettings.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/CCv2ProjectSettings.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -52,11 +52,6 @@ class CCv2ProjectSettings : SerializablePersistentStateComponent<CCv2Application
         set(value) {
             updateState { it.copy(authentication = value) }
         }
-    var hanaApiUrl: String
-        get() = state.hanaApiUrl
-        set(value) {
-            updateState { it.copy(hanaApiUrl = value) }
-        }
     var kymaApiUrl: String
         get() = state.kymaApiUrl
         set(value) {
@@ -72,33 +67,12 @@ class CCv2ProjectSettings : SerializablePersistentStateComponent<CCv2Application
                 .onChange(state)
         }
 
-    fun getCCv2Token(subscriptionUUID: String? = null) = PasswordSafe.instance[getCredentials(subscriptionUUID)]
-        ?.getPasswordAsString()
-        ?.takeIf { it.isNotBlank() }
-
     fun getCCv2Authentication(subscriptionUUID: String? = null) = PasswordSafe.instance[getAuthentication(subscriptionUUID)]
-
-    fun loadDefaultCCv2Token(callback: (String?) -> Unit) {
-        ProgressManager.getInstance().run(object : Task.Backgroundable(null, "Retrieving SAP CCv2 Token", false) {
-            override fun run(indicator: ProgressIndicator) {
-                callback(getCCv2Token())
-            }
-        })
-    }
 
     fun loadDefaultCCv2Authentication(callback: (Credentials?) -> Unit) {
         ProgressManager.getInstance().run(object : Task.Backgroundable(null, "Retrieving SAP CCv2 Authentication", false) {
             override fun run(indicator: ProgressIndicator) {
                 callback(getCCv2Authentication())
-            }
-        })
-    }
-
-    fun loadCCv2Token(subscriptionUUID: String?, callback: (String?) -> Unit) {
-        subscriptionUUID ?: return
-        ProgressManager.getInstance().run(object : Task.Backgroundable(null, "Retrieving SAP CCv2 Token", false) {
-            override fun run(indicator: ProgressIndicator) {
-                callback(getCCv2Token(subscriptionUUID))
             }
         })
     }
@@ -112,20 +86,7 @@ class CCv2ProjectSettings : SerializablePersistentStateComponent<CCv2Application
         })
     }
 
-    fun saveDefaultCCv2Token(token: String?, callback: ((String?) -> Unit)? = null) = saveCCv2Token(null, token, callback)
-
     fun saveDefaultCCv2Authentication(authentication: Credentials?, callback: ((Credentials?) -> Unit)? = null) = saveCCv2Authentication(null, authentication, callback)
-
-    fun saveCCv2Token(subscriptionUUID: String?, token: String?, callback: ((String?) -> Unit)? = null) {
-        ProgressManager.getInstance().run(object : Task.Backgroundable(null, "Persisting SAP CCv2 Token", false) {
-            override fun run(indicator: ProgressIndicator) {
-                callback?.invoke(token)
-
-                if (token.isNullOrEmpty()) PasswordSafe.instance.setPassword(getCredentials(subscriptionUUID), null)
-                else PasswordSafe.instance.setPassword(getCredentials(subscriptionUUID), token)
-            }
-        })
-    }
 
     fun saveCCv2Authentication(subscriptionUUID: String?, credentials: Credentials?, callback: ((Credentials?) -> Unit)? = null) {
         ProgressManager.getInstance().run(object : Task.Backgroundable(null, "Persisting SAP CCv2 Token", false) {
@@ -144,9 +105,6 @@ class CCv2ProjectSettings : SerializablePersistentStateComponent<CCv2Application
     override fun getModificationCount() = stateModificationCount
 
     fun mutable() = state.mutable()
-
-    private fun getCredentials(subscriptionUUID: String?) = if (subscriptionUUID == null) CredentialAttributes(CCv2Constants.SECURE_STORAGE_CCV2_TOKEN)
-    else CredentialAttributes(subscriptionUUID, CCv2Constants.SECURE_STORAGE_CCV2_TOKEN)
 
     private fun getAuthentication(subscriptionUUID: String?) = if (subscriptionUUID == null) CredentialAttributes(CCv2Constants.SECURE_STORAGE_CCV2_AUTHENTICATION)
     else CredentialAttributes(CCv2Constants.SECURE_STORAGE_CCV2_AUTHENTICATION + " - " + subscriptionUUID)

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2ApplicationSettingsState.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2ApplicationSettingsState.kt
@@ -25,8 +25,8 @@ import com.intellij.util.xmlb.annotations.Tag
 data class CCv2ApplicationSettingsState(
     @JvmField @OptionTag val readTimeout: Int = 60,
     @JvmField @OptionTag val authentication: CCv2Authentication = CCv2Authentication(),
-    @JvmField @OptionTag val hanaApiUrl: String = "https://portalrotapi.hana.ondemand.com",
-    @JvmField @OptionTag val kymaApiUrl: String = "https://portalrotapi.kyma.ondemand.com",
+    @JvmField @OptionTag val hanaApiUrl: String = "https://portalapi.commerce.ondemand.com",
+    @JvmField @OptionTag val kymaApiUrl: String = "https://portalapi.commerce.ondemand.com",
     @JvmField val subscriptions: List<CCv2Subscription> = emptyList()
 ) {
     fun mutable() = Mutable(

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2ApplicationSettingsState.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2ApplicationSettingsState.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -25,13 +25,11 @@ import com.intellij.util.xmlb.annotations.Tag
 data class CCv2ApplicationSettingsState(
     @JvmField @OptionTag val readTimeout: Int = 60,
     @JvmField @OptionTag val authentication: CCv2Authentication = CCv2Authentication(),
-    @JvmField @OptionTag val hanaApiUrl: String = "https://portalapi.commerce.ondemand.com",
     @JvmField @OptionTag val kymaApiUrl: String = "https://portalapi.commerce.ondemand.com",
     @JvmField val subscriptions: List<CCv2Subscription> = emptyList()
 ) {
     fun mutable() = Mutable(
         origin = this,
-        hanaApiUrl = hanaApiUrl,
         kymaApiUrl = kymaApiUrl,
         authentication = authentication.mutable(),
         subscriptions = subscriptions
@@ -41,13 +39,11 @@ data class CCv2ApplicationSettingsState(
 
     data class Mutable(
         private val origin: CCv2ApplicationSettingsState,
-        var hanaApiUrl: String,
         var kymaApiUrl: String,
         var authentication: CCv2Authentication.Mutable,
         var subscriptions: MutableList<CCv2Subscription.Mutable>
     ) {
         fun immutable() = CCv2ApplicationSettingsState(
-            hanaApiUrl = hanaApiUrl,
             kymaApiUrl = kymaApiUrl,
             authentication = authentication.immutable(),
             subscriptions = subscriptions

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2AuthenticationMode.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2AuthenticationMode.kt
@@ -19,6 +19,5 @@
 package sap.commerce.toolset.ccv2.settings.state
 
 enum class CCv2AuthenticationMode(val presentationTitle: String) {
-    TOKEN("Token (legacy)"),
     TECHNICAL_USER("Technical User"),
 }

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2Subscription.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2Subscription.kt
@@ -25,7 +25,7 @@ data class CCv2Subscription(
     @JvmField @OptionTag val uuid: String = UUID.randomUUID().toString(),
     @JvmField @OptionTag val id: String? = null,
     @JvmField @OptionTag val name: String? = null,
-    @JvmField @OptionTag val authenticationMode: CCv2AuthenticationMode = CCv2AuthenticationMode.TOKEN,
+    @JvmField @OptionTag val authenticationMode: CCv2AuthenticationMode = CCv2AuthenticationMode.TECHNICAL_USER,
     @JvmField @OptionTag val authentication: CCv2Authentication? = null,
 ) : Comparable<CCv2Subscription> {
 

--- a/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2Subscription.kt
+++ b/modules/ccv2/core/src/sap/commerce/toolset/ccv2/settings/state/CCv2Subscription.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -25,7 +25,6 @@ data class CCv2Subscription(
     @JvmField @OptionTag val uuid: String = UUID.randomUUID().toString(),
     @JvmField @OptionTag val id: String? = null,
     @JvmField @OptionTag val name: String? = null,
-    @JvmField @OptionTag val authenticationMode: CCv2AuthenticationMode = CCv2AuthenticationMode.TECHNICAL_USER,
     @JvmField @OptionTag val authentication: CCv2Authentication? = null,
 ) : Comparable<CCv2Subscription> {
 
@@ -33,7 +32,6 @@ data class CCv2Subscription(
         uuid = uuid,
         id = id,
         name = name,
-        authenticationMode = authenticationMode,
         authentication = authentication?.mutable() ?: CCv2Authentication.Mutable(),
     )
 
@@ -49,19 +47,15 @@ data class CCv2Subscription(
         var uuid: String,
         var id: String?,
         var name: String?,
-        var authenticationMode: CCv2AuthenticationMode,
         var authentication: CCv2Authentication.Mutable,
-        var ccv2Token: String? = null,
     ) {
         var modified = false
-        var ccv2LegacyTokenLoaded = false
         var ccv2ClientTokenLoaded = false
 
         fun immutable() = CCv2Subscription(
             uuid = uuid,
             id = id,
             name = name,
-            authenticationMode = authenticationMode,
             authentication = authentication.immutable(),
         )
 
@@ -71,7 +65,7 @@ data class CCv2Subscription(
                 val name = (name
                     ?.takeIf { it.isNotEmpty() }
                     ?: id ?: "?")
-                return name + " (${authenticationMode.presentationTitle})"
+                return name
             }
     }
 }

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/options/CCv2ExecProjectSettingsConfigurableProvider.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/options/CCv2ExecProjectSettingsConfigurableProvider.kt
@@ -90,9 +90,13 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
 
                 CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlTextField.text, auth, credentials)
             }
+            val ccv2ClientCredentialsSupplier: () -> Credentials? = {
+                Credentials(String(clientIdTextField.password), String(clientSecretTextField.password))
+                    .takeUnless { it.userName.isNullOrBlank() || it.password.isNullOrBlank() }
+            }
             val hanaApiUrlSupplier: () -> String = { hanaApiUrlTextField.text }
             val kymaApiUrlSupplier: () -> String = { kymaApiUrlTextField.text }
-            subscriptionListPanel = CCv2SubscriptionListPanel(project, disposable, ccv2LegacyTokenSupplier, ccv2ClientTokenSupplier, hanaApiUrlSupplier, kymaApiUrlSupplier) {
+            subscriptionListPanel = CCv2SubscriptionListPanel(project, disposable, ccv2LegacyTokenSupplier, ccv2ClientTokenSupplier, ccv2ClientCredentialsSupplier, hanaApiUrlSupplier, kymaApiUrlSupplier) {
                 val previousSelectedItem = subscriptionsComboBoxModel.selectedItem?.asSafely<CCv2Subscription>()?.uuid
                 val modifiedSubscriptions = subscriptionListPanel.data.map { it.immutable() }
 
@@ -133,8 +137,8 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
                         .component
                 }.layout(RowLayout.PARENT_GRID)
 
-                authToken()
                 authClient()
+                authToken()
 
                 group("Subscriptions", false) {
                     row {
@@ -218,10 +222,19 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
             }
         }
 
-        private fun Panel.authToken() = group("Authentication via Token") {
+        private fun Panel.authToken() = collapsibleGroup("Authentication via Token (Deprecated)") {
+            row {
+                inlineBanner(
+                    message = """API tokens have stopped working after the Kyma runtime migration.
+                        |<br>You will need to create and use technical users instead.
+                        |<br>See <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/0fa6bcf4736c46f78c248512391eb467/edcfd89aa5154be59910ebb7081030e3.html?locale=en-US">Migration of Cloud Portal to Kyma Runtime</a>."""
+                        .trimMargin(),
+                    status = EditorNotificationPanel.Status.Warning
+                ).align(AlignX.FILL)
+            }.resizableRow().topGap(TopGap.MEDIUM)
             row {
                 hanaApiUrlTextField = textField()
-                    .label("Hana api url:")
+                    .label("Api URL link (Neo Runtime):")
                     .align(AlignX.FILL)
                     .bindText(projectSettings::hanaApiUrl)
                     .component
@@ -240,21 +253,12 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
                     .component
                 contextHelp(i18n("hybris.settings.application.ccv2Token.help.description"))
             }.layout(RowLayout.PARENT_GRID)
-        }
+        }.apply { expanded = false }
 
         private fun Panel.authClient() = group("Authentication via Technical User") {
             row {
-                inlineBanner(
-                    message = """
-                        Experimental authentication mode, see more here <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/0fa6bcf4736c46f78c248512391eb467/edcfd89aa5154be59910ebb7081030e3.html">Migration of Cloud Portal to Kyma Runtime</a>.
-                        """.trimIndent(),
-                    status = EditorNotificationPanel.Status.Warning
-                )
-            }
-
-            row {
                 kymaApiUrlTextField = textField()
-                    .label("Kyma api url:")
+                    .label("Api URL link (Kyma Runtime):")
                     .align(AlignX.FILL)
                     .bindText(projectSettings::kymaApiUrl)
                     .component
@@ -288,6 +292,7 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
             row {
                 clientSecretTextField = passwordField()
                     .label("Client secret:")
+                    .comment(i18n("hybris.settings.application.ccv2AuthToken.tooltip"))
                     .align(AlignX.FILL)
                     .onIsModified { (originalClientSecret ?: "") != String(clientSecretTextField.password) }
                     .onApply { originalClientSecret = String(clientSecretTextField.password) }

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/options/CCv2ExecProjectSettingsConfigurableProvider.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/options/CCv2ExecProjectSettingsConfigurableProvider.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -25,7 +25,6 @@ import com.intellij.openapi.options.ConfigurableProvider
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
@@ -34,7 +33,6 @@ import com.intellij.util.asSafely
 import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.ccv2.CCv2Service
 import sap.commerce.toolset.ccv2.api.ApiContext
-import sap.commerce.toolset.ccv2.api.HanaApiContext
 import sap.commerce.toolset.ccv2.settings.CCv2DeveloperSettings
 import sap.commerce.toolset.ccv2.settings.CCv2ProjectSettings
 import sap.commerce.toolset.ccv2.settings.state.CCv2Authentication
@@ -44,7 +42,6 @@ import sap.commerce.toolset.ccv2.ui.components.CCv2SubscriptionsComboBoxModel
 import sap.commerce.toolset.ccv2.ui.components.CCv2SubscriptionsComboBoxModelFactory
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.isHybrisProject
-import sap.commerce.toolset.ui.inlineBanner
 
 class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) : ConfigurableProvider() {
 
@@ -56,12 +53,10 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
     ) {
 
         private lateinit var timeoutTextField: JBTextField
-        private lateinit var defaultCCv2TokenTextField: JBPasswordField
         private lateinit var activeCCv2SubscriptionComboBox: ComboBox<CCv2Subscription>
         private lateinit var subscriptionListPanel: CCv2SubscriptionListPanel
         private lateinit var subscriptionsComboBoxModel: CCv2SubscriptionsComboBoxModel
 
-        private lateinit var hanaApiUrlTextField: JBTextField
         private lateinit var kymaApiUrlTextField: JBTextField
         private lateinit var endpointTextField: JBTextField
         private lateinit var resourceTextField: JBTextField
@@ -72,18 +67,14 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
         private val projectSettings = CCv2ProjectSettings.getInstance()
         private val developerSettings = CCv2DeveloperSettings.getInstance(project)
         private val mutable = projectSettings.state.mutable()
-        private var originalToken: String? = null
         private var originalClientId: String? = null
         private var originalClientSecret: String? = null
         private var originalActiveSubscription = developerSettings.getActiveCCv2Subscription()
         private lateinit var pane: DialogPanel
 
         override fun createPanel(): DialogPanel {
-            // disposable is being created only now, do not move dependant items
+            // disposable is being created only now, do not move dependent items
             subscriptionsComboBoxModel = CCv2SubscriptionsComboBoxModelFactory.create(project, allowBlank = true, disposable = disposable)
-            val ccv2LegacyTokenSupplier: () -> ApiContext? = {
-                defaultCCv2TokenTextField.password?.let { HanaApiContext(hanaApiUrlTextField.text, String(it)) }
-            }
             val ccv2ClientTokenSupplier: () -> ApiContext? = {
                 val auth = CCv2Authentication(endpointTextField.text, resourceTextField.text)
                 val credentials = Credentials(String(clientIdTextField.password), String(clientSecretTextField.password))
@@ -94,9 +85,8 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
                 Credentials(String(clientIdTextField.password), String(clientSecretTextField.password))
                     .takeUnless { it.userName.isNullOrBlank() || it.password.isNullOrBlank() }
             }
-            val hanaApiUrlSupplier: () -> String = { hanaApiUrlTextField.text }
             val kymaApiUrlSupplier: () -> String = { kymaApiUrlTextField.text }
-            subscriptionListPanel = CCv2SubscriptionListPanel(project, disposable, ccv2LegacyTokenSupplier, ccv2ClientTokenSupplier, ccv2ClientCredentialsSupplier, hanaApiUrlSupplier, kymaApiUrlSupplier) {
+            subscriptionListPanel = CCv2SubscriptionListPanel(project, disposable, ccv2ClientTokenSupplier, ccv2ClientCredentialsSupplier, kymaApiUrlSupplier) {
                 val previousSelectedItem = subscriptionsComboBoxModel.selectedItem?.asSafely<CCv2Subscription>()?.uuid
                 val modifiedSubscriptions = subscriptionListPanel.data.map { it.immutable() }
 
@@ -138,7 +128,6 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
                 }.layout(RowLayout.PARENT_GRID)
 
                 authClient()
-                authToken()
 
                 group("Subscriptions", false) {
                     row {
@@ -157,7 +146,6 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
             subscriptionsComboBoxModel.refresh(subscriptionListPanel.data.map { it.immutable() })
 
             activeCCv2SubscriptionComboBox.selectedItem = originalActiveSubscription
-            defaultCCv2TokenTextField.text = originalToken
             clientIdTextField.text = originalClientId
             clientSecretTextField.text = originalClientSecret
 
@@ -171,7 +159,6 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
             projectSettings.subscriptions = subscriptionListPanel.data
                 .onEach {
                     if (it.modified) {
-                        projectSettings.saveCCv2Token(it.uuid, it.ccv2Token)
                         projectSettings.saveCCv2Authentication(it.uuid, it.authentication.credentials)
                     }
                     it.modified = false
@@ -193,20 +180,6 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
         }
 
         private fun initForm() {
-            var expectedLoads = 2
-
-            projectSettings.loadDefaultCCv2Token {
-                val ccv2Token = projectSettings.getCCv2Token()
-
-                defaultCCv2TokenTextField.text = ccv2Token
-                originalToken = ccv2Token
-
-                expectedLoads--
-                if (expectedLoads == 0) {
-                    editable.set(true)
-                }
-            }
-
             projectSettings.loadDefaultCCv2Authentication { credentials ->
                 credentials?.let {
                     originalClientId = it.userName ?: ""
@@ -215,45 +188,9 @@ class CCv2ExecProjectSettingsConfigurableProvider(private val project: Project) 
                     clientSecretTextField.text = originalClientSecret
                 }
 
-                expectedLoads--
-                if (expectedLoads == 0) {
-                    editable.set(true)
-                }
+                editable.set(true)
             }
         }
-
-        private fun Panel.authToken() = collapsibleGroup("Authentication via Token (Deprecated)") {
-            row {
-                inlineBanner(
-                    message = """API tokens have stopped working after the Kyma runtime migration.
-                        |<br>You will need to create and use technical users instead.
-                        |<br>See <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/0fa6bcf4736c46f78c248512391eb467/edcfd89aa5154be59910ebb7081030e3.html?locale=en-US">Migration of Cloud Portal to Kyma Runtime</a>."""
-                        .trimMargin(),
-                    status = EditorNotificationPanel.Status.Warning
-                ).align(AlignX.FILL)
-            }.resizableRow().topGap(TopGap.MEDIUM)
-            row {
-                hanaApiUrlTextField = textField()
-                    .label("Api URL link (Neo Runtime):")
-                    .align(AlignX.FILL)
-                    .bindText(projectSettings::hanaApiUrl)
-                    .component
-            }.layout(RowLayout.PARENT_GRID)
-            row {
-                defaultCCv2TokenTextField = passwordField()
-                    .label(i18n("hybris.settings.application.ccv2Token"))
-                    .comment(i18n("hybris.settings.application.ccv2Token.tooltip"))
-                    .align(AlignX.FILL)
-                    .onIsModified { (originalToken ?: "") != String(defaultCCv2TokenTextField.password) }
-                    .onApply {
-                        val token = String(defaultCCv2TokenTextField.password).takeIf { it.isNotBlank() }
-                        originalToken = token
-                        projectSettings.saveDefaultCCv2Token(token)
-                    }
-                    .component
-                contextHelp(i18n("hybris.settings.application.ccv2Token.help.description"))
-            }.layout(RowLayout.PARENT_GRID)
-        }.apply { expanded = false }
 
         private fun Panel.authClient() = group("Authentication via Technical User") {
             row {

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2SubscriptionDialog.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2SubscriptionDialog.kt
@@ -46,8 +46,11 @@ import sap.commerce.toolset.ccv2.settings.state.CCv2Authentication
 import sap.commerce.toolset.ccv2.settings.state.CCv2AuthenticationMode
 import sap.commerce.toolset.ccv2.settings.state.CCv2Subscription
 import sap.commerce.toolset.ui.contextHelp
+import sap.commerce.toolset.ui.inlineBanner
 import sap.commerce.toolset.ui.repackDialog
 import sap.commerce.toolset.ui.scrollPanel
+import com.intellij.credentialStore.Credentials
+import com.intellij.openapi.diagnostic.thisLogger
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.GridBagLayout
@@ -61,6 +64,7 @@ internal class CCv2SubscriptionDialog(
     dialogTitle: String,
     private val ccv2LegacyTokenSupplier: () -> ApiContext?,
     private val ccv2ClientTokenSupplier: () -> ApiContext?,
+    private val ccv2ClientCredentialsSupplier: () -> Credentials?,
     private val hanaApiUrlSupplier: () -> String,
     private val kymaApiUrlSupplier: () -> String,
 ) : DialogWrapper(null, parentComponent, false, IdeModalityType.IDE) {
@@ -70,6 +74,8 @@ internal class CCv2SubscriptionDialog(
     )
     private val enabled by lazy { AtomicBooleanProperty(subscription.id == null) }
     private val showSubscriptions = AtomicBooleanProperty(false)
+    private val isFetching = AtomicBooleanProperty(false)
+    private val showIdle = AtomicBooleanProperty(true)
 
     private lateinit var idTextField: JBTextField
     private lateinit var nameTextField: JBTextField
@@ -90,6 +96,10 @@ internal class CCv2SubscriptionDialog(
             subscriptionsPanel.removeAll()
             subscriptionsPanel.add(panel)
 
+            if (!showIdle.get()) {
+                isFetching.set(false)
+                showSubscriptions.set(true)
+            }
             repackDialog()
         }
     }
@@ -99,11 +109,8 @@ internal class CCv2SubscriptionDialog(
         private val serialVersionUID: Long = -6131274561037160651L
 
         override fun doAction(e: ActionEvent) {
-            if (showSubscriptions.get()) {
-                val authToken = getSubscriptionToken()
-                    ?: HanaApiContext(hanaApiUrlSupplier(), "")
-                initSubscriptionsPanel(authToken)
-            }
+            val authToken = getSubscriptionToken() ?: return
+            initSubscriptionsPanel(authToken)
         }
     }
 
@@ -137,9 +144,10 @@ internal class CCv2SubscriptionDialog(
 
         if (!subscription.ccv2ClientTokenLoaded) {
             CCv2ProjectSettings.getInstance().loadCCv2Authentication(subscription.uuid) { credentials ->
+                val effectiveCredentials = credentials ?: ccv2ClientCredentialsSupplier()
                 subscription.ccv2ClientTokenLoaded = true
-                subscription.authentication.clientId = credentials?.userName ?: ""
-                subscription.authentication.clientSecret = credentials?.getPasswordAsString() ?: ""
+                subscription.authentication.clientId = effectiveCredentials?.userName ?: ""
+                subscription.authentication.clientSecret = effectiveCredentials?.getPasswordAsString() ?: ""
 
                 subscriptionCCv2ClientIdField.text = subscription.authentication.clientId
                 subscriptionCCv2ClientSecretField.text = subscription.authentication.clientSecret
@@ -150,11 +158,10 @@ internal class CCv2SubscriptionDialog(
                 if (subscription.authenticationMode == CCv2AuthenticationMode.TECHNICAL_USER) {
                     enabled.set(true)
 
-                    val authToken = credentials
+                    val authToken = effectiveCredentials
                         ?.let { CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), subscription.authentication.immutable(), it) }
                         ?: ccv2ClientTokenSupplier()
-                        ?: KymaApiContext(kymaApiUrlSupplier(), "")
-                    initSubscriptionsPanel(authToken)
+                    if (authToken != null) initSubscriptionsPanel(authToken)
                 }
             }
         } else if (subscription.authenticationMode == CCv2AuthenticationMode.TECHNICAL_USER) initWithNotPersistedToken()
@@ -218,11 +225,23 @@ internal class CCv2SubscriptionDialog(
                         label("Retrieving subscriptions...")
                     }
                 }.align(Align.CENTER)
-            }.visibleIf(showSubscriptions.not())
+            }.visibleIf(isFetching)
+
+            row {
+                comment("Fill in credentials and click <b>Fetch Subscriptions</b>.")
+            }.visibleIf(showIdle)
         }
     }
 
     private fun Panel.authToken() = indent {
+        row {
+            inlineBanner(
+                message = """API tokens have stopped working.
+                    |<br>Create and use technical users instead."""
+                    .trimMargin(),
+                status = EditorNotificationPanel.Status.Warning
+            ).align(AlignX.FILL)
+        }.resizableRow().topGap(TopGap.MEDIUM)
         row {
             subscriptionCCv2TokenField = passwordField()
                 .label("CCv2 token:")
@@ -274,9 +293,14 @@ internal class CCv2SubscriptionDialog(
     private fun initWithNotPersistedToken() {
         enabled.set(true)
 
-        val authToken = getSubscriptionToken()
-            ?: HanaApiContext(hanaApiUrlSupplier(), "")
+        val authToken = getSubscriptionToken() ?: return
         initSubscriptionsPanel(authToken)
+    }
+
+    private fun emptyApiContext(): ApiContext = if (authModeObservable.get() == CCv2AuthenticationMode.TECHNICAL_USER) {
+        KymaApiContext(kymaApiUrlSupplier(), "")
+    } else {
+        HanaApiContext(hanaApiUrlSupplier(), "")
     }
 
     private fun subscribe() {
@@ -286,13 +310,16 @@ internal class CCv2SubscriptionDialog(
                 else CCv2ToolWindowUtil.noDataPanel("No subscriptions found for the given token.")
 
                 subscriptionsPanel.add(panel)
+                isFetching.set(false)
                 showSubscriptions.set(true)
                 peer.window?.pack()
             }
 
             override fun onFetchingError(e: Throwable) {
+                thisLogger().warn("CCv2: Failed to fetch subscriptions", e)
                 val panel = CCv2ToolWindowUtil.noDataPanel("Unable to get subscriptions due: </br>${e.message}", EditorNotificationPanel.Status.Error)
                 subscriptionsPanel.add(panel)
+                isFetching.set(false)
                 showSubscriptions.set(true)
                 peer.window?.pack()
             }
@@ -362,14 +389,18 @@ internal class CCv2SubscriptionDialog(
         val tokenEndpoint = subscriptionCCv2EndpointField.text.takeIf { it.isNotBlank() } ?: return ccv2ClientTokenSupplier()
         val resource = subscriptionCCv2ResourceField.text.takeIf { it.isNotBlank() } ?: return ccv2ClientTokenSupplier()
         val auth = CCv2Authentication(tokenEndpoint, resource)
-        val credentials = subscription.authentication.credentials
-            ?: return ccv2ClientTokenSupplier()
+        val clientId = String(subscriptionCCv2ClientIdField.password).takeIf { it.isNotBlank() }
+        val clientSecret = String(subscriptionCCv2ClientSecretField.password).takeIf { it.isNotBlank() }
+        val credentials = if (clientId != null && clientSecret != null) Credentials(clientId, clientSecret)
+            else return ccv2ClientTokenSupplier()
 
         CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), auth, credentials)
             ?: ccv2ClientTokenSupplier()
     }
 
     private fun initSubscriptionsPanel(token: ApiContext) {
+        isFetching.set(true)
+        showIdle.set(false)
         showSubscriptions.set(false)
         subscriptionsPanel.removeAll()
 

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2SubscriptionDialog.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/CCv2SubscriptionDialog.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -19,16 +19,12 @@
 package sap.commerce.toolset.ccv2.ui
 
 import com.intellij.openapi.observable.properties.AtomicBooleanProperty
-import com.intellij.openapi.observable.properties.AtomicProperty
-import com.intellij.openapi.observable.util.equalsTo
 import com.intellij.openapi.observable.util.not
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.ui.AnimatedIcon
 import com.intellij.ui.EditorNotificationPanel
-import com.intellij.ui.EnumComboBoxModel
-import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBPanel
 import com.intellij.ui.components.JBPasswordField
 import com.intellij.ui.components.JBTextField
@@ -38,15 +34,12 @@ import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.ccv1.model.SubscriptionDTO
 import sap.commerce.toolset.ccv2.CCv2Service
 import sap.commerce.toolset.ccv2.api.ApiContext
-import sap.commerce.toolset.ccv2.api.HanaApiContext
 import sap.commerce.toolset.ccv2.api.KymaApiContext
 import sap.commerce.toolset.ccv2.event.CCv2SubscriptionsListener
 import sap.commerce.toolset.ccv2.settings.CCv2ProjectSettings
 import sap.commerce.toolset.ccv2.settings.state.CCv2Authentication
-import sap.commerce.toolset.ccv2.settings.state.CCv2AuthenticationMode
 import sap.commerce.toolset.ccv2.settings.state.CCv2Subscription
 import sap.commerce.toolset.ui.contextHelp
-import sap.commerce.toolset.ui.inlineBanner
 import sap.commerce.toolset.ui.repackDialog
 import sap.commerce.toolset.ui.scrollPanel
 import com.intellij.credentialStore.Credentials
@@ -62,10 +55,8 @@ internal class CCv2SubscriptionDialog(
     parentComponent: Component,
     private val subscription: CCv2Subscription.Mutable,
     dialogTitle: String,
-    private val ccv2LegacyTokenSupplier: () -> ApiContext?,
     private val ccv2ClientTokenSupplier: () -> ApiContext?,
     private val ccv2ClientCredentialsSupplier: () -> Credentials?,
-    private val hanaApiUrlSupplier: () -> String,
     private val kymaApiUrlSupplier: () -> String,
 ) : DialogWrapper(null, parentComponent, false, IdeModalityType.IDE) {
 
@@ -79,7 +70,6 @@ internal class CCv2SubscriptionDialog(
 
     private lateinit var idTextField: JBTextField
     private lateinit var nameTextField: JBTextField
-    private lateinit var subscriptionCCv2TokenField: JBPasswordField
     private lateinit var subscriptionCCv2EndpointField: JBTextField
     private lateinit var subscriptionCCv2ResourceField: JBTextField
     private lateinit var subscriptionCCv2ClientIdField: JBPasswordField
@@ -89,21 +79,6 @@ internal class CCv2SubscriptionDialog(
             it.border = JBUI.Borders.empty()
             it.maximumSize = Dimension(Int.MAX_VALUE, 200)
         }
-    private val authModeObservable = AtomicProperty(subscription.authenticationMode).apply {
-        afterChange(disposable) {
-            val panel = CCv2ToolWindowUtil.noDataPanel("Re-fetch subscriptions...")
-
-            subscriptionsPanel.removeAll()
-            subscriptionsPanel.add(panel)
-
-            if (!showIdle.get()) {
-                isFetching.set(false)
-                showSubscriptions.set(true)
-            }
-            repackDialog()
-        }
-    }
-
     private val fetchSubscriptionsButton = object : DialogWrapperAction("Fetch Subscriptions") {
         @Serial
         private val serialVersionUID: Long = -6131274561037160651L
@@ -122,26 +97,6 @@ internal class CCv2SubscriptionDialog(
 
         subscribe()
 
-        if (!subscription.ccv2LegacyTokenLoaded) {
-            CCv2ProjectSettings.getInstance().loadCCv2Token(subscription.uuid) { token ->
-                subscriptionCCv2TokenField.text = token
-                subscription.ccv2LegacyTokenLoaded = true
-                subscription.ccv2Token = token
-
-                beforeModification.ccv2Token = subscription.ccv2Token
-
-                if (subscription.authenticationMode == CCv2AuthenticationMode.TOKEN) {
-                    enabled.set(true)
-
-                    val authToken = token
-                        ?.let { HanaApiContext(hanaApiUrlSupplier(), token) }
-                        ?: ccv2LegacyTokenSupplier()
-                        ?: HanaApiContext(hanaApiUrlSupplier(), "")
-                    initSubscriptionsPanel(authToken)
-                }
-            }
-        } else if (subscription.authenticationMode == CCv2AuthenticationMode.TOKEN) initWithNotPersistedToken()
-
         if (!subscription.ccv2ClientTokenLoaded) {
             CCv2ProjectSettings.getInstance().loadCCv2Authentication(subscription.uuid) { credentials ->
                 val effectiveCredentials = credentials ?: ccv2ClientCredentialsSupplier()
@@ -155,16 +110,14 @@ internal class CCv2SubscriptionDialog(
                 beforeModification.authentication.clientId = subscription.authentication.clientId
                 beforeModification.authentication.clientSecret = subscription.authentication.clientSecret
 
-                if (subscription.authenticationMode == CCv2AuthenticationMode.TECHNICAL_USER) {
-                    enabled.set(true)
+                enabled.set(true)
 
-                    val authToken = effectiveCredentials
-                        ?.let { CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), subscription.authentication.immutable(), it) }
-                        ?: ccv2ClientTokenSupplier()
-                    if (authToken != null) initSubscriptionsPanel(authToken)
-                }
+                val authToken = effectiveCredentials
+                    ?.let { CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), subscription.authentication.immutable(), it) }
+                    ?: ccv2ClientTokenSupplier()
+                if (authToken != null) initSubscriptionsPanel(authToken)
             }
-        } else if (subscription.authenticationMode == CCv2AuthenticationMode.TECHNICAL_USER) initWithNotPersistedToken()
+        } else initWithNotPersistedToken()
     }
 
     override fun createLeftSideActions() = arrayOf(fetchSubscriptionsButton)
@@ -196,17 +149,6 @@ internal class CCv2SubscriptionDialog(
                 .component
         }.layout(RowLayout.PARENT_GRID)
 
-        row {
-            comboBox(
-                model = EnumComboBoxModel(CCv2AuthenticationMode::class.java),
-                renderer = SimpleListCellRenderer.create("?") { it.presentationTitle }
-            )
-                .label("Auth mode:")
-                .bindItem(subscription::authenticationMode.toNullableProperty())
-                .onChanged { authModeObservable.set(it.selectedItem as CCv2AuthenticationMode) }
-        }.layout(RowLayout.PARENT_GRID)
-
-        authToken()
         authClient()
 
         group("Available Subscriptions") {
@@ -232,27 +174,6 @@ internal class CCv2SubscriptionDialog(
             }.visibleIf(showIdle)
         }
     }
-
-    private fun Panel.authToken() = indent {
-        row {
-            inlineBanner(
-                message = """API tokens have stopped working.
-                    |<br>Create and use technical users instead."""
-                    .trimMargin(),
-                status = EditorNotificationPanel.Status.Warning
-            ).align(AlignX.FILL)
-        }.resizableRow().topGap(TopGap.MEDIUM)
-        row {
-            subscriptionCCv2TokenField = passwordField()
-                .label("CCv2 token:")
-                .enabledIf(enabled)
-                .comment("Overrides default CCv2 token per subscription.")
-                .align(AlignX.FILL)
-                .bindText(subscription::ccv2Token.toNonNullableProperty(""))
-                .component
-        }.layout(RowLayout.PARENT_GRID)
-    }
-        .visibleIf(authModeObservable.equalsTo(CCv2AuthenticationMode.TOKEN))
 
     private fun Panel.authClient() = indent {
         row {
@@ -288,7 +209,6 @@ internal class CCv2SubscriptionDialog(
         }.layout(RowLayout.PARENT_GRID)
     }
         .enabledIf(enabled)
-        .visibleIf(authModeObservable.equalsTo(CCv2AuthenticationMode.TECHNICAL_USER))
 
     private fun initWithNotPersistedToken() {
         enabled.set(true)
@@ -297,11 +217,6 @@ internal class CCv2SubscriptionDialog(
         initSubscriptionsPanel(authToken)
     }
 
-    private fun emptyApiContext(): ApiContext = if (authModeObservable.get() == CCv2AuthenticationMode.TECHNICAL_USER) {
-        KymaApiContext(kymaApiUrlSupplier(), "")
-    } else {
-        HanaApiContext(hanaApiUrlSupplier(), "")
-    }
 
     private fun subscribe() {
         project.messageBus.connect(disposable).subscribe(CCv2SubscriptionsListener.TOPIC, object : CCv2SubscriptionsListener {
@@ -379,13 +294,7 @@ internal class CCv2SubscriptionDialog(
         .let { scrollPanel(it) }
         .apply { preferredSize = Dimension(preferredSize.width, 180) }
 
-    private fun getSubscriptionToken(): ApiContext? = if (authModeObservable.get() == CCv2AuthenticationMode.TOKEN) {
-        subscriptionCCv2TokenField.password
-            ?.let { String(it) }
-            ?.takeIf { it.isNotBlank() }
-            ?.let { HanaApiContext(hanaApiUrlSupplier(), it) }
-            ?: ccv2LegacyTokenSupplier()
-    } else {
+    private fun getSubscriptionToken(): ApiContext? {
         val tokenEndpoint = subscriptionCCv2EndpointField.text.takeIf { it.isNotBlank() } ?: return ccv2ClientTokenSupplier()
         val resource = subscriptionCCv2ResourceField.text.takeIf { it.isNotBlank() } ?: return ccv2ClientTokenSupplier()
         val auth = CCv2Authentication(tokenEndpoint, resource)
@@ -394,7 +303,7 @@ internal class CCv2SubscriptionDialog(
         val credentials = if (clientId != null && clientSecret != null) Credentials(clientId, clientSecret)
             else return ccv2ClientTokenSupplier()
 
-        CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), auth, credentials)
+        return CCv2Service.getInstance(project).retrieveAuthToken(kymaApiUrlSupplier(), auth, credentials)
             ?: ccv2ClientTokenSupplier()
     }
 

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/components/CCv2SubscriptionListPanel.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/components/CCv2SubscriptionListPanel.kt
@@ -18,6 +18,7 @@
 
 package sap.commerce.toolset.ccv2.ui.components
 
+import com.intellij.credentialStore.Credentials
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.observable.util.whenListChanged
 import com.intellij.openapi.project.Project
@@ -42,6 +43,7 @@ internal class CCv2SubscriptionListPanel(
     disposable: Disposable?,
     private val ccv2LegacyTokenSupplier: () -> ApiContext?,
     private val ccv2ClientTokenSupplier: () -> ApiContext?,
+    private val ccv2ClientCredentialsSupplier: () -> Credentials?,
     private val hanaApiUrlSupplier: () -> String,
     private val kymaApiUrlSupplier: () -> String,
     listener: (ListDataEvent) -> Unit
@@ -68,6 +70,7 @@ internal class CCv2SubscriptionListPanel(
             dialogTitle = "Create CCv2 Subscription",
             ccv2LegacyTokenSupplier = ccv2LegacyTokenSupplier,
             ccv2ClientTokenSupplier = ccv2ClientTokenSupplier,
+            ccv2ClientCredentialsSupplier = ccv2ClientCredentialsSupplier,
             hanaApiUrlSupplier = hanaApiUrlSupplier,
             kymaApiUrlSupplier = kymaApiUrlSupplier,
         )
@@ -89,6 +92,7 @@ internal class CCv2SubscriptionListPanel(
             dialogTitle = "Edit CCv2 Subscription",
             ccv2LegacyTokenSupplier = ccv2LegacyTokenSupplier,
             ccv2ClientTokenSupplier = ccv2ClientTokenSupplier,
+            ccv2ClientCredentialsSupplier = ccv2ClientCredentialsSupplier,
             hanaApiUrlSupplier = hanaApiUrlSupplier,
             kymaApiUrlSupplier = kymaApiUrlSupplier,
         )

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/components/CCv2SubscriptionListPanel.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/components/CCv2SubscriptionListPanel.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -41,10 +41,8 @@ import javax.swing.event.ListDataEvent
 internal class CCv2SubscriptionListPanel(
     private val project: Project,
     disposable: Disposable?,
-    private val ccv2LegacyTokenSupplier: () -> ApiContext?,
     private val ccv2ClientTokenSupplier: () -> ApiContext?,
     private val ccv2ClientCredentialsSupplier: () -> Credentials?,
-    private val hanaApiUrlSupplier: () -> String,
     private val kymaApiUrlSupplier: () -> String,
     listener: (ListDataEvent) -> Unit
 ) : AddEditDeleteListPanel<CCv2Subscription.Mutable>(null, emptyList()) {
@@ -68,10 +66,8 @@ internal class CCv2SubscriptionListPanel(
             parentComponent = this,
             subscription = mutable,
             dialogTitle = "Create CCv2 Subscription",
-            ccv2LegacyTokenSupplier = ccv2LegacyTokenSupplier,
             ccv2ClientTokenSupplier = ccv2ClientTokenSupplier,
             ccv2ClientCredentialsSupplier = ccv2ClientCredentialsSupplier,
-            hanaApiUrlSupplier = hanaApiUrlSupplier,
             kymaApiUrlSupplier = kymaApiUrlSupplier,
         )
         return if (dialog.showAndGet()) mutable
@@ -82,7 +78,6 @@ internal class CCv2SubscriptionListPanel(
         val copy = item.copy(
             authentication = item.authentication.copy(),
         ).apply {
-            ccv2LegacyTokenLoaded = item.ccv2LegacyTokenLoaded
             ccv2ClientTokenLoaded = item.ccv2ClientTokenLoaded
         }
         val dialog = CCv2SubscriptionDialog(
@@ -90,22 +85,17 @@ internal class CCv2SubscriptionListPanel(
             parentComponent = this,
             subscription = copy,
             dialogTitle = "Edit CCv2 Subscription",
-            ccv2LegacyTokenSupplier = ccv2LegacyTokenSupplier,
             ccv2ClientTokenSupplier = ccv2ClientTokenSupplier,
             ccv2ClientCredentialsSupplier = ccv2ClientCredentialsSupplier,
-            hanaApiUrlSupplier = hanaApiUrlSupplier,
             kymaApiUrlSupplier = kymaApiUrlSupplier,
         )
         return if (
             dialog.showAndGet()) {
             item.apply {
                 modified = copy.modified
-                ccv2LegacyTokenLoaded = copy.ccv2LegacyTokenLoaded
                 ccv2ClientTokenLoaded = copy.ccv2ClientTokenLoaded
                 id = copy.id
                 name = copy.name
-                ccv2Token = copy.ccv2Token
-                authenticationMode = copy.authenticationMode
                 authentication.apply {
                     tokenEndpoint = copy.authentication.tokenEndpoint
                     resource = copy.authentication.resource

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -589,6 +589,7 @@ hybris.settings.project.cng.title=Cockpit NG
 hybris.settings.application.ccv2Token=Token:
 hybris.settings.application.ccv2Token.help.description=Specify developer specific Token for CCv2 API, it will be stored in the OS specific secure storage under <strong>SAP CX CCv2 Token</strong> alias.<br>
 hybris.settings.application.ccv2Token.tooltip=Official documentation <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/0fa6bcf4736c46f78c248512391eb467/b5d4d851cbd54469906a089bb8dd58d8.html">help.sap.com - Generating API Tokens</a>.
+hybris.settings.application.ccv2AuthToken.tooltip=Official documentation <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/452dcbb0e00f47e88a69cdaeb87a925d/66abfe678b55457fab235ce8039dda71.html?locale=en-US">help.sap.com - Cloud Portal API Documentation</a>.
 
 hybris.startupActivity.itemsXmlValidation.progress.title=Validating items.xml files...
 hybris.startupActivity.itemsXmlValidation.progress.subTitle.validating=Validating: {0}...

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -586,9 +586,6 @@ hybris.settings.project.bs.title=Bean System
 hybris.settings.project.ts.title=Type System
 hybris.settings.project.bp.title=Business Process
 hybris.settings.project.cng.title=Cockpit NG
-hybris.settings.application.ccv2Token=Token:
-hybris.settings.application.ccv2Token.help.description=Specify developer specific Token for CCv2 API, it will be stored in the OS specific secure storage under <strong>SAP CX CCv2 Token</strong> alias.<br>
-hybris.settings.application.ccv2Token.tooltip=Official documentation <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/0fa6bcf4736c46f78c248512391eb467/b5d4d851cbd54469906a089bb8dd58d8.html">help.sap.com - Generating API Tokens</a>.
 hybris.settings.application.ccv2AuthToken.tooltip=Official documentation <a href="https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/452dcbb0e00f47e88a69cdaeb87a925d/66abfe678b55457fab235ce8039dda71.html?locale=en-US">help.sap.com - Cloud Portal API Documentation</a>.
 
 hybris.startupActivity.itemsXmlValidation.progress.title=Validating items.xml files...


### PR DESCRIPTION
Refactor CCv2 UI components and settings to support correct authentication via Technical User  technical users; deprecate token-based auth. Update API URLs and documentation links.

<img width="971" height="716" alt="Skärmavbild 2026-03-14 kl  03 29 12" src="https://github.com/user-attachments/assets/ea1ed280-74df-47b5-bd78-ab49c51045b5" />

<img width="980" height="724" alt="Skärmavbild 2026-03-14 kl  03 29 31" src="https://github.com/user-attachments/assets/bfb9eafa-461d-4757-8f3f-1acbeef07910" />

<img width="402" height="476" alt="Skärmavbild 2026-03-14 kl  03 30 01" src="https://github.com/user-attachments/assets/3739a138-4120-4814-8a20-77506abcf0c7" />

<img width="410" height="468" alt="Skärmavbild 2026-03-14 kl  03 30 15" src="https://github.com/user-attachments/assets/eb16413a-4b70-4cc3-b3ea-b7fbfe423011" />




Signed-off-by: Sina Bastani sina@sinabastani.dev
