### PR TITLE
ImpEx | Inspection Rules | Local fix: exclude attribute of the specific type from the wrap value string in quotes rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 10 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 11 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements
@@ -16,6 +16,7 @@
 - Inspection: respect macro declarations required by abbreviations in the parameter [#1791](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1791)
 - Inspection: quote value strings for non-unique string columns & localized string columns [#1797](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1797)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
+- Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -19,22 +19,21 @@
 package sap.commerce.toolset.impex.codeInspection
 
 import com.intellij.codeHighlighting.HighlightDisplayLevel
-import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.codeInsight.intention.HighPriorityAction
+import com.intellij.codeInsight.intention.LowPriorityAction
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.codeInspection.*
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.childrenOfType
 import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
-import sap.commerce.toolset.impex.psi.ImpExElementFactory
-import sap.commerce.toolset.impex.psi.ImpExValue
-import sap.commerce.toolset.impex.psi.ImpExValueLine
-import sap.commerce.toolset.impex.psi.ImpExVisitor
+import sap.commerce.toolset.impex.psi.*
 import sap.commerce.toolset.impex.psi.references.ImpExTSAttributeReference
+import sap.commerce.toolset.settings.yDeveloperSettings
 import sap.commerce.toolset.typeSystem.psi.reference.result.AttributeResolveResult
 
 class ImpExQuoteValueStringInspection : LocalInspectionTool() {
@@ -43,17 +42,57 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = Visitor(holder)
 
     class Visitor(private val holder: ProblemsHolder) : ImpExVisitor() {
+
+        override fun visitFullHeaderParameter(headerParameter: ImpExFullHeaderParameter) {
+            val parameterName = headerParameter.anyHeaderParameterName
+            val attributeMeta = parameterName.applicableItemAttribute ?: return
+
+            val typeName = attributeMeta.owner.name ?: return
+            val attributeName = attributeMeta.name
+
+            val hasUnquotedValues = headerParameter.valueGroups
+                .mapNotNull { it.value }
+                .any { it.text.isNotBlank() && !it.text.trim().startsWith("\"") }
+
+            if (hasUnquotedValues) {
+                holder.registerProblem(
+                    parameterName,
+                    i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key", typeName, attributeName),
+                    ProblemHighlightType.WEAK_WARNING,
+                    LocalFixExclude(typeName, attributeName),
+                )
+            }
+        }
+
         override fun visitValue(value: ImpExValue) {
             val trimmedText = value.text.trim()
             if (trimmedText.startsWith('\"')) return
             if (trimmedText.isBlank()) return
 
-            val valueGroup = value.valueGroup ?: return
-
-            valueGroup
-                .fullHeaderParameter
+            val attributeMeta = value.valueGroup
+                ?.fullHeaderParameter
                 ?.anyHeaderParameterName
-                ?.reference
+                ?.applicableItemAttribute
+                ?: return
+
+            val typeName = attributeMeta.owner.name ?: return
+            val attributeName = attributeMeta.name
+
+            val isExcluded = value.project.yDeveloperSettings.impexSettings.quoteStringsExclusions[typeName]
+                ?.contains(attributeName)
+                ?: false
+            if (isExcluded) return
+
+            holder.registerProblem(
+                value,
+                i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key", typeName, attributeName, StringUtil.shortenPathWithEllipsis(trimmedText, 25)),
+                ProblemHighlightType.WEAK_WARNING,
+                LocalFix(value, typeName, attributeName)
+            )
+        }
+
+        private val ImpExAnyHeaderParameterName.applicableItemAttribute
+            get() = reference
                 ?.asSafely<ImpExTSAttributeReference>()
                 ?.multiResolve(false)
                 ?.firstOrNull()
@@ -63,20 +102,16 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     "localized:java.lang.String" == it.type
                         || "java.lang.String" == it.type && !it.modifiers.isUnique
                 }
-                ?: return
 
-            holder.registerProblem(
-                value,
-                i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key"),
-                ProblemHighlightType.WEAK_WARNING,
-                LocalFix(value)
-            )
-        }
-
-        private class LocalFix(element: PsiElement) : LocalQuickFixOnPsiElement(element) {
+        private class LocalFix(
+            element: PsiElement,
+            private val typeName: String,
+            private val attributeName: String,
+            private val shortText: String = StringUtil.shortenPathWithEllipsis(element.text, 25)
+        ) : LocalQuickFixOnPsiElement(element), LowPriorityAction {
 
             override fun getFamilyName() = "[y] Quote value string"
-            override fun getText() = "Wrap unquoted value string in quotes"
+            override fun getText() = "Wrap in quotes '$typeName.$attributeName' value string: '$shortText'"
 
             override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
                 val newValue = startElement.text.replace("\"", "\"\"")
@@ -96,6 +131,26 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
 
                 startElement.replace(newElement)
             }
+        }
+
+        private class LocalFixExclude(
+            private val typeName: String,
+            private val attributeName: String,
+        ) : LocalQuickFix, HighPriorityAction {
+
+            override fun getFamilyName() = "[y] Exclusion: quote value strings"
+            override fun getName() = "Do not quote value strings for: '$typeName.$attributeName'"
+            override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
+
+            override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                project.yDeveloperSettings.impexSettings = project.yDeveloperSettings.impexSettings.mutable()
+                    .apply {
+                        quoteStringsExclusions.getOrPut(typeName) { mutableSetOf() }
+                            .add(attributeName)
+                    }
+                    .immutable()
+            }
+
         }
     }
 }

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -283,7 +283,8 @@ hybris.editor.gutter.ts.interceptor.choose.title=Choose Interceptor
 hybris.editor.gutter.ts.interceptor.tooltip.text=Navigate to [y] Interceptor declaration(s)
 hybris.editor.gutter.ts.interceptor.no.matches=Interceptors are not registered
 
