### PR TITLE
ImpEx | Inspection Rules | Inspection: resolve expected macro declarations by abbreviations in the parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 3 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 
 ### `ImpEx` enhancements
 - Do not format value if the declared macro [#1788](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1788)
 - Resolve header abbreviation in the complex param `; categories(code, myAbbreviation);` [#1789](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1789)
+
+### `ImpEx` inspection rules
+- Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)
 
 ## [2026.0.6]
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
@@ -50,8 +50,11 @@ class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
         private val cachedMacros: Set<String>
     ) : ImpExVisitor() {
 
-        override fun visitAnyHeaderParameterName(parameter: ImpExAnyHeaderParameterName) {
-            val reference = parameter.reference.asSafely<ImpExHeaderAbbreviationReference>() ?: return
+        override fun visitParameter(parameter: ImpExParameter) = visit(parameter)
+        override fun visitAnyHeaderParameterName(parameter: ImpExAnyHeaderParameterName) = visit(parameter)
+
+        private fun visit(element: PsiElement) {
+            val reference = element.reference.asSafely<ImpExHeaderAbbreviationReference>() ?: return
 
             val headerAbbreviationValue = reference
                 .resolve()
@@ -73,25 +76,24 @@ class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
             problemsHolder.registerProblemForReference(
                 reference,
                 ProblemHighlightType.WARNING,
-                i18n("hybris.inspections.impex.ImpExIncompleteHeaderAbbreviationUsageInspection.key", parameter.text, missingExpectedMacros.joinToString()),
+                i18n("hybris.inspections.impex.ImpExIncompleteHeaderAbbreviationUsageInspection.key", element.text, missingExpectedMacros.joinToString()),
                 *missingExpectedMacros
-                    .map { LocalFix(parameter, it) }
+                    .map { LocalFix(element, it) }
                     .toTypedArray()
             )
         }
 
         private class LocalFix(
-            parameter: ImpExAnyHeaderParameterName,
+            element: PsiElement,
             private val macroName: String
-        ) : LocalQuickFixOnPsiElement(parameter) {
+        ) : LocalQuickFixOnPsiElement(element) {
 
             override fun getFamilyName() = "[y] Missing macro declarations"
             override fun getText() = "Add macro declaration '$macroName'"
 
             override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
                 val firstLeaf = startElement
-                    .asSafely<ImpExAnyHeaderParameterName>()
-                    ?.parentOfType<ImpExHeaderLine>()
+                    .parentOfType<ImpExHeaderLine>()
                     ?: return
 
                 val snippetFile = ImpExElementFactory.createFile(


### PR DESCRIPTION
before
<img width="1239" height="288" alt="Screenshot 2026-03-27 at 11 10 01" src="https://github.com/user-attachments/assets/c226cd72-e034-4bfd-8967-4df1f2ff6bf7" />


after
<img width="1455" height="305" alt="Screenshot 2026-03-27 at 11 11 26" src="https://github.com/user-attachments/assets/f2a0b6cd-8120-4a15-83a3-40c965c4e962" />

