### PR TITLE
ImpEx | Inspection Rules | Inspection: validate various references used in the ImpEx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 45 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 46 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -47,6 +47,7 @@
 - Inspection: support localized columns in the no unique value validation [#1805](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1805)
 - Inspection: improved detection of the unused macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
 - Inspection: changed highlighting region & style for `docId` uniqueness inspection [#1833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1833)
+- Inspection: validate validity of various references used in the ImpEx [#1835](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1835)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
+++ b/modules/impex/core/resources/META-INF/sap.commerce.toolset-impex-core.xml
@@ -214,6 +214,10 @@
         <localInspection groupPath="SAP Commerce" shortName="ImpExMissingDocumentIdColumnInspection" displayName="[y] Missing DocId"
                          groupName="[y] ImpEx" level="INFORMATION" language="ImpEx" enabledByDefault="true"
                          implementationClass="sap.commerce.toolset.impex.codeInspection.ImpExMissingDocumentIdColumnInspection"/>
+
+        <localInspection groupPath="SAP Commerce" shortName="ImpExUnresolvedReferenceInspection" displayName="[y] Unresolved reference"
+                         groupName="[y] ImpEx" level="ERROR" language="ImpEx" enabledByDefault="true"
+                         implementationClass="sap.commerce.toolset.impex.codeInspection.ImpExUnresolvedReferenceInspection"/>
     </extensions>
 
 </idea-plugin>

--- a/modules/impex/core/resources/colorSchemes/ImpExDarcula.xml
+++ b/modules/impex/core/resources/colorSchemes/ImpExDarcula.xml
@@ -105,11 +105,6 @@
             <option name="FOREGROUND" value="FC67E4"/>
         </value>
     </option>
-    <option name="IMPEX_VALUE_SUBTYPE_SAME">
-        <value>
-            <option name="FONT_TYPE" value="2"/>
-        </value>
-    </option>
     <option name="IMPEX_VALUE_REFERENCE">
         <value>
             <option name="FONT_TYPE" value="2"/>

--- a/modules/impex/core/resources/colorSchemes/ImpExDefault.xml
+++ b/modules/impex/core/resources/colorSchemes/ImpExDefault.xml
@@ -192,11 +192,6 @@
             <option name="FOREGROUND" value="006386"/>
         </value>
     </option>
-    <option name="IMPEX_VALUE_SUBTYPE_SAME">
-        <value>
-            <option name="FONT_TYPE" value="2"/>
-        </value>
-    </option>
     <option name="IMPEX_VALUE_REFERENCE">
         <value>
             <option name="FONT_TYPE" value="2"/>

--- a/modules/impex/core/resources/inspectionDescriptions/ImpExUnresolvedReferenceInspection.html
+++ b/modules/impex/core/resources/inspectionDescriptions/ImpExUnresolvedReferenceInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+  ~ Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html lang="en">
+<body>
+Reference is not resolved.
+</body>
+</html>

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnresolvedReferenceInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnresolvedReferenceInspection.kt
@@ -1,0 +1,81 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package sap.commerce.toolset.impex.codeInspection
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReference
+import com.intellij.util.asSafely
+import sap.commerce.toolset.i18n
+import sap.commerce.toolset.impex.psi.ImpExSubTypeName
+import sap.commerce.toolset.impex.psi.ImpExUserRightsAttributeValue
+import sap.commerce.toolset.impex.psi.ImpExUserRightsSingleValue
+import sap.commerce.toolset.impex.psi.ImpExValue
+import sap.commerce.toolset.impex.psi.references.ImpExDocumentIdUsageReference
+import sap.commerce.toolset.impex.psi.references.ImpExValueTSClassifierReference
+import sap.commerce.toolset.impex.psi.references.ImpExValueTSStaticEnumReference
+import sap.commerce.toolset.spring.psi.reference.SpringReference
+
+class ImpExUnresolvedReferenceInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.ERROR
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = ImpExVisitor(holder)
+
+    private class ImpExVisitor(private val problemsHolder: ProblemsHolder) : sap.commerce.toolset.impex.psi.ImpExVisitor() {
+
+        override fun visitUserRightsSingleValue(element: ImpExUserRightsSingleValue) = element.verifyReferences {
+            i18n("hybris.inspections.impex.unresolved.type.key", canonicalText)
+        }
+
+        override fun visitUserRightsAttributeValue(element: ImpExUserRightsAttributeValue) = element.verifyReferences {
+            i18n("hybris.inspections.impex.unresolved.type.key", canonicalText)
+        }
+
+        override fun visitSubTypeName(element: ImpExSubTypeName) = element.verifyReferences {
+            i18n("hybris.inspections.impex.unresolved.subType.key", canonicalText)
+        }
+
+        override fun visitValue(element: ImpExValue) = element.verifyReferences {
+            when (this) {
+                is ImpExValueTSStaticEnumReference -> "hybris.inspections.impex.unresolved.enumValue.key"
+                is ImpExValueTSClassifierReference -> "hybris.inspections.impex.unresolved.composedType.key"
+                is ImpExDocumentIdUsageReference -> "hybris.inspections.impex.unresolved.docUsage.key"
+                is SpringReference -> "hybris.inspections.impex.unresolved.springBean.key"
+                else -> null
+            }
+                ?.let { i18n(it, canonicalText) }
+        }
+
+        private fun PsiElement.verifyReferences(descriptionProvider: PsiReference.() -> String?) = references
+            .filter {
+                it.asSafely<PsiPolyVariantReference>()
+                    ?.multiResolve(false)
+                    ?.isEmpty()
+                    ?: (it.resolve() == null)
+            }
+            .forEach { reference ->
+                val description = descriptionProvider(reference) ?: return@forEach
+                problemsHolder.registerProblem(reference, description, ProblemHighlightType.ERROR)
+            }
+    }
+}

--- a/modules/impex/core/src/sap/commerce/toolset/impex/highlighting/ImpExColorSettingsPage.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/highlighting/ImpExColorSettingsPage.kt
@@ -71,10 +71,9 @@ INSERT_UPDATE SomeType; ${"$"}contentCV[unique = true][map-delimiter = |][datefo
             )
         }
 Subtype ; ; account                ; "Your Account"
-        ; ; <ignore>               ; "Add/Edit Address"
-        ; ; <null>                 ;
-        ; ; key -> vaue | key ->
-vaue                               ; "Address Book"
+<sst>SomeType</sst>        ; ; <ignore>               ; "Add/Edit Address"
+        ; ; <null>                  ;
+        ; ; key -> vaue | key ->vaue ; "Address Book"
         ; ; value1, value2, value3 ; 12345 ; com.domain.Class ; qwe : asd
 
 INSERT Address[impex.legacy.mode = true, batchmode = true]; firstname; owner(Principal.uid | AbstractOrder.code); Hans; admin
@@ -123,6 +122,7 @@ INSERT Employee; uid[unique=true]; @password[translator=de.hybris.platform.impex
         put("vref", ImpExHighlighterColors.VALUE_REFERENCE)
         put("unique", ImpExHighlighterColors.HEADER_UNIQUE_PARAMETER_NAME)
         put("sriptbody", ImpExHighlighterColors.SCRIPT_BODY)
+        put("sst", ImpExHighlighterColors.VALUE_SUBTYPE_SAME)
         this
     }
     private val inheritedPermission = "<permission_inherited>.</permission_inherited>"
@@ -143,7 +143,8 @@ INSERT Employee; uid[unique=true]; @password[translator=de.hybris.platform.impex
         AttributesDescriptor("Mode//Remove", ImpExHighlighterColors.HEADER_MODE_REMOVE),
 
         AttributesDescriptor("Type//Header type", ImpExHighlighterColors.HEADER_TYPE),
-        AttributesDescriptor("Type//Value sub-type", ImpExHighlighterColors.VALUE_SUBTYPE),
+        AttributesDescriptor("Type//Sub-type", ImpExHighlighterColors.VALUE_SUBTYPE),
+        AttributesDescriptor("Type//Same sub-type", ImpExHighlighterColors.VALUE_SUBTYPE_SAME),
 
         AttributesDescriptor("Separators//Field value separator", ImpExHighlighterColors.FIELD_VALUE_SEPARATOR),
         AttributesDescriptor("Separators//List item separator", ImpExHighlighterColors.FIELD_LIST_ITEM_SEPARATOR),

--- a/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
@@ -110,11 +110,7 @@ class ImpExAnnotator : AbstractAnnotator() {
                 val headerParameter = value.headerParameter ?: return
                 if (!tsElementTypes.contains(headerParameter.firstChild.elementType)) return
 
-                highlightReference(
-                    ImpExTypes.HEADER_TYPE, holder, element,
-                    "hybris.inspections.impex.unresolved.type.key",
-                    referenceHolder = element
-                )
+                highlight(ImpExTypes.HEADER_TYPE, holder, element)
             }
 
             ImpExTypes.VALUE -> {
@@ -122,39 +118,10 @@ class ImpExAnnotator : AbstractAnnotator() {
 
                 value.references.forEach { reference ->
                     when (reference) {
-                        is ImpExValueTSStaticEnumReference -> {
-                            val valueElement = reference.getTargetElement()
-                            highlightReference(
-                                ImpExHighlighterColors.VALUE_REFERENCE, holder, valueElement,
-                                "hybris.inspections.impex.unresolved.enumValue.key",
-                                reference = reference
-                            )
-                        }
-
-                        is ImpExValueTSClassifierReference -> {
-                            val valueElement = reference.getTargetElement() ?: return
-                            highlightReference(
-                                ImpExHighlighterColors.VALUE_REFERENCE, holder, valueElement,
-                                "hybris.inspections.impex.unresolved.composedType.key",
-                                reference = reference
-                            )
-                        }
-
-                        is ImpExDocumentIdUsageReference -> {
-                            highlightReference(
-                                ImpExHighlighterColors.VALUE_REFERENCE, holder, value,
-                                "hybris.inspections.impex.unresolved.docUsage.key",
-                                reference = reference
-                            )
-                        }
-
-                        is SpringReference -> {
-                            highlightReference(
-                                ImpExHighlighterColors.VALUE_REFERENCE, holder, value,
-                                "hybris.inspections.impex.unresolved.springBean.key",
-                                reference = reference
-                            )
-                        }
+                        is ImpExValueTSStaticEnumReference,
+                        is ImpExValueTSClassifierReference,
+                        is ImpExDocumentIdUsageReference,
+                        is SpringReference -> holder.highlightReference(reference, ImpExHighlighterColors.VALUE_REFERENCE)
                     }
                 }
             }
@@ -164,11 +131,7 @@ class ImpExAnnotator : AbstractAnnotator() {
                 val headerParameter = value.headerParameter ?: return
                 if (!tsElementTypes.contains(headerParameter.firstChild.elementType)) return
 
-                highlightReference(
-                    ImpExTypes.HEADER_PARAMETER_NAME, holder, element,
-                    "hybris.inspections.impex.unresolved.type.key",
-                    referenceHolder = element
-                )
+                highlight(ImpExTypes.HEADER_PARAMETER_NAME, holder, element)
             }
 
             ImpExTypes.DOT -> {
@@ -183,8 +146,6 @@ class ImpExAnnotator : AbstractAnnotator() {
 
                 if (subType.textMatches(headerType)) {
                     highlight(ImpExHighlighterColors.VALUE_SUBTYPE_SAME, holder, element)
-                } else {
-                    highlightReference(ImpExTypes.VALUE_SUBTYPE, holder, element, "hybris.inspections.impex.unresolved.subType.key")
                 }
             }
 
@@ -195,6 +156,7 @@ class ImpExAnnotator : AbstractAnnotator() {
                     val propertyKey = macroUsageDec.configPropertyKey
                         ?: element.text.replace(ImpExConstants.IMPEX_CONFIG_COMPLETE_PREFIX, "")
 
+                    // TODO: replace this with the correct Lexer and Parse, introduce new TOKEN MACRO_CONFIG_PREFIX
                     highlight(
                         ImpExHighlighterColors.MACRO_CONFIG_KEY,
                         holder,

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExTSSubTypeItemReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExTSSubTypeItemReference.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -77,6 +77,5 @@ class ImpExTSSubTypeItemReference(owner: ImpExSubTypeName) : TSReferenceBase<Imp
             ?.let { TSMetaModelAccess.getInstance(element.project).findMetaItemByName(it) }
             ?.hierarchy
             ?: emptyList()
-
     }
 }

--- a/modules/shared/core/src/sap/commerce/toolset/lang/annotation/AbstractAnnotator.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/lang/annotation/AbstractAnnotator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -151,6 +151,12 @@ abstract class AbstractAnnotator : Annotator {
         fix?.let { builder.withFix(it) }
         builder.create()
     }
+
+    fun AnnotationHolder.highlightReference(reference: PsiReference, textAttributes: TextAttributesKey) = this
+        .newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
+        .range(reference.absoluteRange)
+        .textAttributes(textAttributes)
+        .create()
 
     fun annotation(
         message: String?,


### PR DESCRIPTION
Also, improved ImpEx file render performance a lot thanks to moving highlight logic of the unresolved PsiReferences from ImpEx annotator to dedicated ImpEx Inspection.