### PR TITLE
FlexibleSearch | Inspection: unexpected language marker for non-localized attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 53 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 54 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -61,6 +61,7 @@
 - Inspection: validate various references used in the FlexibleSearch [#1837](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1837)
 - Inspection: db dependent boolean should be omitted [#1841](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1841)
 - Inspection: unsupported language for localized attribute [#1842](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1842)
+- Inspection: unexpected language marker for non-localized attribute [#1843](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1843)
 
 ### `Polyglot Query` inspection rules
 - Inspection: validate various references used in the Polyglot Query [#1838](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1838)

--- a/modules/flexibleSearch/core/resources/META-INF/sap.commerce.toolset-flexibleSearch-core.xml
+++ b/modules/flexibleSearch/core/resources/META-INF/sap.commerce.toolset-flexibleSearch-core.xml
@@ -78,6 +78,10 @@
                          groupName="[y] FlexibleSearch" level="ERROR" language="FlexibleSearch" enabledByDefault="true"
                          implementationClass="sap.commerce.toolset.flexibleSearch.codeInspection.FlexibleSearchUnresolvedReferenceInspection"/>
 
+        <localInspection groupPath="SAP Commerce" shortName="FlexibleSearchUnexpectedLocalizedMarkerInspection" displayName="[y] Localized marker for non-localized attributes"
+                         groupName="[y] FlexibleSearch" level="ERROR" language="FlexibleSearch" enabledByDefault="true"
+                         implementationClass="sap.commerce.toolset.flexibleSearch.codeInspection.FlexibleSearchUnexpectedLocalizedMarkerInspection"/>
+
         <localInspection groupPath="SAP Commerce" shortName="FlexibleSearchNotSupportedLanguageInspection" displayName="[y] Not supported language"
                          groupName="[y] FlexibleSearch" level="ERROR" language="FlexibleSearch" enabledByDefault="true"
                          implementationClass="sap.commerce.toolset.flexibleSearch.codeInspection.FlexibleSearchNotSupportedLanguageInspection"/>

--- a/modules/flexibleSearch/core/resources/inspectionDescriptions/FlexibleSearchUnexpectedLocalizedMarkerInspection.html
+++ b/modules/flexibleSearch/core/resources/inspectionDescriptions/FlexibleSearchUnexpectedLocalizedMarkerInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+  ~ Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html lang="en">
+<body>
+Language marker should not be used for non-localized attributes.
+</body>
+</html>

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/FlexibleSearchUnexpectedLocalizedMarkerInspection.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/FlexibleSearchUnexpectedLocalizedMarkerInspection.kt
@@ -1,0 +1,64 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package sap.commerce.toolset.flexibleSearch.codeInspection
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.util.*
+import com.intellij.util.asSafely
+import sap.commerce.toolset.flexibleSearch.codeInspection.fix.FlexibleSearchDeleteLocalizedMarkerQuickFix
+import sap.commerce.toolset.flexibleSearch.psi.*
+import sap.commerce.toolset.i18n
+import sap.commerce.toolset.typeSystem.psi.reference.result.TSResolveResultUtil
+
+class FlexibleSearchUnexpectedLocalizedMarkerInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.ERROR
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = FlexibleSearchPsiVisitor(holder)
+
+    private class FlexibleSearchPsiVisitor(private val problemsHolder: ProblemsHolder) : FlexibleSearchVisitor() {
+
+        override fun visitColumnLocalizedName(element: FlexibleSearchColumnLocalizedName) {
+            val yColumn = element.parentOfType<FlexibleSearchColumnRefYExpression>()
+                ?.childrenOfType<FlexibleSearchYColumnName>()
+                ?.firstOrNull() ?: return
+            val attributeName = yColumn.text.trim()
+
+            yColumn.reference
+                ?.asSafely<PsiPolyVariantReference>()
+                ?.multiResolve(false)
+                ?.firstOrNull()
+                ?.takeUnless { TSResolveResultUtil.isLocalized(it, attributeName) }
+                ?.let {
+                    val lBracket = element.prevLeaf { it.elementType == FlexibleSearchTypes.LBRACKET } ?: return
+                    val rBracket = element.nextLeaf { it.elementType == FlexibleSearchTypes.RBRACKET } ?: return
+
+                    problemsHolder.registerProblem(
+                        element,
+                        i18n("hybris.inspections.language.unexpected", attributeName),
+                        ProblemHighlightType.ERROR,
+                        FlexibleSearchDeleteLocalizedMarkerQuickFix(lBracket, rBracket, attributeName)
+                    )
+                }
+        }
+    }
+}

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/fix/FlexibleSearchDeleteLocalizedMarkerQuickFix.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/fix/FlexibleSearchDeleteLocalizedMarkerQuickFix.kt
@@ -16,25 +16,19 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package sap.commerce.toolset.codeInspection.fix
+package sap.commerce.toolset.flexibleSearch.codeInspection.fix
 
-import com.intellij.codeInspection.LocalQuickFixOnPsiElement
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import sap.commerce.toolset.codeInspection.fix.DeletePsiElementFix
+import sap.commerce.toolset.i18n
 
-open class DeletePsiElementFix(
-    private val myFamilyName: String,
-    private val myText: String,
+class FlexibleSearchDeleteLocalizedMarkerQuickFix(
     startElement: PsiElement,
-    endElement: PsiElement? = null,
-) : LocalQuickFixOnPsiElement(startElement, endElement ?: startElement) {
-
-    override fun getFamilyName() = myFamilyName
-    override fun getText() = myText
-
-    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
-        if (startElement != endElement) startElement.parent.deleteChildRange(startElement, endElement)
-        else startElement.delete()
-    }
-}
+    endElement: PsiElement,
+    attributeName: String,
+) : DeletePsiElementFix(
+    i18n("hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker"),
+    i18n("hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker.key", attributeName),
+    startElement,
+    endElement
+)

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
@@ -25,19 +25,15 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.TokenType
 import com.intellij.psi.impl.source.tree.LeafPsiElement
-import com.intellij.psi.util.childrenOfType
 import com.intellij.psi.util.elementType
 import sap.commerce.toolset.flexibleSearch.FlexibleSearchConstants
 import sap.commerce.toolset.flexibleSearch.highlighting.FlexibleSearchHighlighterColors
 import sap.commerce.toolset.flexibleSearch.highlighting.FlexibleSearchSyntaxHighlighter
 import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchTypes.*
-import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchYColumnName
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.lang.annotation.AbstractAnnotator
-import sap.commerce.toolset.typeSystem.psi.reference.result.TSResolveResultUtil
 
 class FlexibleSearchAnnotator : AbstractAnnotator() {
 
@@ -98,25 +94,6 @@ class FlexibleSearchAnnotator : AbstractAnnotator() {
             EXCLAMATION_MARK,
             DASH_MARK -> when (element.parent.elementType) {
                 DEFINED_TABLE_NAME -> highlight(FlexibleSearchHighlighterColors.FXS_TABLE_TAIL, holder, element)
-            }
-
-            // TODO: migrate to Inspection Rule
-            COLUMN_LOCALIZED_NAME -> {
-                element.parent.childrenOfType<FlexibleSearchYColumnName>()
-                    .firstOrNull()
-                    ?.let { yColumn ->
-                        val featureName = yColumn.text.trim()
-                        (yColumn.reference as? PsiReferenceBase.Poly<*>)
-                            ?.multiResolve(false)
-                            ?.firstOrNull()
-                            ?.takeIf { !TSResolveResultUtil.isLocalized(it, featureName) }
-                            ?.let {
-                                highlightError(
-                                    holder, element,
-                                    i18n("hybris.inspections.language.unexpected", featureName)
-                                )
-                            }
-                    }
             }
 
             // TODO: migrate to Inspection Rule

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -339,7 +339,9 @@ hybris.inspections.fix.impex.DeleteMacro.key=[y] Delete macro declaration ''{0}'
 hybris.inspections.fix.impex.ConvertToSingleQuoteString=[y] Convert double-quoted string to single-quoted
 hybris.inspections.fix.impex.ConvertToSingleQuoteString.text=[y] Convert double-quoted " string to single-quoted ' string
 hybris.inspections.fix.pgq.DeleteLocalizedMarker=[y] Delete localized marker
-hybris.inspections.fix.pgq.DeleteLocalizedMarker.key=[y] Delete localized marker for ''{0}''
+hybris.inspections.fix.pgq.DeleteLocalizedMarker.key=[y] Delete localized marker for non-localized ''{0}''
+hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker=[y] Delete localized marker
+hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker.key=[y] Delete localized marker for non-localized ''{0}''
 hybris.inspections.fix.fsq.FlexibleSearchChangeBooleanQuickFix=[y] Change boolean expression
 hybris.inspections.fix.fsq.FlexibleSearchChangeBooleanQuickFix.key=[y] Change boolean expression from ''{0}'' to ''{1}''
 


### PR DESCRIPTION
<img width="1405" height="151" alt="Screenshot 2026-04-04 at 20 37 41" src="https://github.com/user-attachments/assets/9e2899d4-ef88-4377-a4d8-35a86dfc34f7" />
