### PR TITLE
ImpEx | Resolve macro values used in the `default` header attribute and displayed as an inline hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 7 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 8 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements
@@ -9,6 +9,7 @@
 - Resolve header abbreviation in the complex param `; categories(code, myAbbreviation);` [#1789](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1789)
 - Do not create TS reference when `&DocId` reference present [#1794](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1794)
 - Show abbreviations in the completion list for parameters [#1795](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1795)
+- Resolve macro values used in the `default` header attribute and displayed as an inline hint [#1796](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1796)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExLanguageIsNotSupportedInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExLanguageIsNotSupportedInspection.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -22,9 +22,13 @@ import com.intellij.codeHighlighting.HighlightDisplayLevel
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
-import sap.commerce.toolset.impex.psi.*
+import sap.commerce.toolset.impex.psi.ImpExAnyAttributeName
+import sap.commerce.toolset.impex.psi.ImpExAnyAttributeValue
+import sap.commerce.toolset.impex.psi.ImpExMacroUsageDec
+import sap.commerce.toolset.impex.psi.ImpExVisitor
 import sap.commerce.toolset.project.PropertyService
 
 class ImpExLanguageIsNotSupportedInspection : LocalInspectionTool() {
@@ -37,15 +41,10 @@ class ImpExLanguageIsNotSupportedInspection : LocalInspectionTool() {
                 ?.takeIf { AttributeModifier.LANG.modifierName == it.text }
                 ?: return
 
-            val language = if (psi.firstChild is ImpExMacroUsageDec) {
-                PsiTreeUtil.getNextSiblingOfType(psi.firstChild.reference
-                    ?.resolve(), ImpExMacroValueDec::class.java)
-                    ?.text
-                    ?: psi.text
-            } else {
-                psi.text
-            }
-                .trim()
+            val language = psi.firstChild.asSafely<ImpExMacroUsageDec>()
+                ?.resolveValue(HashSet())
+                ?.trim()
+                ?: psi.text
 
             val propertyService = PropertyService.getInstance(psi.project)
             val supportedLanguages = propertyService.getLanguages()

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
@@ -24,9 +24,7 @@ import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.util.*
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
-import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
-import sap.commerce.toolset.impex.psi.ImpExValueGroup
-import sap.commerce.toolset.impex.psi.ImpExValueLine
+import sap.commerce.toolset.impex.psi.*
 import sap.commerce.toolset.impex.utils.ImpExPsiUtils
 import java.io.Serial
 
@@ -69,10 +67,13 @@ abstract class ImpExValueGroupMixin(node: ASTNode) : ASTWrapperPsiElement(node),
             ?: this.fullHeaderParameter
                 ?.getAttribute(AttributeModifier.DEFAULT)
                 ?.anyAttributeValue
-                ?.let {
-                    it.stringList.firstOrNull()
-                        ?.text
+                ?.childLeafs()
+                ?.toList()
+                ?.joinToString("") {
+                    if (it.elementType == ImpExTypes.MACRO_USAGE) it.parentOfType<ImpExMacroUsageDec>()
+                        ?.resolveValue(HashSet())
                         ?: it.text
+                    else it.text
                 }
 
         val defaultValue = computedValue


### PR DESCRIPTION
before
<img width="588" height="166" alt="Screenshot 2026-03-27 at 17 06 40" src="https://github.com/user-attachments/assets/8e918ffb-b144-4d82-98cb-2f08ea3de85d" />

after
<img width="593" height="151" alt="Screenshot 2026-03-27 at 17 07 49" src="https://github.com/user-attachments/assets/c57c7184-2619-418e-9c7e-110013ac0e59" />
