### PR TITLE
ImpEx | Inspection Rules | Inspection: changed highlighting region & style for `docId` uniqueness inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 43 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 44 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -45,6 +45,7 @@
 - Inspection: improved no unique value logic [#1804](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1804)
 - Inspection: support localized columns in the no unique value validation [#1805](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1805)
 - Inspection: improved detection of the unused macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
+- Inspection: changed highlighting region & style for `docId` uniqueness inspection [#1833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1833)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUniqueDocumentIdInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUniqueDocumentIdInspection.kt
@@ -27,7 +27,6 @@ import com.intellij.psi.util.parentOfType
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdDec
 import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
-import sap.commerce.toolset.impex.psi.ImpExValueGroup
 import sap.commerce.toolset.impex.psi.ImpExVisitor
 
 class ImpExUniqueDocumentIdInspection : LocalInspectionTool() {
@@ -40,16 +39,14 @@ class ImpExUniqueDocumentIdInspection : LocalInspectionTool() {
             val set = HashSet<String>()
 
             impexFullHeaderParameter.valueGroups
+                .mapNotNull { it.value }
                 .forEach {
-                    if (!set.add(it.text)) {
-                        val qualifier = (it as ImpExValueGroup).value
-                            ?.text
-                            ?: it.text
-
+                    val qualifier = it.text
+                    if (!set.add(qualifier)) {
                         holder.registerProblem(
                             it,
                             i18n("hybris.inspections.impex.ImpExUniqueDocumentIdInspection.key", qualifier, parameter.text),
-                            ProblemHighlightType.ERROR
+                            ProblemHighlightType.GENERIC_ERROR
                         )
                     }
                 }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/lang/findUsages/ImpExCustomUsageSearcher.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/lang/findUsages/ImpExCustomUsageSearcher.kt
@@ -35,6 +35,9 @@ import kotlinx.coroutines.launch
 import sap.commerce.toolset.impex.psi.ImpExMacroNameDec
 import sap.commerce.toolset.impex.psi.ImpExMacroUsageDec
 
+/**
+ * Implementation based on the reverse-engineering of the: FindUsagesManager & ShowUsagesAction
+ */
 class ImpExCustomUsageSearcher : CustomUsageSearcher() {
 
     override fun processElementUsages(


### PR DESCRIPTION
before
<img width="701" height="428" alt="Screenshot 2026-04-03 at 15 51 18" src="https://github.com/user-attachments/assets/c32af209-ea63-470b-9c47-774bf0c9d79e" />



after

<img width="733" height="432" alt="Screenshot 2026-04-03 at 15 56 20" src="https://github.com/user-attachments/assets/754dd956-2f1d-473e-b6df-55544aeec878" />
