### PR TITLE
ImpEx | Preserve indentation on moving lines up / down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 30 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 31 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -26,6 +26,7 @@
 - Ensure that the whole ImpEx statement (table) will be formatted despite the modified/selected range of the value line [#1815](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1815)
 - Ensure that the whole ImpEx statement (table) will be formatted despite the modified/selected range of the header line [#1816](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1816)
 - Preserve formatting ranges in case of the local-fixes, they should not reformat the whole ImpEx statement (table) [#1818](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1818)
+- Preserve indentation on moving lines up / down [#1820](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1820)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
+++ b/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
@@ -52,6 +52,7 @@
         <lang.commenter language="ImpEx" implementationClass="sap.commerce.toolset.impex.lang.ImpExCommenter"/>
         <lang.formatter language="ImpEx" implementationClass="sap.commerce.toolset.impex.formatting.ImpExFormattingModelBuilder"/>
         <preFormatProcessor implementation="sap.commerce.toolset.impex.formatting.ImpExPreFormatProcessor"/>
+        <statementUpDownMover implementation="sap.commerce.toolset.impex.codeInsight.editorActions.moveUpDown.ImpExStatementUpDownMover"/>
         <lang.foldingBuilder language="ImpEx" implementationClass="sap.commerce.toolset.impex.lang.folding.ImpExFoldingBuilder"/>
         <lang.foldingBuilder language="ImpEx" implementationClass="sap.commerce.toolset.impex.lang.folding.ImpExFoldingLinesBuilder"/>
         <lang.foldingBuilder language="ImpEx" implementationClass="sap.commerce.toolset.impex.lang.folding.ImpExMacroFoldingBuilder"/>

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/editorActions/moveUpDown/ImpExStatementUpDownMover.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/editorActions/moveUpDown/ImpExStatementUpDownMover.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package sap.commerce.toolset.impex.codeInsight.editorActions.moveUpDown
+
+import com.intellij.codeInsight.editorActions.moveUpDown.StatementUpDownMover
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.PsiFile
+import sap.commerce.toolset.impex.psi.ImpExFile
+
+class ImpExStatementUpDownMover : StatementUpDownMover() {
+
+    override fun checkAvailable(
+        editor: Editor,
+        file: PsiFile,
+        info: MoveInfo,
+        down: Boolean
+    ): Boolean {
+        if (file !is ImpExFile) return false
+
+        info.indentSource = false
+        info.indentTarget = false
+        return true
+    }
+}


### PR DESCRIPTION
Moving logic:

before
<img width="1042" height="99" alt="Screenshot 2026-04-01 at 13 12 22" src="https://github.com/user-attachments/assets/7b8287d2-8eaa-4cca-99b3-4450cb3fd8b2" />


after
<img width="1045" height="135" alt="Screenshot 2026-04-01 at 13 12 31" src="https://github.com/user-attachments/assets/1a217735-c5eb-4063-9337-86688d028aee" />
