### PR TITLE
ImpEx | Inspection Rules | Local fix: generate `&docId` column based on the unique columns of the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 13 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 14 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 
 ### `ImpEx` enhancements
@@ -19,6 +19,7 @@
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)
+- Local fix: generate `&docId` column based on the unique columns of the table [#1802](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1802)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchInEditorResultsView.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchInEditorResultsView.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -79,7 +79,6 @@ class FlexibleSearchInEditorResultsView(
             PlainTextFileType.INSTANCE,
             content
         )
-
 
         return edtWriteAction {
             val newDisposable = Disposer.newDisposable().apply {

--- a/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
+++ b/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
@@ -207,6 +207,10 @@
         <localInspection groupPath="SAP Commerce" shortName="ImpExQuoteValueStringInspection" displayName="[y] Quote value strings"
                          groupName="[y] ImpEx" level="WEAK WARNING" language="ImpEx" enabledByDefault="true"
                          implementationClass="sap.commerce.toolset.impex.codeInspection.ImpExQuoteValueStringInspection"/>
+
+        <localInspection groupPath="SAP Commerce" shortName="ImpExMissingDocumentIdColumnInspection" displayName="[y] Missing DocId"
+                         groupName="[y] ImpEx" level="INFORMATION" language="ImpEx" enabledByDefault="true"
+                         implementationClass="sap.commerce.toolset.impex.codeInspection.ImpExMissingDocumentIdColumnInspection"/>
     </extensions>
 
 </idea-plugin>

--- a/modules/impex/core/resources/inspectionDescriptions/ImpExMissingDocumentIdColumnInspection.html
+++ b/modules/impex/core/resources/inspectionDescriptions/ImpExMissingDocumentIdColumnInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+  ~ Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html>
+<body>
+Declare DocumentId column based on the defined unique columns for an ImpEx Header.
+</body>
+</html>

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExMissingDocumentIdColumnInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExMissingDocumentIdColumnInspection.kt
@@ -1,0 +1,117 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.impex.codeInspection
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.codeInspection.*
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.prevLeaf
+import com.intellij.psi.util.startOffset
+import com.intellij.util.asSafely
+import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
+import sap.commerce.toolset.impex.psi.ImpExHeaderLine
+import sap.commerce.toolset.impex.psi.ImpExHeaderTypeName
+import sap.commerce.toolset.impex.psi.ImpExTypes
+import sap.commerce.toolset.impex.psi.ImpExVisitor
+
+class ImpExMissingDocumentIdColumnInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.WEAK_WARNING
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val problemsHolder: ProblemsHolder) : ImpExVisitor() {
+
+        override fun visitHeaderTypeName(element: ImpExHeaderTypeName) {
+            val headerLine = element.parentOfType<ImpExHeaderLine>() ?: return
+            val hasDocId = headerLine.fullHeaderParameterList
+                .any { it.anyHeaderParameterName.documentIdDec != null }
+
+            if (hasDocId) return
+
+            val uniqueColumnNumbers = headerLine.fullHeaderParameterList
+                .filter { it.getAttributeValue(AttributeModifier.UNIQUE, "false") == "true" }
+                .map { it.columnNumber }
+                .takeIf { it.isNotEmpty() }
+                ?: return
+
+            val typeName = element.text.trim()
+
+            problemsHolder.registerProblem(
+                element,
+                "Declare documentId for ${typeName}",
+                ProblemHighlightType.INFORMATION,
+                LocalFix(element, uniqueColumnNumbers, typeName)
+            )
+        }
+
+        private class LocalFix(
+            el: ImpExHeaderTypeName,
+            private val uniqueColumnNumbers: List<Int>,
+            private val typeName: String
+        ) : LocalQuickFixOnPsiElement(el) {
+
+            override fun getFamilyName() = "[y] DocId column is not declared "
+            override fun getText() = "Generate &docId column for '$typeName'"
+            override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
+
+            override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+                val typeName = startElement.asSafely<ImpExHeaderTypeName>() ?: return
+                val headerLine = typeName.parentOfType<ImpExHeaderLine>() ?: return
+                val headerInjectPosition = headerLine.fullHeaderParameterList.firstOrNull()
+                    ?.prevLeaf { it.elementType == ImpExTypes.PARAMETERS_SEPARATOR }
+                    ?.startOffset
+                    ?: return
+
+                val tableRange = headerLine.tableRange
+
+                val reversedValueInsertions = headerLine.valueLines
+                    .mapNotNull { valueLine ->
+                        val injectAt = valueLine.valueGroupList.firstOrNull()
+                            ?.startOffset
+                            ?: return@mapNotNull null
+                        val valueDocId = uniqueColumnNumbers
+                            .mapNotNull { valueLine.getValueGroup(it) }
+                            .mapNotNull { it.computeValue() }
+                            .joinToString("-")
+                        val relativeOffset = injectAt - tableRange.startOffset
+                        relativeOffset to ";$valueDocId"
+                    }
+                    .sortedByDescending { it.first }
+
+                val newContent = StringBuilder(file.text.substring(tableRange.startOffset, tableRange.endOffset))
+
+                reversedValueInsertions.forEach { (relativeOffset, insertion) ->
+                    newContent.insert(relativeOffset, insertion)
+                }
+
+                val headerRelativeOffset = headerInjectPosition - tableRange.startOffset
+                newContent.insert(headerRelativeOffset, ";&docId")
+
+                file.fileDocument.replaceString(tableRange.startOffset, tableRange.endOffset, newContent)
+            }
+        }
+    }
+}
+

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ImpExTableColumnInsertLeftAction.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/ImpExTableColumnInsertLeftAction.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -28,5 +28,4 @@ class ImpExTableColumnInsertLeftAction : AbstractImpExTableColumnInsertAction(Im
             icon = HybrisIcons.ImpEx.Actions.INSERT_COLUMN_LEFT
         }
     }
-
 }


### PR DESCRIPTION
<img width="535" height="131" alt="Screenshot 2026-03-30 at 12 54 26" src="https://github.com/user-attachments/assets/dbab2351-57a7-4ae2-b89b-3a3da355aa22" />