-hybris.inspections.impex.ImpExQuoteValueStringInspection.key=[y] Wrap string in quote for value group
+hybris.inspections.impex.ImpExQuoteValueStringInspection.key=[y] Wrap in quotes ''{0}.{1}'' value string: ''{2}''
+hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key=[y] Do not quote value strings for: ''{0}.{1}''
 hybris.inspections.impex.ImpExUniqueAttributeWithoutIndexInspection.key=[y] Attribute ''{0}'' does not have an index for ''{1}'' type
 hybris.inspections.impex.ImpExUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' is already used for docId ''{1}''
 hybris.inspections.impex.ImpExConfigProcessorInspection.key=[y] Incorrect use of the ''{0}'' macros - not defined ConfigPropertyImportProcessor

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -20,6 +20,8 @@ package sap.commerce.toolset.settings.state
 
 import com.intellij.util.xmlb.annotations.OptionTag
 import com.intellij.util.xmlb.annotations.Tag
+import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.collections.immutable.toImmutableSet
 
 @Tag("ImpexSettings")
 data class ImpExSettingsState(
@@ -27,12 +29,17 @@ data class ImpExSettingsState(
     @JvmField @OptionTag val editMode: ImpExEditModeSettingsState = ImpExEditModeSettingsState(),
     @JvmField @OptionTag val completion: ImpExCompletionSettingsState = ImpExCompletionSettingsState(),
     @JvmField @OptionTag val documentation: ImpExDocumentationSettingsState = ImpExDocumentationSettingsState(),
+    // Type name to > set of attribute names
+    @JvmField @OptionTag val quoteStringsExclusions: Map<String, Set<String>> = mapOf(),
 ) {
     fun mutable() = Mutable(
         groupLocalizedFiles = groupLocalizedFiles,
         editMode = editMode.mutable(),
         completion = completion.mutable(),
         documentation = documentation.mutable(),
+        quoteStringsExclusions = quoteStringsExclusions
+            .mapValues { (_, value) -> value.toMutableSet() }
+            .toMutableMap(),
     )
 
     data class Mutable(
@@ -40,12 +47,16 @@ data class ImpExSettingsState(
         var editMode: ImpExEditModeSettingsState.Mutable,
         var completion: ImpExCompletionSettingsState.Mutable,
         var documentation: ImpExDocumentationSettingsState.Mutable,
+        var quoteStringsExclusions: MutableMap<String, MutableSet<String>>,
     ) {
         fun immutable() = ImpExSettingsState(
             groupLocalizedFiles = groupLocalizedFiles,
             editMode = editMode.immutable(),
             completion = completion.immutable(),
             documentation = documentation.immutable(),
+            quoteStringsExclusions = quoteStringsExclusions
+                .mapValues { (_, value) -> value.toImmutableSet() }
+                .toImmutableMap(),
         )
     }
 }


### PR DESCRIPTION
<img width="635" height="175" alt="Screenshot 2026-03-28 at 18 17 47" src="https://github.com/user-attachments/assets/e462c8bc-e937-4515-a167-73d1530f586b" />
<img width="1321" height="306" alt="Screenshot 2026-03-28 at 18 17 55" src="https://github.com/user-attachments/assets/be16b7fb-f2f2-4131-9620-645d417bb54b" />
