### PR TITLE
ImpEx | Inspection Rules | Local fix: quote value strings for non-unique string columns & localized string columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 9 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 10 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements
@@ -15,6 +15,7 @@
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)
 - Inspection: respect macro declarations required by abbreviations in the parameter [#1791](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1791)
 - Inspection: quote value strings for non-unique string columns & localized string columns [#1797](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1797)
+- Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -20,12 +20,19 @@ package sap.commerce.toolset.impex.codeInspection
 
 import com.intellij.codeHighlighting.HighlightDisplayLevel
 import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.childrenOfType
 import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
+import sap.commerce.toolset.impex.psi.ImpExElementFactory
 import sap.commerce.toolset.impex.psi.ImpExValue
+import sap.commerce.toolset.impex.psi.ImpExValueLine
 import sap.commerce.toolset.impex.psi.ImpExVisitor
 import sap.commerce.toolset.impex.psi.references.ImpExTSAttributeReference
 import sap.commerce.toolset.typeSystem.psi.reference.result.AttributeResolveResult
@@ -62,7 +69,33 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                 value,
                 i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key"),
                 ProblemHighlightType.WEAK_WARNING,
+                LocalFix(value)
             )
+        }
+
+        private class LocalFix(element: PsiElement) : LocalQuickFixOnPsiElement(element) {
+
+            override fun getFamilyName() = "[y] Quote value string"
+            override fun getText() = "Wrap unquoted value string in quotes"
+
+            override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+                val newValue = startElement.text.replace("\"", "\"\"")
+
+                val newElement = ImpExElementFactory.createFile(
+                    project, """
+                        UPDATE Title;name;
+                        ; "$newValue"
+
+                """.trimIndent()
+                )
+                    .childrenOfType<ImpExValueLine>()
+                    .flatMap { it.valueGroupList }
+                    .mapNotNull { it.value }
+                    .lastOrNull()
+                    ?: return
+
+                startElement.replace(newElement)
+            }
         }
     }
 }


### PR DESCRIPTION
<img width="1324" height="177" alt="Screenshot 2026-03-27 at 23 16 04" src="https://github.com/user-attachments/assets/dd54db59-7d4f-4a56-bf1c-e0ea3d955db6" />
