### PR TITLE
ImpEx | Inspection Rules | Inspection: do not enforce index for parameters as macro or abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 56 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 57 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -49,6 +49,7 @@
 - Inspection: improved detection of the unused macros [#1831](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1831)
 - Inspection: changed highlighting region & style for `docId` uniqueness inspection [#1833](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1833)
 - Inspection: validate various references used in the ImpEx [#1835](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1835)
+- Inspection: do not enforce index for parameters as macro or abbreviation [#1847](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1847)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUniqueAttributeWithoutIndexInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUniqueAttributeWithoutIndexInspection.kt
@@ -27,6 +27,7 @@ import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
 import sap.commerce.toolset.impex.psi.ImpExHeaderLine
 import sap.commerce.toolset.impex.psi.ImpExVisitor
+import sap.commerce.toolset.impex.psi.references.ImpExHeaderAbbreviationReference
 import sap.commerce.toolset.typeSystem.TSConstants
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
 
@@ -39,7 +40,11 @@ class ImpExUniqueAttributeWithoutIndexInspection : LocalInspectionTool() {
             val attribute = param.anyHeaderParameterName.text
 
             // no need to validate special parameters
-            if (attribute.startsWith('@') || TSConstants.Attribute.PK.equals(attribute, true)) return
+            if (attribute.startsWith('@')
+                || TSConstants.Attribute.PK.equals(attribute, true)
+                || param.anyHeaderParameterName.reference is ImpExHeaderAbbreviationReference
+                || param.anyHeaderParameterName.macroUsageDecList.isNotEmpty()
+                ) return
 
             param.modifiersList
                 .flatMap { it.attributeList }


### PR DESCRIPTION
before
<img width="611" height="194" alt="Screenshot 2026-04-05 at 00 09 56" src="https://github.com/user-attachments/assets/dc081d5c-c321-4072-8c70-a1cfbe0eefbd" />


after
<img width="306" height="73" alt="Screenshot 2026-04-05 at 00 11 34" src="https://github.com/user-attachments/assets/a76b6d67-41a8-465d-8214-864991e10345" />
