### PR TITLE
ImpEx | Show abbreviations in the completion list for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 6 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 7 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,17 @@
 - Do not format value if the declared macro [#1788](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1788)
 - Resolve header abbreviation in the complex param `; categories(code, myAbbreviation);` [#1789](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1789)
 - Do not create TS reference when `&DocId` reference present [#1794](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1794)
+- Show abbreviations in the completion list for parameters [#1795](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1795)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)
 - Inspection: respect macro declarations required by abbreviations in the parameter [#1791](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1791)
 
-### Other
-- Include only last 10 releases in the shipped changelog [#1793](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1793)
-
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)
+
+### Other
+- Include only last 10 releases in the shipped changelog [#1793](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1793)
 
 ## [2026.0.6]
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/provider/ImpExHeaderItemTypeParameterNameCompletionProvider.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/provider/ImpExHeaderItemTypeParameterNameCompletionProvider.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
  * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -41,9 +41,10 @@ class ImpExHeaderItemTypeParameterNameCompletionProvider : CompletionProvider<Co
         val parameter = psiElementUnderCaret as? ImpExParameter ?: return
         val typeName = parameter.itemTypeName ?: return
 
-        TSCompletionService.getInstance(project)
-            .getCompletions(typeName)
-            .let { result.addAllElements(it) }
+        with(TSCompletionService.getInstance(project)) {
+            result.addAllElements(getHeaderAbbreviationCompletions(project))
+            result.caseInsensitive().addAllElements(getCompletions(typeName))
+        }
     }
 
 }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExParameterMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExParameterMixin.kt
@@ -22,9 +22,10 @@ package sap.commerce.toolset.impex.psi.impl
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.removeUserData
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+import com.intellij.psi.util.PsiModificationTracker
 import com.intellij.psi.util.childrenOfType
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdUsage
 import sap.commerce.toolset.impex.psi.ImpExMacroUsageDec
@@ -32,40 +33,37 @@ import sap.commerce.toolset.impex.psi.ImpExParameter
 import sap.commerce.toolset.impex.psi.references.ImpExFunctionTSAttributeReference
 import sap.commerce.toolset.impex.psi.references.ImpExFunctionTSItemReference
 import sap.commerce.toolset.impex.psi.references.ImpExHeaderAbbreviationReference
+import sap.commerce.toolset.typeSystem.meta.TSModificationTracker
 import java.io.Serial
 
 abstract class ImpExParameterMixin(astNode: ASTNode) : ASTWrapperPsiElement(astNode), ImpExParameter {
 
-    private val myReferences = mutableListOf<PsiReferenceBase<out PsiElement>>()
-    private var previousText: String? = null
-
     override fun getReference() = references.firstOrNull()
 
-    override fun getReferences(): Array<PsiReference> {
-        if (previousText != text) {
-            myReferences.clear()
-        }
-
-        if (childrenOfType<ImpExDocumentIdUsage>().isNotEmpty()) return emptyArray()
-
-        if (myReferences.isEmpty() || previousText == null) {
-            previousText = text
-
+    override fun getReferences(): Array<PsiReference> = CachedValuesManager.getManager(project).getCachedValue(this) {
+        val references = if (childrenOfType<ImpExDocumentIdUsage>().isNotEmpty()) emptyArray()
+        else buildList<PsiReference> {
             if (inlineTypeName != null) {
-                myReferences.add(ImpExFunctionTSItemReference(this))
+                add(ImpExFunctionTSItemReference(this@ImpExParameterMixin))
 
                 // attribute can be a Macro item(CMSLinkComponent.$contentCV)
-                if (childrenOfType<ImpExMacroUsageDec>().isEmpty()) addReference()
-            } else addReference()
+                if (childrenOfType<ImpExMacroUsageDec>().isEmpty()) {
+                    add(getSuitableReference())
+                }
+            } else {
+                add(getSuitableReference())
+            }
         }
+            .toTypedArray()
 
-        return myReferences.toTypedArray()
+        CachedValueProvider.Result.create(
+            references,
+            TSModificationTracker.getInstance(project), PsiModificationTracker.MODIFICATION_COUNT
+        )
     }
 
     override fun clone(): Any {
         val result = super.clone() as ImpExParameterMixin
-        result.previousText = null
-        result.myReferences.clear()
         return result
     }
 
@@ -75,10 +73,8 @@ abstract class ImpExParameterMixin(astNode: ASTNode) : ASTWrapperPsiElement(astN
         removeUserData(ImpExHeaderAbbreviationReference.CACHE_KEY)
     }
 
-    private fun addReference() {
-        if (isHeaderAbbreviation()) myReferences.add(ImpExHeaderAbbreviationReference(this))
-        else myReferences.add(ImpExFunctionTSAttributeReference(this))
-    }
+    private fun getSuitableReference() = if (isHeaderAbbreviation()) ImpExHeaderAbbreviationReference(this)
+    else ImpExFunctionTSAttributeReference(this)
 
     companion object {
         @Serial


### PR DESCRIPTION
before
<img width="913" height="189" alt="Screenshot 2026-03-27 at 14 48 11" src="https://github.com/user-attachments/assets/8fa5dbb8-9917-4269-859b-067b30127f55" />


after
<img width="881" height="359" alt="Screenshot 2026-03-27 at 15 49 22" src="https://github.com/user-attachments/assets/dcfc1ecc-ea42-4bf4-8bb7-48e971a184d7" />
