### PR TITLE
ImpEx | Resolve header abbreviation in the complex param `; categories(code, myAbbreviation);`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 
 ### `ImpEx` enhancements
 - Do not format value if the declared macro [#1788](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1788)
+- Resolve header abbreviation in the complex param `; categories(code, myAbbreviation);` [#1789](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1789)
 
 ## [2026.0.6]
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyAttributeName.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyAttributeName.java
@@ -32,7 +32,6 @@ public interface ImpExAnyAttributeName extends PsiElement {
   @NotNull
   List<ImpExString> getStringList();
 
-  @Nullable
-  ImpExAnyAttributeValue getAnyAttributeValue();
+  @Nullable ImpExAnyAttributeValue getAnyAttributeValue();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyAttributeValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyAttributeValue.java
@@ -35,7 +35,6 @@ public interface ImpExAnyAttributeValue extends PsiElement {
   @NotNull
   List<ImpExString> getStringList();
 
-  @Nullable
-  ImpExAnyAttributeName getAnyAttributeName();
+  @Nullable ImpExAnyAttributeName getAnyAttributeName();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyHeaderParameterName.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExAnyHeaderParameterName.java
@@ -38,7 +38,8 @@ public interface ImpExAnyHeaderParameterName extends PsiElement {
   @Nullable
   ImpExSpecialParameter getSpecialParameter();
 
-  @Nullable
-  ImpExHeaderTypeName getHeaderItemTypeName();
+  @Nullable ImpExHeaderTypeName getHeaderItemTypeName();
+
+  boolean isHeaderAbbreviation();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExDocumentIdDec.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExDocumentIdDec.java
@@ -31,10 +31,8 @@ import java.util.Map;
 
 public interface ImpExDocumentIdDec extends ImpExPsiNamedElement {
 
-  @NotNull
-  Map<String, Collection<ImpExValue>> getValues();
+  @NotNull Map<@NotNull String, @NotNull Collection<@NotNull ImpExValue>> getValues();
 
-  @Nullable
-  ImpExHeaderTypeName getHeaderType();
+  @Nullable ImpExHeaderTypeName getHeaderType();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameter.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameter.java
@@ -39,18 +39,14 @@ public interface ImpExFullHeaderParameter extends PsiElement {
   @NotNull
   List<ImpExParameters> getParametersList();
 
-  @Nullable
-  ImpExHeaderLine getHeaderLine();
+  @Nullable ImpExHeaderLine getHeaderLine();
 
   int getColumnNumber();
 
-  @Nullable
-  ImpExAttribute getAttribute(@NotNull AttributeModifier attributeModifier);
+  @Nullable ImpExAttribute getAttribute(@NotNull AttributeModifier attributeModifier);
 
-  @NotNull
-  String getAttributeValue(@NotNull AttributeModifier attributeModifier, @NotNull String defaultValue);
+  @NotNull String getAttributeValue(@NotNull AttributeModifier attributeModifier, @NotNull String defaultValue);
 
-  @NotNull
-  List<ImpExValueGroup> getValueGroups();
+  @NotNull List<@NotNull ImpExValueGroup> getValueGroups();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExHeaderLine.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExHeaderLine.java
@@ -40,19 +40,14 @@ public interface ImpExHeaderLine extends PsiElement {
   @Nullable
   ImpExFullHeaderType getFullHeaderType();
 
-  @Nullable
-  ImpExFullHeaderParameter getFullHeaderParameter(@NotNull String parameterName);
+  @Nullable ImpExFullHeaderParameter getFullHeaderParameter(@NotNull String parameterName);
 
-  @Nullable
-  ImpExFullHeaderParameter getFullHeaderParameter(int index);
+  @Nullable ImpExFullHeaderParameter getFullHeaderParameter(int index);
 
-  @NotNull
-  Collection<ImpExValueLine> getValueLines();
+  @NotNull Collection<@NotNull ImpExValueLine> getValueLines();
 
-  @NotNull
-  TextRange getTableRange();
+  @NotNull TextRange getTableRange();
 
-  @NotNull
-  List<ImpExFullHeaderParameter> getUniqueFullHeaderParameters();
+  @NotNull List<ImpExFullHeaderParameter> getUniqueFullHeaderParameters();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExMacroNameDec.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExMacroNameDec.java
@@ -31,10 +31,8 @@ import sap.commerce.toolset.impex.psi.impl.ImpExMacroNameDecMixin;
 
 public interface ImpExMacroNameDec extends ImpExPsiNamedElement {
 
-  @NotNull
-  ImpExMacroNameDecMixin getNameIdentifier();
+  @NotNull ImpExMacroNameDecMixin getNameIdentifier();
 
-  @NotNull
-  String resolveValue(@NotNull Set<ImpExMacroUsageDec> evaluatedMacroUsages);
+  @NotNull String resolveValue(@NotNull Set<@Nullable ImpExMacroUsageDec> evaluatedMacroUsages);
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExMacroUsageDec.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExMacroUsageDec.java
@@ -31,13 +31,10 @@ import sap.commerce.toolset.impex.psi.impl.ImpExMacroUsageDecMixin;
 
 public interface ImpExMacroUsageDec extends ImpExPsiNamedElement {
 
-  @NotNull
-  ImpExMacroUsageDecMixin getNameIdentifier();
+  @NotNull ImpExMacroUsageDecMixin getNameIdentifier();
 
-  @Nullable
-  String getConfigPropertyKey();
+  @Nullable String getConfigPropertyKey();
 
-  @NotNull
-  String resolveValue(@NotNull Set<ImpExMacroUsageDec> evaluatedMacroUsages);
+  @NotNull String resolveValue(@NotNull Set<@Nullable ImpExMacroUsageDec> evaluatedMacroUsages);
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExParameter.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExParameter.java
@@ -41,19 +41,16 @@ public interface ImpExParameter extends PsiElement {
   @Nullable
   ImpExSubParameters getSubParameters();
 
-  @Nullable
-  String getReferenceItemTypeName();
+  @Nullable String getReferenceItemTypeName();
 
-  @Nullable
-  String getReferenceName();
+  @Nullable String getReferenceName();
 
-  @Nullable
-  String getItemTypeName();
+  @Nullable String getItemTypeName();
 
-  @Nullable
-  String getInlineTypeName();
+  @Nullable String getInlineTypeName();
 
-  @NotNull
-  String getAttributeName();
+  @NotNull String getAttributeName();
+
+  boolean isHeaderAbbreviation();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExString.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExString.java
@@ -32,7 +32,6 @@ public interface ImpExString extends PsiElement {
   @NotNull
   List<ImpExMacroUsageDec> getMacroUsageDecList();
 
-  @Nullable
-  ImpExValueGroup getValueGroup();
+  @Nullable ImpExValueGroup getValueGroup();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExSubTypeName.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExSubTypeName.java
@@ -29,10 +29,8 @@ import com.intellij.psi.PsiElement;
 
 public interface ImpExSubTypeName extends PsiElement {
 
-  @Nullable
-  ImpExValueLine getValueLine();
+  @Nullable ImpExValueLine getValueLine();
 
-  @Nullable
-  ImpExHeaderTypeName getHeaderTypeName();
+  @Nullable ImpExHeaderTypeName getHeaderTypeName();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRights.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRights.java
@@ -42,7 +42,6 @@ public interface ImpExUserRights extends PsiElement {
   @NotNull
   List<ImpExUserRightsValueLine> getUserRightsValueLineList();
 
-  @NotNull
-  Collection<ImpExUserRightsValueGroup> getValueGroups(int index);
+  @NotNull Collection<@NotNull ImpExUserRightsValueGroup> getValueGroups(int index);
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsAttributeValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsAttributeValue.java
@@ -29,7 +29,6 @@ import com.intellij.psi.PsiElement;
 
 public interface ImpExUserRightsAttributeValue extends ImpExUserRightsValue {
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter();
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsFirstValueGroup.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsFirstValueGroup.java
@@ -41,7 +41,6 @@ public interface ImpExUserRightsFirstValueGroup extends PsiElement {
   @Nullable
   ImpExUserRightsSingleValue getUserRightsSingleValue();
 
-  @Nullable
-  ImpExValueLine getValueLine();
+  @Nullable ImpExValueLine getValueLine();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsHeaderLine.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsHeaderLine.java
@@ -32,7 +32,6 @@ public interface ImpExUserRightsHeaderLine extends PsiElement {
   @NotNull
   List<ImpExUserRightsHeaderParameter> getUserRightsHeaderParameterList();
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter(int index);
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter(int index);
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsHeaderParameter.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsHeaderParameter.java
@@ -30,13 +30,10 @@ import java.util.Collection;
 
 public interface ImpExUserRightsHeaderParameter extends PsiElement {
 
-  @Nullable
-  ImpExUserRightsHeaderLine getHeaderLine();
+  @Nullable ImpExUserRightsHeaderLine getHeaderLine();
 
-  @Nullable
-  Integer getColumnNumber();
+  @Nullable Integer getColumnNumber();
 
-  @NotNull
-  Collection<ImpExUserRightsValueGroup> getValueGroups();
+  @NotNull Collection<@NotNull ImpExUserRightsValueGroup> getValueGroups();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsMultiValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsMultiValue.java
@@ -29,7 +29,6 @@ import com.intellij.psi.PsiElement;
 
 public interface ImpExUserRightsMultiValue extends ImpExUserRightsValue {
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter();
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsPermissionValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsPermissionValue.java
@@ -29,7 +29,6 @@ import com.intellij.psi.PsiElement;
 
 public interface ImpExUserRightsPermissionValue extends ImpExUserRightsValue {
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter();
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsSingleValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsSingleValue.java
@@ -29,7 +29,6 @@ import com.intellij.psi.PsiElement;
 
 public interface ImpExUserRightsSingleValue extends ImpExUserRightsValue {
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter();
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsValueGroup.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsValueGroup.java
@@ -41,13 +41,10 @@ public interface ImpExUserRightsValueGroup extends PsiElement {
   @Nullable
   ImpExUserRightsSingleValue getUserRightsSingleValue();
 
-  @Nullable
-  ImpExUserRightsValueLine getValueLine();
+  @Nullable ImpExUserRightsValueLine getValueLine();
 
-  @Nullable
-  Integer getColumnNumber();
+  @Nullable Integer getColumnNumber();
 
-  @Nullable
-  ImpExUserRightsHeaderParameter getHeaderParameter();
+  @Nullable ImpExUserRightsHeaderParameter getHeaderParameter();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsValueLine.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExUserRightsValueLine.java
@@ -35,10 +35,8 @@ public interface ImpExUserRightsValueLine extends PsiElement {
   @NotNull
   List<ImpExUserRightsValueGroup> getUserRightsValueGroupList();
 
-  @Nullable
-  ImpExUserRightsValueGroup getValueGroup(int index);
+  @Nullable ImpExUserRightsValueGroup getValueGroup(int index);
 
-  @Nullable
-  ImpExUserRightsHeaderLine getHeaderLine();
+  @Nullable ImpExUserRightsHeaderLine getHeaderLine();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValue.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValue.java
@@ -32,8 +32,7 @@ public interface ImpExValue extends PsiElement {
   @NotNull
   List<ImpExMacroUsageDec> getMacroUsageDecList();
 
-  @Nullable
-  ImpExValueGroup getValueGroup();
+  @Nullable ImpExValueGroup getValueGroup();
 
   @Nullable PsiElement getFieldValue(int index);
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueGroup.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueGroup.java
@@ -32,15 +32,12 @@ public interface ImpExValueGroup extends PsiElement {
   @Nullable
   ImpExValue getValue();
 
-  @Nullable
-  ImpExFullHeaderParameter getFullHeaderParameter();
+  @Nullable ImpExFullHeaderParameter getFullHeaderParameter();
 
   int getColumnNumber();
 
-  @Nullable
-  ImpExValueLine getValueLine();
+  @Nullable ImpExValueLine getValueLine();
 
-  @Nullable
-  String computeValue();
+  @Nullable String computeValue();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueLine.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueLine.java
@@ -35,11 +35,9 @@ public interface ImpExValueLine extends PsiElement {
   @NotNull
   List<ImpExValueGroup> getValueGroupList();
 
-  @Nullable
-  ImpExHeaderLine getHeaderLine();
+  @Nullable ImpExHeaderLine getHeaderLine();
 
-  @Nullable
-  ImpExValueGroup getValueGroup(int columnNumber);
+  @Nullable ImpExValueGroup getValueGroup(int columnNumber);
 
   void addValueGroups(int groupsToAdd);
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyAttributeNameImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyAttributeNameImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExAnyAttributeNameImpl extends ImpExAttributeNameMixin implements ImpExAnyAttributeName {
 
-  public ImpExAnyAttributeNameImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExAnyAttributeNameImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -55,8 +55,7 @@ public class ImpExAnyAttributeNameImpl extends ImpExAttributeNameMixin implement
   }
 
   @Override
-  @Nullable
-  public ImpExAnyAttributeValue getAnyAttributeValue() {
+  public @Nullable ImpExAnyAttributeValue getAnyAttributeValue() {
     return ImpExPsiUtil.getAnyAttributeValue(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyAttributeValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyAttributeValueImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExAnyAttributeValueImpl extends ImpExAttributeValueMixin implements ImpExAnyAttributeValue {
 
-  public ImpExAnyAttributeValueImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExAnyAttributeValueImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -61,8 +61,7 @@ public class ImpExAnyAttributeValueImpl extends ImpExAttributeValueMixin impleme
   }
 
   @Override
-  @Nullable
-  public ImpExAnyAttributeName getAnyAttributeName() {
+  public @Nullable ImpExAnyAttributeName getAnyAttributeName() {
     return ImpExPsiUtil.getAnyAttributeName(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyHeaderParameterNameImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExAnyHeaderParameterNameImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExAnyHeaderParameterNameImpl extends ImpExAnyHeaderParameterNameMixin implements ImpExAnyHeaderParameterName {
 
-  public ImpExAnyHeaderParameterNameImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExAnyHeaderParameterNameImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -67,9 +67,13 @@ public class ImpExAnyHeaderParameterNameImpl extends ImpExAnyHeaderParameterName
   }
 
   @Override
-  @Nullable
-  public ImpExHeaderTypeName getHeaderItemTypeName() {
+  public @Nullable ImpExHeaderTypeName getHeaderItemTypeName() {
     return ImpExPsiUtil.getHeaderItemTypeName(this);
+  }
+
+  @Override
+  public boolean isHeaderAbbreviation() {
+    return ImpExPsiUtil.isHeaderAbbreviation(this);
   }
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterImpl.java
@@ -68,14 +68,12 @@ public class ImpExFullHeaderParameterImpl extends ImpExFullHeaderParameterMixin 
   }
 
   @Override
-  @Nullable
-  public ImpExHeaderLine getHeaderLine() {
+  public @Nullable ImpExHeaderLine getHeaderLine() {
     return ImpExPsiUtil.getHeaderLine(this);
   }
 
   @Override
-  @Nullable
-  public ImpExAttribute getAttribute(@NotNull AttributeModifier attributeModifier) {
+  public @Nullable ImpExAttribute getAttribute(@NotNull AttributeModifier attributeModifier) {
     return ImpExPsiUtil.getAttribute(this, attributeModifier);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExHeaderLineImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExHeaderLineImpl.java
@@ -69,14 +69,12 @@ public class ImpExHeaderLineImpl extends ImpExHeaderLineMixin implements ImpExHe
   }
 
   @Override
-  @NotNull
-  public TextRange getTableRange() {
+  public @NotNull TextRange getTableRange() {
     return ImpExPsiUtil.getTableRange(this);
   }
 
   @Override
-  @NotNull
-  public List<ImpExFullHeaderParameter> getUniqueFullHeaderParameters() {
+  public @NotNull List<ImpExFullHeaderParameter> getUniqueFullHeaderParameters() {
     return ImpExPsiUtil.getUniqueFullHeaderParameters(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExHeaderTypeNameImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExHeaderTypeNameImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExHeaderTypeNameImpl extends ImpExHeaderTypeNameMixin implements ImpExHeaderTypeName {
 
-  public ImpExHeaderTypeNameImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExHeaderTypeNameImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExMacroUsageDecImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExMacroUsageDecImpl.java
@@ -50,8 +50,7 @@ public class ImpExMacroUsageDecImpl extends ImpExMacroUsageDecMixin implements I
   }
 
   @Override
-  @Nullable
-  public String getConfigPropertyKey() {
+  public @Nullable String getConfigPropertyKey() {
     return ImpExPsiUtil.getConfigPropertyKey(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExParameterImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExParameterImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExParameterImpl extends ImpExParameterMixin implements ImpExParameter {
 
-  public ImpExParameterImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExParameterImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -73,33 +73,33 @@ public class ImpExParameterImpl extends ImpExParameterMixin implements ImpExPara
   }
 
   @Override
-  @Nullable
-  public String getReferenceItemTypeName() {
+  public @Nullable String getReferenceItemTypeName() {
     return ImpExPsiUtil.getReferenceItemTypeName(this);
   }
 
   @Override
-  @Nullable
-  public String getReferenceName() {
+  public @Nullable String getReferenceName() {
     return ImpExPsiUtil.getReferenceName(this);
   }
 
   @Override
-  @Nullable
-  public String getItemTypeName() {
+  public @Nullable String getItemTypeName() {
     return ImpExPsiUtil.getItemTypeName(this);
   }
 
   @Override
-  @Nullable
-  public String getInlineTypeName() {
+  public @Nullable String getInlineTypeName() {
     return ImpExPsiUtil.getInlineTypeName(this);
   }
 
   @Override
-  @NotNull
-  public String getAttributeName() {
+  public @NotNull String getAttributeName() {
     return ImpExPsiUtil.getAttributeName(this);
+  }
+
+  @Override
+  public boolean isHeaderAbbreviation() {
+    return ImpExPsiUtil.isHeaderAbbreviation(this);
   }
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExStringImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExStringImpl.java
@@ -55,8 +55,7 @@ public class ImpExStringImpl extends ImpExStringMixin implements ImpExString {
   }
 
   @Override
-  @Nullable
-  public ImpExValueGroup getValueGroup() {
+  public @Nullable ImpExValueGroup getValueGroup() {
     return ImpExPsiUtil.getValueGroup(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExSubTypeNameImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExSubTypeNameImpl.java
@@ -49,8 +49,7 @@ public class ImpExSubTypeNameImpl extends ImpExSubTypeNameMixin implements ImpEx
   }
 
   @Override
-  @Nullable
-  public ImpExHeaderTypeName getHeaderTypeName() {
+  public @Nullable ImpExHeaderTypeName getHeaderTypeName() {
     return ImpExPsiUtil.getHeaderTypeName(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsAttributeValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsAttributeValueImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExUserRightsAttributeValueImpl extends ImpExUserRightsAttributeValueMixin implements ImpExUserRightsAttributeValue {
 
-  public ImpExUserRightsAttributeValueImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExUserRightsAttributeValueImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -49,8 +49,7 @@ public class ImpExUserRightsAttributeValueImpl extends ImpExUserRightsAttributeV
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter() {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter() {
     return ImpExPsiUtil.getHeaderParameter(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsHeaderLineImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsHeaderLineImpl.java
@@ -56,8 +56,7 @@ public class ImpExUserRightsHeaderLineImpl extends ASTWrapperPsiElement implemen
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter(int index) {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter(int index) {
     return ImpExPsiUtil.getHeaderParameter(this, index);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsMultiValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsMultiValueImpl.java
@@ -50,8 +50,7 @@ public class ImpExUserRightsMultiValueImpl extends ASTWrapperPsiElement implemen
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter() {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter() {
     return ImpExPsiUtil.getHeaderParameter(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsPermissionValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsPermissionValueImpl.java
@@ -50,8 +50,7 @@ public class ImpExUserRightsPermissionValueImpl extends ASTWrapperPsiElement imp
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter() {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter() {
     return ImpExPsiUtil.getHeaderParameter(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsSingleValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsSingleValueImpl.java
@@ -34,8 +34,8 @@ import sap.commerce.toolset.impex.psi.*;
 
 public class ImpExUserRightsSingleValueImpl extends ImpExUserRightsSingleValueMixin implements ImpExUserRightsSingleValue {
 
-  public ImpExUserRightsSingleValueImpl(@NotNull ASTNode node) {
-    super(node);
+  public ImpExUserRightsSingleValueImpl(@NotNull ASTNode astNode) {
+    super(astNode);
   }
 
   public void accept(@NotNull ImpExVisitor visitor) {
@@ -49,8 +49,7 @@ public class ImpExUserRightsSingleValueImpl extends ImpExUserRightsSingleValueMi
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter() {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter() {
     return ImpExPsiUtil.getHeaderParameter(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsValueGroupImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsValueGroupImpl.java
@@ -74,20 +74,17 @@ public class ImpExUserRightsValueGroupImpl extends ASTWrapperPsiElement implemen
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsValueLine getValueLine() {
+  public @Nullable ImpExUserRightsValueLine getValueLine() {
     return ImpExPsiUtil.getValueLine(this);
   }
 
   @Override
-  @Nullable
-  public Integer getColumnNumber() {
+  public @Nullable Integer getColumnNumber() {
     return ImpExPsiUtil.getColumnNumber(this);
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderParameter getHeaderParameter() {
+  public @Nullable ImpExUserRightsHeaderParameter getHeaderParameter() {
     return ImpExPsiUtil.getHeaderParameter(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsValueLineImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExUserRightsValueLineImpl.java
@@ -62,14 +62,12 @@ public class ImpExUserRightsValueLineImpl extends ASTWrapperPsiElement implement
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsValueGroup getValueGroup(int index) {
+  public @Nullable ImpExUserRightsValueGroup getValueGroup(int index) {
     return ImpExPsiUtil.getValueGroup(this, index);
   }
 
   @Override
-  @Nullable
-  public ImpExUserRightsHeaderLine getHeaderLine() {
+  public @Nullable ImpExUserRightsHeaderLine getHeaderLine() {
     return ImpExPsiUtil.getHeaderLine(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueImpl.java
@@ -55,8 +55,7 @@ public class ImpExValueImpl extends ImpExValueMixin implements ImpExValue {
   }
 
   @Override
-  @Nullable
-  public ImpExValueGroup getValueGroup() {
+  public @Nullable ImpExValueGroup getValueGroup() {
     return ImpExPsiUtil.getValueGroup(this);
   }
 

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueLineImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueLineImpl.java
@@ -61,8 +61,7 @@ public class ImpExValueLineImpl extends ImpExValueLineMixin implements ImpExValu
   }
 
   @Override
-  @Nullable
-  public ImpExValueGroup getValueGroup(int columnNumber) {
+  public @Nullable ImpExValueGroup getValueGroup(int columnNumber) {
     return ImpExPsiUtil.getValueGroup(this, columnNumber);
   }
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
@@ -351,7 +351,7 @@ any_header_parameter_name ::= document_id_dec
 {
     recoverWhile = recover_parameter_name
     mixin = "sap.commerce.toolset.impex.psi.impl.ImpExAnyHeaderParameterNameMixin"
-    methods=[getHeaderItemTypeName]
+    methods=[getHeaderItemTypeName isHeaderAbbreviation]
 }
 
 special_parameter ::= SPECIAL_PARAMETER_MARKER special_parameter_value
@@ -387,7 +387,7 @@ parameter ::= (HEADER_PARAMETER_NAME | macro_usage_dec | document_id_usage | FUN
 {
     pin=1
     mixin="sap.commerce.toolset.impex.psi.impl.ImpExParameterMixin"
-    methods=[getReferenceItemTypeName getReferenceName getItemTypeName getInlineTypeName getAttributeName]
+    methods=[getReferenceItemTypeName getReferenceName getItemTypeName getInlineTypeName getAttributeName isHeaderAbbreviation]
 }
 
 sub_parameters ::= LEFT_ROUND_BRACKET (parameter ((COMMA | ALTERNATIVE_PATTERN) parameter)*)? RIGHT_ROUND_BRACKET

--- a/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -240,7 +240,8 @@ class ImpExAnnotator : AbstractAnnotator() {
                 }
             }
 
-            ImpExTypes.HEADER_PARAMETER_NAME -> {
+            ImpExTypes.HEADER_PARAMETER_NAME,
+            ImpExTypes.PARAMETER -> {
                 if (element.parent.reference is ImpExHeaderAbbreviationReference) {
                     highlight(
                         ImpExHighlighterColors.ATTRIBUTE_HEADER_ABBREVIATION,

--- a/modules/impex/core/src/sap/commerce/toolset/impex/lang/documentation/ImpExDocumentationTarget.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/lang/documentation/ImpExDocumentationTarget.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -85,11 +85,13 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
                         "With that, you can export a constant value or can aggregate different attributes.",
                         "Using the following header at an export of an order item, the code of the order is exported as well as the id and name of the user owning the order and its payment address, street name, and country.",
                     )
-                    example("""
+                    example(
+                        """
                         INSERT_UPDATE Order; code[unique=true]; \
                                             @template1[translator=de.hybris.jakarta.ext.impex.jalo.translators.VelocityTranslator, expr='${"$"}item.user.getUID()']; \
                                             @template2[translator=de.hybris.jakarta.ext.impex.jalo.translators.VelocityTranslator, expr='${"$"}item.user.name'];
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                 }.build()
 
                 AttributeModifier.CLASSIFICATION_CLASS.modifierName,
@@ -106,9 +108,11 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
                         "Therefore you have to declare a special attribute for each feature to import.",
                         "Assuming you want to set a value for feature type at your product a suitable header could be as follows:",
                     )
-                    example("""
+                    example(
+                        """
                         UPDATE Product; code[unique=true]; @type[system='SampleClassification',version='1.0',translator=de.hybris.platform.catalog.jalo.classification.impex.ClassificationAttributeTranslator;]
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                     texts("In this example, the modifiers system and version, which are both mandatory, specify the classification system version of the product feature.")
                     texts("One more optional modifier class can be used with this translator.")
                 }.build()
@@ -125,10 +129,12 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
                         "To disable UniqueAttributesValidator, specify a comma-separated item types for which you want to disable it:",
                         "The following impex specifies only one such interceptor:"
                     )
-                    example("""
+                    example(
+                        """
                         INSERT_UPDATE Currency[disable.UniqueAttributesValidator.for.types='Currency'];isocode[unique=true];digits;
                         ;EUR_Test;-2;
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                     texts("If you want to specify more than one ID, put the bean IDs in apostrophes: <'beanID'>.")
                 }.build()
 
@@ -144,10 +150,12 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
                         "To disable specific interceptors, specify a comma-separated bean-IDs list for the disable.interceptor.beans header attribute.",
                         "The following impex specifies only one such interceptor:"
                     )
-                    example("""
+                    example(
+                        """
                         INSERT_UPDATE Currency[disable.interceptor.beans='validateCurrencyDataInterceptor'];isocode[unique=true];digits;
                         ;EUR_Test;-2;
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                 }.build()
 
                 TypeModifier.DISABLE_INTERCEPTOR_TYPES.modifierName -> impexDoc {
@@ -160,10 +168,12 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
                         "disable.interceptor.types (InterceptorExecutionPolicy#DISABLED_INTERCEPTOR_TYPES constant)",
                         "This attribute takes a set of interceptor types (de.hybris.platform.servicelayer.interceptor.impl.InterceptorExecutionPolicy.InterceptorType) that you want to disable."
                     )
-                    example("""
+                    example(
+                        """
                         INSERT_UPDATE Currency[disable.interceptor.types=validate];isocode[unique=true];digits;
                         ;EUR_Test2;-2;
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                 }.build()
 
                 TypeModifier.SLD_ENABLED.modifierName -> impexDoc {
@@ -519,7 +529,8 @@ class ImpExDocumentationTarget(val element: PsiElement, private val originalElem
             }
         }
 
-        ImpExTypes.HEADER_PARAMETER_NAME -> {
+        ImpExTypes.HEADER_PARAMETER_NAME,
+        ImpExTypes.PARAMETER -> {
             element.parent.reference
                 ?.asSafely<ImpExHeaderAbbreviationReference>()
                 ?.let {

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExPsiUtil.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExPsiUtil.kt
@@ -20,12 +20,15 @@
 
 package sap.commerce.toolset.impex.psi
 
+import com.intellij.codeInsight.completion.CompletionUtilCore
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiPolyVariantReference
 import com.intellij.psi.util.*
 import com.intellij.util.asSafely
+import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.impex.ImpExConstants
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
 import sap.commerce.toolset.project.PropertyService
@@ -231,3 +234,20 @@ fun getHeaderParameter(element: ImpExUserRightsValue): ImpExUserRightsHeaderPara
 
     else -> null
 }
+
+fun isHeaderAbbreviation(element: ImpExAnyHeaderParameterName): Boolean = isHeaderAbbreviation(element.project, element.text)
+fun isHeaderAbbreviation(element: ImpExParameter): Boolean = isHeaderAbbreviation(element.project, element.text)
+
+private fun isHeaderAbbreviation(project: Project, text: String): Boolean = PropertyService.getInstance(project)
+    .findAutoCompleteProperties(HybrisConstants.PROPERTY_IMPEX_HEADER_REPLACEMENT)
+    .asSequence()
+    .mapNotNull { it.value }
+    .mapNotNull { abbreviation ->
+        abbreviation
+            .split("...")
+            .takeIf { it.size == 2 }
+            ?.map { it.trim() }
+    }
+    .mapNotNull { it.firstOrNull() }
+    .map { it.replace("\\\\", "\\") }
+    .any { text.removeSuffix(CompletionUtilCore.DUMMY_IDENTIFIER_TRIMMED).matches(it.toRegex()) }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExAnyHeaderParameterNameMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExAnyHeaderParameterNameMixin.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
  * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -18,18 +18,15 @@
  */
 package sap.commerce.toolset.impex.psi.impl
 
-import com.intellij.codeInsight.completion.CompletionUtilCore
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.removeUserData
 import com.intellij.psi.PsiReference
 import com.intellij.psi.util.PsiTreeUtil
-import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.impex.psi.ImpExAnyHeaderParameterName
 import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
 import sap.commerce.toolset.impex.psi.ImpExTypes
 import sap.commerce.toolset.impex.psi.references.*
-import sap.commerce.toolset.project.PropertyService
 import sap.commerce.toolset.psi.shouldCreateNewReference
 import java.io.Serial
 
@@ -58,7 +55,7 @@ abstract class ImpExAnyHeaderParameterNameMixin(astNode: ASTNode) : ASTWrapperPs
         when {
             ImpExTypes.MACRO_USAGE == leafType -> return arrayOf(ImpExMacroReference(this))
 
-            //optimisation: don't even try for macro's and documents
+            // optimization: don't even try for macro's and documents
             ImpExTypes.HEADER_PARAMETER_NAME != leafType
                 && ImpExTypes.FUNCTION != leafType -> return PsiReference.EMPTY_ARRAY
 
@@ -78,20 +75,6 @@ abstract class ImpExAnyHeaderParameterNameMixin(astNode: ASTNode) : ASTWrapperPs
         result.myReference = null
         return result
     }
-
-    private fun isHeaderAbbreviation() = PropertyService.getInstance(project)
-        .findAutoCompleteProperties(HybrisConstants.PROPERTY_IMPEX_HEADER_REPLACEMENT)
-        .asSequence()
-        .mapNotNull { it.value }
-        .mapNotNull { abbreviation ->
-            abbreviation
-                .split("...")
-                .takeIf { it.size == 2 }
-                ?.map { it.trim() }
-        }
-        .mapNotNull { it.firstOrNull() }
-        .map { it.replace("\\\\", "\\") }
-        .any { text.removeSuffix(CompletionUtilCore.DUMMY_IDENTIFIER_TRIMMED).matches(it.toRegex()) }
 
     companion object {
         @Serial

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExParameterMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExParameterMixin.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -30,6 +30,7 @@ import sap.commerce.toolset.impex.psi.ImpExMacroUsageDec
 import sap.commerce.toolset.impex.psi.ImpExParameter
 import sap.commerce.toolset.impex.psi.references.ImpExFunctionTSAttributeReference
 import sap.commerce.toolset.impex.psi.references.ImpExFunctionTSItemReference
+import sap.commerce.toolset.impex.psi.references.ImpExHeaderAbbreviationReference
 import java.io.Serial
 
 abstract class ImpExParameterMixin(astNode: ASTNode) : ASTWrapperPsiElement(astNode), ImpExParameter {
@@ -48,13 +49,9 @@ abstract class ImpExParameterMixin(astNode: ASTNode) : ASTWrapperPsiElement(astN
             if (inlineTypeName != null) {
                 myReferences.add(ImpExFunctionTSItemReference(this))
 
-                if (childrenOfType<ImpExMacroUsageDec>().isEmpty()) {
-                    // attribute can be a Macro item(CMSLinkComponent.$contentCV)
-                    myReferences.add(ImpExFunctionTSAttributeReference(this))
-                }
-            } else {
-                myReferences.add(ImpExFunctionTSAttributeReference(this))
-            }
+                // attribute can be a Macro item(CMSLinkComponent.$contentCV)
+                if (childrenOfType<ImpExMacroUsageDec>().isEmpty()) addReference()
+            } else addReference()
         }
 
         return myReferences.toTypedArray()
@@ -70,6 +67,12 @@ abstract class ImpExParameterMixin(astNode: ASTNode) : ASTWrapperPsiElement(astN
     override fun subtreeChanged() {
         removeUserData(ImpExFunctionTSItemReference.CACHE_KEY)
         removeUserData(ImpExFunctionTSAttributeReference.CACHE_KEY)
+        removeUserData(ImpExHeaderAbbreviationReference.CACHE_KEY)
+    }
+
+    private fun addReference() {
+        if (isHeaderAbbreviation()) myReferences.add(ImpExHeaderAbbreviationReference(this))
+        else myReferences.add(ImpExFunctionTSAttributeReference(this))
     }
 
     companion object {

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExHeaderAbbreviationReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExHeaderAbbreviationReference.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
  * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -28,11 +28,10 @@ import com.intellij.psi.ResolveResult
 import com.intellij.psi.util.*
 import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.impex.lang.refactoring.ImpExPsiElementManipulator
-import sap.commerce.toolset.impex.psi.ImpExAnyHeaderParameterName
 import sap.commerce.toolset.project.PropertyService
 import sap.commerce.toolset.psi.getValidResults
 
-class ImpExHeaderAbbreviationReference(owner: ImpExAnyHeaderParameterName) : PsiReferenceBase.Poly<PsiElement?>(owner, false) {
+class ImpExHeaderAbbreviationReference(owner: PsiElement) : PsiReferenceBase.Poly<PsiElement>(owner, false) {
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> = CachedValuesManager.getManager(element.project)
         .getParameterizedCachedValue(element, CACHE_KEY, provider, false, this)


### PR DESCRIPTION
before
<img width="1210" height="190" alt="Screenshot 2026-03-27 at 10 29 39" src="https://github.com/user-attachments/assets/f9074d26-7047-4a86-b798-89c0c8455ff4" />


after

<img width="1377" height="654" alt="Screenshot 2026-03-27 at 10 58 32" src="https://github.com/user-attachments/assets/349fcbb7-4c33-441a-bec7-732762dc473b" />
