### PR TITLE
ImpEx | Allow `$` in the unquoted strings via default RegEx (can be changed via settings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 29 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 30 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -21,6 +21,7 @@
 - Improved lexer to support `$macroUsages` in the single line script body string [#1809](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1809)
 - Improved lexer to support `$macroUsages` & `""` in th multi-line script body string [#1810](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1810)
 - Allow `\` in the unquoted strings via default RegEx (can be changed via settings) [#1811](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1811)
+- Allow `$` in the unquoted strings via default RegEx (can be changed via settings) [#1819](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1819)
 - Added preview for `&docID` generator Wizard [#1812](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1812)
 - Ensure that the whole ImpEx statement (table) will be formatted despite the modified/selected range of the value line [#1815](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1815)
 - Ensure that the whole ImpEx statement (table) will be formatted despite the modified/selected range of the header line [#1816](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1816)

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
@@ -29,7 +29,7 @@ data class ImpExSettingsState(
     @JvmField @OptionTag val documentation: ImpExDocumentationSettingsState = ImpExDocumentationSettingsState(),
     // Type name to > set of attribute names
     @JvmField @OptionTag val quoteStringMatching: Boolean = true,
-    @JvmField @OptionTag val quoteStringMatchingRegex: Regex = Regex("^[a-zA-Z0-9_\\-]+$"),
+    @JvmField @OptionTag val quoteStringMatchingRegex: Regex = Regex("^[a-zA-Z0-9_$\\-]+$"),
     @JvmField @OptionTag val quoteStringExclusions: Map<String, Set<String>> = mapOf(),
 ) {
     fun mutable() = Mutable(


### PR DESCRIPTION
<img width="138" height="97" alt="image" src="https://github.com/user-attachments/assets/aeca507b-67b1-4472-97f7-260e402d5547" />