### PR TITLE
ImpEx | Improved injection of the `Xml` language to quoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Ensure correctness of the code injection into the quoted strings [#1826](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1826)
 - Do not quote `<ignore>` & `<null>` values [#1829](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1829)
 - Enhanced find usages for macro declaration [#1832](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1832)
+- Improved injection of the `Xml` language to quoted strings [#1833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1833)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 44 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 45 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -36,7 +36,7 @@
 - Ensure correctness of the code injection into the quoted strings [#1826](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1826)
 - Do not quote `<ignore>` & `<null>` values [#1829](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1829)
 - Enhanced find usages for macro declaration [#1832](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1832)
-- Improved injection of the `Xml` language to quoted strings [#1833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1833)
+- Improved injection of the `Xml` language to quoted strings [#1834](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1834)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/src/sap/commerce/toolset/codeInsight/injection/XmlToImpExLanguageInjector.kt
+++ b/src/sap/commerce/toolset/codeInsight/injection/XmlToImpExLanguageInjector.kt
@@ -45,7 +45,9 @@ class XmlToImpExLanguageInjector : LanguageInjector {
         if (StringUtil.trim(hostString).replaceFirst("\"", "").isXmlLike()) {
             injectionPlacesRegistrar.addPlace(
                 XMLLanguage.INSTANCE,
-                TextRange.from(QUOTE_SYMBOL_LENGTH, host.textLength - 2), null, null
+                TextRange.from(QUOTE_SYMBOL_LENGTH, host.textLength - 2),
+                "<CDATA>",
+                "</CDATA>"
             )
         }
     }


### PR DESCRIPTION
before:
<img width="868" height="148" alt="Screenshot 2026-04-03 at 23 09 18" src="https://github.com/user-attachments/assets/7295260d-8cb9-4f72-ae6a-d23bc253105b" />

after:
<img width="821" height="96" alt="image" src="https://github.com/user-attachments/assets/495d6f7d-2f09-439a-a7f9-3fcb3aa54b2f" />
