### PR TITLE
ImpEx | Inspection Rules | Inspection: improved detection of the unused macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 41 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 42 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -43,6 +43,7 @@
 - Inspection: remove multi-line separator `\` on quoted value strings [#1806](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1806)
 - Inspection: improved no unique value logic [#1804](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1804)
 - Inspection: support localized columns in the no unique value validation [#1805](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1805)
+- Inspection: improved detection of the unsued macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Inspection: remove multi-line separator `\` on quoted value strings [#1806](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1806)
 - Inspection: improved no unique value logic [#1804](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1804)
 - Inspection: support localized columns in the no unique value validation [#1805](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1805)
-- Inspection: improved detection of the unsued macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
+- Inspection: improved detection of the unused macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnusedMacroInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnusedMacroInspection.kt
@@ -25,9 +25,6 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.lang.properties.IProperty
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.search.LocalSearchScope
-import com.intellij.psi.search.SearchScope
-import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.nextLeaf
@@ -72,27 +69,24 @@ class ImpExUnusedMacroInspection : LocalInspectionTool() {
             val macroName = macro.text
             if (expectedMacrosByAbbreviations.contains(macroName)) return
 
-            val macroDeclaration = macro.parentOfType<ImpExMacroDeclaration>()
-                ?: return
+            val hasUsages = PsiTreeUtil.findChildrenOfAnyType(macro.containingFile, ImpExMacroUsageDec::class.java)
+                .any { it.reference?.resolve() == macro }
+
+            if (hasUsages) return
+
+            val macroDeclaration = macro.parentOfType<ImpExMacroDeclaration>() ?: return
             val endElement = macroDeclaration.nextLeaf({ it.elementType == ImpExTypes.CRLF })
-            val file = problemsHolder.file
 
-            val scope: SearchScope = LocalSearchScope(file)
-            val usages = ReferencesSearch.search(macro, scope)
-                .findFirst()
-
-            if (usages == null) {
-                problemsHolder.registerProblem(
-                    macro,
-                    i18n("hybris.inspections.impex.ImpExUnusedMacroInspection.key", macroName),
-                    ProblemHighlightType.WARNING,
-                    ImpExDeleteMacroDeclarationFix(
-                        macroName,
-                        macroDeclaration,
-                        endElement,
-                    )
+            problemsHolder.registerProblem(
+                macro,
+                i18n("hybris.inspections.impex.ImpExUnusedMacroInspection.key", macroName),
+                ProblemHighlightType.WARNING,
+                ImpExDeleteMacroDeclarationFix(
+                    macroName,
+                    macroDeclaration,
+                    endElement,
                 )
-            }
+            )
         }
     }
 }


### PR DESCRIPTION
before
<img width="521" height="228" alt="Screenshot 2026-04-03 at 10 01 23" src="https://github.com/user-attachments/assets/e74135c1-77a3-45c4-a7d8-31761d1c0cc9" />

after
<img width="512" height="221" alt="Screenshot 2026-04-03 at 10 02 37" src="https://github.com/user-attachments/assets/3eb5cbd4-5bcc-4e26-8a31-f593a4e28a14" />
