### PR TITLE
ImpEx | Inspection Rules | Local fix: enable value to be quoted for string attribute of the specific type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 12 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 13 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements
@@ -18,6 +18,7 @@
 - Inspection: quote value strings for non-unique string columns & localized string columns [#1797](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1797)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
+- Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -59,11 +59,14 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                 val isExcluded = headerParameter.project.yDeveloperSettings.impexSettings.quoteStringExclusions[typeName]
                     ?.contains(attributeName)
                     ?: false
-                // already excluded
-                // TODO: add one more "fix" to re-enable quotes for value strings
-                if (isExcluded) return
 
-                holder.registerProblem(
+                if (isExcluded) holder.registerProblem(
+                    parameterName,
+                    i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.enable.key", typeName, attributeName),
+                    ProblemHighlightType.INFORMATION,
+                    LocalFixEnable(typeName, attributeName),
+                )
+                else holder.registerProblem(
                     parameterName,
                     i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key", typeName, attributeName),
                     ProblemHighlightType.WEAK_WARNING,
@@ -153,6 +156,22 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
             override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
                 project.yDeveloperSettings.impexSettings = project.yDeveloperSettings.impexSettings.mutable()
                     .apply { quoteStringExclusions.add(ImpExQuoteStringExclusion(typeName, attributeName)) }
+                    .immutable()
+            }
+        }
+
+        private class LocalFixEnable(
+            private val typeName: String,
+            private val attributeName: String,
+        ) : LocalQuickFix, HighPriorityAction {
+
+            override fun getFamilyName() = "[y] Enable quote value strings"
+            override fun getName() = "Enable quoting of value strings for: '$typeName.$attributeName'"
+            override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
+
+            override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+                project.yDeveloperSettings.impexSettings = project.yDeveloperSettings.impexSettings.mutable()
+                    .apply { quoteStringExclusions.removeIf { it.typeName == typeName && it.attributeName == attributeName } }
                     .immutable()
             }
         }

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -285,6 +285,7 @@ hybris.editor.gutter.ts.interceptor.no.matches=Interceptors are not registered
 
 hybris.inspections.impex.ImpExQuoteValueStringInspection.key=[y] Wrap in quotes ''{0}.{1}'' value string: ''{2}''
 hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key=[y] Do not quote value strings for: ''{0}.{1}''
+hybris.inspections.impex.ImpExQuoteValueStringInspection.enable.key=[y] Enable value to be quoted for: ''{0}.{1}''
 hybris.inspections.impex.ImpExUniqueAttributeWithoutIndexInspection.key=[y] Attribute ''{0}'' does not have an index for ''{1}'' type
 hybris.inspections.impex.ImpExUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' is already used for docId ''{1}''
 hybris.inspections.impex.ImpExConfigProcessorInspection.key=[y] Incorrect use of the ''{0}'' macros - not defined ConfigPropertyImportProcessor


### PR DESCRIPTION
<img width="756" height="215" alt="Screenshot 2026-03-29 at 16 09 19" src="https://github.com/user-attachments/assets/aaa11f95-4138-4c03-b92f-1751600615f1" />
