### PR TITLE
FlexibleSearch | Improve lexer to treat `order` as identifier and not a keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 ### `Access Control Lists` inspection rules
 - Inspection: validate various references used in the ACL [#1836](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1836)
 
+### `FlexibleSearch` enhancements
+- Improve lexer to treat `order` as identifier and not a keyword [#1845](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1845)
+
 ### `FlexibleSearch` inspection rules
 - Inspection: validate various references used in the FlexibleSearch [#1837](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1837)
 - Inspection: db dependent boolean should be omitted [#1841](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1841)

--- a/modules/flexibleSearch/core/gen/sap/commerce/toolset/flexibleSearch/_FlexibleSearchLexer.java
+++ b/modules/flexibleSearch/core/gen/sap/commerce/toolset/flexibleSearch/_FlexibleSearchLexer.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -1467,7 +1467,8 @@ public class _FlexibleSearchLexer implements FlexLexer {
           // fall through
           case 164: break;
           case 75:
-            { return ORDER;
+            { if (!braces.isEmpty() && braces.getFirst()) return IDENTIFIER;
+                                        return ORDER;
             }
           // fall through
           case 165: break;

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/flexibleSearch.flex
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/flexibleSearch.flex
@@ -142,7 +142,10 @@ LINE_COMMENT=--[^\r\n]*
   "NUMBERED_PARAMETER"               { return NUMBERED_PARAMETER; }
   "LIMIT"                            { return LIMIT; }
   "OFFSET"                           { return OFFSET; }
-  "ORDER"                            { return ORDER; }
+  "ORDER"                            {
+                                        if (!braces.isEmpty() && braces.getFirst()) return IDENTIFIER;
+                                        return ORDER;
+                                     }
   "BY"                               { return BY; }
   "ALL"                              { return ALL; }
   "GROUP"                            { return GROUP; }


### PR DESCRIPTION
before
<img width="367" height="75" alt="Screenshot 2026-04-04 at 22 10 11" src="https://github.com/user-attachments/assets/e9c3c2eb-4c05-400a-add0-2c426d7365ec" />


after
<img width="297" height="51" alt="Screenshot 2026-04-04 at 22 11 35" src="https://github.com/user-attachments/assets/24857cbe-35a2-4d59-bdeb-1a0e6ab248ae" />
