### PR TITLE
ImpEx | Local Fix: added possibility to define missing macro declaration expected by abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.6]
 
 <cite>Release contributors</cite>
-- 16 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.6+author%3Amlytvyn+is%3Apr)
+- 17 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.6+author%3Amlytvyn+is%3Apr)
 
 ### `ImpEx` enhancements
 - Improved handling of the double-quoted `"` strings in the data row fields [#1761](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1761)
@@ -22,6 +22,7 @@
 ### `ImpEx` inspection rules
 - Inspection: detect and delete unused macro declarations [#1772](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1772)
 - Inspection: resolve expected macro declarations by abbreviations [#1776](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1776)
+- Local Fix: added possibility to define missing macro declaration expected by abbreviation [#1777](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1777)
 
 ## [2026.0.5]
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
@@ -19,18 +19,17 @@
 package sap.commerce.toolset.impex.codeInspection
 
 import com.intellij.codeHighlighting.HighlightDisplayLevel
-import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalInspectionToolSession
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInspection.*
 import com.intellij.lang.properties.IProperty
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
-import sap.commerce.toolset.impex.psi.ImpExAnyHeaderParameterName
-import sap.commerce.toolset.impex.psi.ImpExMacroDeclaration
-import sap.commerce.toolset.impex.psi.ImpExVisitor
+import sap.commerce.toolset.impex.psi.*
 import sap.commerce.toolset.impex.psi.references.ImpExHeaderAbbreviationReference
 
 class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
@@ -46,7 +45,10 @@ class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
             .let { cachedMacros.addAll(it) }
     }
 
-    private class ImpExHeaderLineVisitor(private val problemsHolder: ProblemsHolder, private val cachedMacros: Set<String>) : ImpExVisitor() {
+    private class ImpExHeaderLineVisitor(
+        private val problemsHolder: ProblemsHolder,
+        private val cachedMacros: Set<String>
+    ) : ImpExVisitor() {
 
         override fun visitAnyHeaderParameterName(parameter: ImpExAnyHeaderParameterName) {
             val reference = parameter.reference.asSafely<ImpExHeaderAbbreviationReference>() ?: return
@@ -72,7 +74,35 @@ class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
                 reference,
                 ProblemHighlightType.ERROR,
                 i18n("hybris.inspections.impex.ImpExIncompleteHeaderAbbreviationUsageInspection.key", parameter.text, missingExpectedMacros.joinToString()),
+                *missingExpectedMacros
+                    .map { LocalFix(parameter, it) }
+                    .toTypedArray()
             )
+        }
+
+        private class LocalFix(
+            parameter: ImpExAnyHeaderParameterName,
+            private val macroName: String
+        ) : LocalQuickFixOnPsiElement(parameter) {
+
+            override fun getFamilyName() = "[y] Missing macro declarations"
+            override fun getText() = "Add macro declaration '$macroName'"
+
+            override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+                val firstLeaf = startElement
+                    .asSafely<ImpExAnyHeaderParameterName>()
+                    ?.parentOfType<ImpExHeaderLine>()
+                    ?: return
+
+                val snippetFile = ImpExElementFactory.createFile(
+                    project, """
+                    $macroName =  
+
+                """.trimIndent()
+                )
+
+                file.addBefore(snippetFile, firstLeaf)
+            }
         }
     }
 }


### PR DESCRIPTION
<img width="1031" height="266" alt="Screenshot 2026-03-24 at 22 50 11" src="https://github.com/user-attachments/assets/09c3fb68-e11b-4382-927e-e3e074848a47" />
