### PR TITLE
ImpEx | Inspection Rules | Local fix: enforce quote value strings via Informative quick-fix on header attribute and individual value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)
 - Local fix: generate `&docId` column based on the unique columns of the table [#1802](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1802)
-- Local fix: enforce quote value strings via Informative quick-fix on header attribute and individual value [#1803](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1803)
+- Local fix: enforce quote value strings via Informative quick-fix on header attribute and individual value [#1817](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1817)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 27 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 28 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -36,6 +36,7 @@
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)
 - Local fix: generate `&docId` column based on the unique columns of the table [#1802](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1802)
+- Local fix: enforce quote value strings via Informative quick-fix on header attribute and individual value [#1803](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1803)
 
 ### `Spring` enhancements
 - Support `classpath*:` prefix in Spring XML imports [#1792](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1792)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -79,8 +79,9 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.forceQuote.key", typeName, attributeName),
                     ProblemHighlightType.INFORMATION,
                     LocalFixQuote(
-                        parameterName,
-                        "Wrap in quotes '$typeName.$attributeName' $unquotedValues value strings"
+                        element = parameterName,
+                        presentationText = "Wrap in quotes $unquotedValues value strings for: '$typeName.$attributeName'",
+                        overridePreviewInfo = IntentionPreviewInfo.EMPTY
                     ),
                 )
             }
@@ -108,8 +109,8 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key", typeName, attributeName, StringUtil.shortenPathWithEllipsis(trimmedText, 25)),
                     type,
                     LocalFixQuote(
-                        value,
-                        "Wrap in quotes '$typeName.$attributeName' value string: '${StringUtil.shortenPathWithEllipsis(value.text, 25)}'"
+                        element = value,
+                        presentationText = "Wrap in quotes '$typeName.$attributeName' value string: '${StringUtil.shortenPathWithEllipsis(value.text, 25)}'"
                     )
                 )
             }
@@ -144,16 +145,19 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
 
         private class LocalFixQuote(
             element: PsiElement,
-            private val presentationText: String
+            private val presentationText: String,
+            private val overridePreviewInfo: IntentionPreviewInfo? = null
         ) : LocalQuickFixOnPsiElement(element), LowPriorityAction {
 
             override fun getFamilyName() = "[y] Quote value string"
             override fun getText() = presentationText
+            override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = overridePreviewInfo
+                ?: super.generatePreview(project, previewDescriptor)
 
             override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
                 when (startElement) {
                     is ImpExValue -> quoteValue(startElement, project)
-                    is ImpExAnyAttributeName -> startElement
+                    is ImpExAnyHeaderParameterName -> startElement
                         .parentOfType<ImpExFullHeaderParameter>()
                         ?.valueGroups
                         ?.mapNotNull { it.value }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -29,6 +29,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.psi.*
@@ -51,11 +52,11 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
             val typeName = attributeMeta.owner.name ?: return
             val attributeName = attributeMeta.name
 
-            val hasUnquotedValues = headerParameter.valueGroups
+            val unquotedValues = headerParameter.valueGroups
                 .mapNotNull { it.value }
-                .any { it.text.isNotBlank() && !it.text.trim().startsWith("\"") }
+                .count { it.text.isNotBlank() && !it.text.trim().startsWith("\"") }
 
-            if (hasUnquotedValues) {
+            if (unquotedValues > 0) {
                 val isExcluded = headerParameter.project.yDeveloperSettings.impexSettings.quoteStringExclusions[typeName]
                     ?.contains(attributeName)
                     ?: false
@@ -71,6 +72,16 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key", typeName, attributeName),
                     ProblemHighlightType.WEAK_WARNING,
                     LocalFixExclude(typeName, attributeName),
+                )
+
+                holder.registerProblem(
+                    parameterName,
+                    i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.forceQuote.key", typeName, attributeName),
+                    ProblemHighlightType.INFORMATION,
+                    LocalFixQuote(
+                        parameterName,
+                        "Wrap in quotes '$typeName.$attributeName' $unquotedValues value strings"
+                    ),
                 )
             }
         }
@@ -91,22 +102,33 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
             val typeName = attributeMeta.owner.name ?: return
             val attributeName = attributeMeta.name
 
+            fun registerFix(type: ProblemHighlightType) {
+                holder.registerProblem(
+                    value,
+                    i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key", typeName, attributeName, StringUtil.shortenPathWithEllipsis(trimmedText, 25)),
+                    type,
+                    LocalFixQuote(
+                        value,
+                        "Wrap in quotes '$typeName.$attributeName' value string: '${StringUtil.shortenPathWithEllipsis(value.text, 25)}'"
+                    )
+                )
+            }
+
             val isExcluded = impExSettings.quoteStringExclusions[typeName]
                 ?.contains(attributeName)
                 ?: false
-            if (isExcluded) return
-
-            if (impExSettings.quoteStringMatching && impExSettings.quoteStringMatchingRegex.matches(trimmedText)) {
-                // ignore whitelisted value
+            if (isExcluded) {
+                registerFix(ProblemHighlightType.INFORMATION)
                 return
             }
 
-            holder.registerProblem(
-                value,
-                i18n("hybris.inspections.impex.ImpExQuoteValueStringInspection.key", typeName, attributeName, StringUtil.shortenPathWithEllipsis(trimmedText, 25)),
-                ProblemHighlightType.WEAK_WARNING,
-                LocalFix(value, typeName, attributeName)
-            )
+            if (impExSettings.quoteStringMatching && impExSettings.quoteStringMatchingRegex.matches(trimmedText)) {
+                // ignore whitelisted value
+                registerFix(ProblemHighlightType.INFORMATION)
+                return
+            }
+
+            registerFix(ProblemHighlightType.WEAK_WARNING)
         }
 
         private val ImpExAnyHeaderParameterName.applicableItemAttribute
@@ -120,18 +142,28 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     "localized:java.lang.String" == it.type || "java.lang.String" == it.type && !it.modifiers.isUnique
                 }
 
-        private class LocalFix(
+        private class LocalFixQuote(
             element: PsiElement,
-            private val typeName: String,
-            private val attributeName: String,
-            private val shortText: String = StringUtil.shortenPathWithEllipsis(element.text, 25)
+            private val presentationText: String
         ) : LocalQuickFixOnPsiElement(element), LowPriorityAction {
 
             override fun getFamilyName() = "[y] Quote value string"
-            override fun getText() = "Wrap in quotes '$typeName.$attributeName' value string: '$shortText'"
+            override fun getText() = presentationText
 
             override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-                val newValue = startElement.text
+                when (startElement) {
+                    is ImpExValue -> quoteValue(startElement, project)
+                    is ImpExAnyAttributeName -> startElement
+                        .parentOfType<ImpExFullHeaderParameter>()
+                        ?.valueGroups
+                        ?.mapNotNull { it.value }
+                        ?.filter { it.text.isNotBlank() && !it.text.trim().startsWith("\"") }
+                        ?.forEach { quoteValue(it, project) }
+                }
+            }
+
+            private fun quoteValue(value: ImpExValue, project: Project) {
+                val newValue = value.text
                     .replace("\"", "\"\"")
                     .replace("\\\n", "")
                     .replace("\\\r", "")
@@ -139,10 +171,10 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
 
                 val newElement = ImpExElementFactory.createFile(
                     project, """
-                        UPDATE Title;name;
-                        ; "$newValue"
-
-                """.trimIndent()
+                                    UPDATE Title;name;
+                                    ; "$newValue"
+            
+                            """.trimIndent()
                 )
                     .childrenOfType<ImpExValueLine>()
                     .flatMap { it.valueGroupList }
@@ -150,7 +182,7 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     .lastOrNull()
                     ?: return
 
-                startElement.replace(newElement)
+                value.replace(newElement)
             }
         }
 

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -286,6 +286,7 @@ hybris.editor.gutter.ts.interceptor.no.matches=Interceptors are not registered
 hybris.inspections.impex.ImpExQuoteValueStringInspection.key=[y] Wrap in quotes ''{0}.{1}'' value string: ''{2}''
 hybris.inspections.impex.ImpExQuoteValueStringInspection.exclude.key=[y] Do not quote value strings for: ''{0}.{1}''
 hybris.inspections.impex.ImpExQuoteValueStringInspection.enable.key=[y] Enable value to be quoted for: ''{0}.{1}''
+hybris.inspections.impex.ImpExQuoteValueStringInspection.forceQuote.key=[y] Quote all value strings for: ''{0}.{1}''
 hybris.inspections.impex.ImpExUniqueAttributeWithoutIndexInspection.key=[y] Attribute ''{0}'' does not have an index for ''{1}'' type
 hybris.inspections.impex.ImpExUniqueDocumentIdInspection.key=[y] Qualifier ''{0}'' is already used for docId ''{1}''
 hybris.inspections.impex.ImpExConfigProcessorInspection.key=[y] Incorrect use of the ''{0}'' macros - not defined ConfigPropertyImportProcessor


### PR DESCRIPTION
<img width="931" height="272" alt="Screenshot 2026-04-01 at 11 26 31" src="https://github.com/user-attachments/assets/2b84b838-ebb5-41d7-ba12-4940ad6ec4dd" />
<img width="452" height="419" alt="Screenshot 2026-04-01 at 11 37 10" src="https://github.com/user-attachments/assets/85dfcc3a-8902-4776-8cdf-758480ff5b1c" />
