### PR TITLE
FlexibleSearch | Inspection: column separator `:` cannot be used for `non-[y]` columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 54 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 55 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -62,6 +62,7 @@
 - Inspection: db dependent boolean should be omitted [#1841](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1841)
 - Inspection: unsupported language for localized attribute [#1842](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1842)
 - Inspection: unexpected language marker for non-localized attribute [#1843](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1843)
+- Inspection: column separator `:` cannot be used for `non-[y]` columns [#1844](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1844)
 
 ### `Polyglot Query` inspection rules
 - Inspection: validate various references used in the Polyglot Query [#1838](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1838)

--- a/modules/flexibleSearch/core/resources/META-INF/sap.commerce.toolset-flexibleSearch-core.xml
+++ b/modules/flexibleSearch/core/resources/META-INF/sap.commerce.toolset-flexibleSearch-core.xml
@@ -89,6 +89,10 @@
         <localInspection groupPath="SAP Commerce" shortName="FlexibleSearchDbDependentBooleanInspection" displayName="[y] DB dependant boolean expression"
                          groupName="[y] FlexibleSearch" level="WARNING" language="FlexibleSearch" enabledByDefault="true"
                          implementationClass="sap.commerce.toolset.flexibleSearch.codeInspection.FlexibleSearchDbDependentBooleanInspection"/>
+
+        <localInspection groupPath="SAP Commerce" shortName="FlexibleSearchColonSeparatorInNonYColumnInspection" displayName="[y] Colon separator cannot be used for non-[y] columns"
+                         groupName="[y] FlexibleSearch" level="ERROR" language="FlexibleSearch" enabledByDefault="true"
+                         implementationClass="sap.commerce.toolset.flexibleSearch.codeInspection.FlexibleSearchColonSeparatorInNonYColumnInspection"/>
     </extensions>
 
 </idea-plugin>

--- a/modules/flexibleSearch/core/resources/inspectionDescriptions/FlexibleSearchColonSeparatorInNonYColumnInspection.html
+++ b/modules/flexibleSearch/core/resources/inspectionDescriptions/FlexibleSearchColonSeparatorInNonYColumnInspection.html
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+  ~ Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ~ See the GNU Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public License
+  ~ along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<html lang="en">
+<body>
+Colon '':'' separator cannot be used for non-[y] columns
+</body>
+</html>

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/FlexibleSearchColonSeparatorInNonYColumnInspection.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/FlexibleSearchColonSeparatorInNonYColumnInspection.kt
@@ -1,0 +1,59 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package sap.commerce.toolset.flexibleSearch.codeInspection
+
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.firstLeaf
+import com.intellij.psi.util.parentOfType
+import sap.commerce.toolset.flexibleSearch.codeInspection.fix.FlexibleSearchReplaceColumnSeparatorQuickFix
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchColumnSeparator
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchResultColumn
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchTypes
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchVisitor
+
+class FlexibleSearchColonSeparatorInNonYColumnInspection : LocalInspectionTool() {
+
+    override fun getDefaultLevel(): HighlightDisplayLevel = HighlightDisplayLevel.GENERIC_SERVER_ERROR_OR_WARNING
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = FlexibleSearchPsiVisitor(holder)
+
+    private class FlexibleSearchPsiVisitor(private val problemsHolder: ProblemsHolder) : FlexibleSearchVisitor() {
+
+        override fun visitColumnSeparator(element: FlexibleSearchColumnSeparator) {
+            element.parentOfType<FlexibleSearchResultColumn>() ?: return
+
+            if (element.firstLeaf().elementType != FlexibleSearchTypes.COLON) return
+
+            problemsHolder.registerProblem(
+                element,
+                "Test",
+                ProblemHighlightType.GENERIC_ERROR,
+                FlexibleSearchReplaceColumnSeparatorQuickFix(
+                    element = element,
+                    oldValue = ":",
+                    newValue = "."
+                )
+            )
+        }
+    }
+}
+

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/fix/FlexibleSearchReplaceColumnSeparatorQuickFix.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/codeInspection/fix/FlexibleSearchReplaceColumnSeparatorQuickFix.kt
@@ -1,0 +1,45 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.flexibleSearch.codeInspection.fix
+
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchColumnSeparator
+import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchElementFactory
+import sap.commerce.toolset.i18n
+
+class FlexibleSearchReplaceColumnSeparatorQuickFix(
+    element: PsiElement,
+    private val oldValue: String,
+    private val newValue: String
+) : LocalQuickFixOnPsiElement(element) {
+
+    override fun getFamilyName() = i18n("hybris.inspections.fix.fsq.FlexibleSearchReplaceColumnSeparatorQuickFix")
+    override fun getText() = i18n("hybris.inspections.fix.fsq.FlexibleSearchReplaceColumnSeparatorQuickFix", oldValue, newValue)
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        FlexibleSearchElementFactory
+            .createFile(project, "SELECT {i.pk} FROM {Item as i}")
+            .let { PsiTreeUtil.findChildOfType(it, FlexibleSearchColumnSeparator::class.java) }
+            ?.apply { startElement.replace(this) }
+    }
+}

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/lang/annotation/FlexibleSearchAnnotator.kt
@@ -17,18 +17,11 @@
  */
 package sap.commerce.toolset.flexibleSearch.lang.annotation
 
-import com.intellij.codeInsight.intention.impl.BaseIntentionAction
 import com.intellij.lang.annotation.AnnotationHolder
-import com.intellij.lang.annotation.HighlightSeverity
-import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileTypes.SyntaxHighlighter
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.TokenType
-import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.elementType
-import sap.commerce.toolset.flexibleSearch.FlexibleSearchConstants
 import sap.commerce.toolset.flexibleSearch.highlighting.FlexibleSearchHighlighterColors
 import sap.commerce.toolset.flexibleSearch.highlighting.FlexibleSearchSyntaxHighlighter
 import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchTypes.*
@@ -62,32 +55,6 @@ class FlexibleSearchAnnotator : AbstractAnnotator() {
                 Y_COLUMN_NAME -> highlight(Y_COLUMN_NAME, holder, element)
                 DEFINED_TABLE_NAME -> highlight(DEFINED_TABLE_NAME, holder, element)
                 EXT_PARAMETER_NAME -> highlight(EXT_PARAMETER_NAME, holder, element)
-            }
-
-            // TODO: Migrate to Inspection Rule
-            COLON -> if (element.parent.elementType == COLUMN_SEPARATOR
-                && element.parent.parent.elementType == COLUMN_REF_EXPRESSION
-            ) {
-                highlight(
-                    textAttributesKey = null,
-                    holder = holder,
-                    element = element,
-                    highlightSeverity = HighlightSeverity.ERROR,
-                    message = i18n("hybris.inspections.fxs.element.separator.colon.notAllowed"),
-                    fix = object : BaseIntentionAction() {
-
-                        override fun getFamilyName() = "[y] FlexibleSearch"
-                        override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?) = (file?.isWritable ?: false) && canModify(file)
-                        override fun getText() = "Replace with '.'"
-
-                        override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
-                            if (editor == null || file == null) return
-
-                            (element as? LeafPsiElement)
-                                ?.replaceWithText(FlexibleSearchConstants.TABLE_ALIAS_SEPARATOR_DOT)
-                        }
-                    }
-                )
             }
 
             STAR,

--- a/modules/shared/core/resources/i18n/HybrisBundle.properties
+++ b/modules/shared/core/resources/i18n/HybrisBundle.properties
@@ -344,6 +344,8 @@ hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker=[y] Delete locali
 hybris.inspections.fix.fsq.FlexibleSearchDeleteLocalizedMarker.key=[y] Delete localized marker for non-localized ''{0}''
 hybris.inspections.fix.fsq.FlexibleSearchChangeBooleanQuickFix=[y] Change boolean expression
 hybris.inspections.fix.fsq.FlexibleSearchChangeBooleanQuickFix.key=[y] Change boolean expression from ''{0}'' to ''{1}''
+hybris.inspections.fix.fsq.FlexibleSearchReplaceColumnSeparatorQuickFix=[y] Change column separator
+hybris.inspections.fix.fsq.FlexibleSearchReplaceColumnSeparatorQuickFix.key=[y] Change column separator from ''{0}'' to ''{1}''
 
 hybris.inspections.ts.AttributeHandlerMustBeSetForDynamicAttribute.key=[y] Attribute handler must be defined for Dynamic Attribute
 hybris.inspections.ts.AttributeHandlerMustBeSetForDynamicAttribute.details.key=[y] Attribute handler must be defined for Dynamic Attribute ''{0}''
@@ -473,7 +475,6 @@ hybris.inspections.fxs.unresolved.columnAlias.key=[y] Unresolved column alias ''
 hybris.inspections.fxs.element.language.missing=Missing language isocode for localized attribute
 hybris.inspections.language.unexpected=Language element is not expected for non-localized attribute ''{0}''
 hybris.inspections.language.unsupported=Language ''{0}'' is not present in the property `lang.packs` = ''{1}''
-hybris.inspections.fxs.element.separator.colon.notAllowed=Colon '':'' separator cannot be used for non-[y] columns
 
 hybris.inspections.pgq.unresolved.type.key=[y] Unresolved type ''{0}''
 hybris.inspections.pgq.unresolved.attribute.key=[y] Unresolved attribute ''{0}''


### PR DESCRIPTION
<img width="921" height="87" alt="Screenshot 2026-04-04 at 22 01 01" src="https://github.com/user-attachments/assets/15a664f8-bf0a-437d-95f7-63c243e03d0e" />
