### PR TITLE
ImpEx | Inspection: respect macro declarations required by abbreviations in the parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 3 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 4 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 
 ### `ImpEx` enhancements
 - Do not format value if the declared macro [#1788](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1788)
@@ -9,6 +9,7 @@
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)
+- Inspection: respect macro declarations required by abbreviations in the parameter [#1791](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1791)
 
 ## [2026.0.6]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-q## Contribution guidelines
+## Contribution guidelines
 
 * Please read [Contributor License Agreement](http://developercertificate.org)
 * Available tasks are in our [project board](https://github.com/epam/sap-commerce-intellij-idea-plugin/projects) 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExIncompleteHeaderAbbreviationUsageInspection.kt
@@ -96,14 +96,14 @@ class ImpExIncompleteHeaderAbbreviationUsageInspection : LocalInspectionTool() {
                     .parentOfType<ImpExHeaderLine>()
                     ?: return
 
-                val snippetFile = ImpExElementFactory.createFile(
+                ImpExElementFactory.createFile(
                     project, """
                     $macroName =  
 
                 """.trimIndent()
                 )
-
-                file.addBefore(snippetFile, firstLeaf)
+                    .children
+                    .forEach { file.addBefore(it, firstLeaf) }
             }
         }
     }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnusedMacroInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnusedMacroInspection.kt
@@ -48,7 +48,7 @@ class ImpExUnusedMacroInspection : LocalInspectionTool() {
     override fun inspectionStarted(session: LocalInspectionToolSession, isOnTheFly: Boolean) {
         expectedMacrosByAbbreviations.clear()
 
-        PsiTreeUtil.findChildrenOfType(session.file, ImpExAnyHeaderParameterName::class.java)
+        PsiTreeUtil.findChildrenOfAnyType(session.file, ImpExAnyHeaderParameterName::class.java, ImpExParameter::class.java)
             .forEach { parameter ->
                 parameter.reference.asSafely<ImpExHeaderAbbreviationReference>()
                     ?.resolve()


### PR DESCRIPTION
before 
<img width="1455" height="305" alt="Screenshot 2026-03-27 at 11 11 26" src="https://github.com/user-attachments/assets/d20d6096-0568-46ae-a9df-d3c564fd37a9" />

after
<img width="1122" height="222" alt="image" src="https://github.com/user-attachments/assets/3d3f2f24-857b-47a3-b7fe-25779e5bfdf8" />