### PR TITLE
ImpEx | Support `$config-` macro usages in the quoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Enhanced find usages for macro declaration [#1832](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1832)
 - Improved injection of the `Xml` language to quoted strings [#1834](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1834)
 - Improved handling of the nested parameters in the header line [#1846](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1846)
+- Support `$config-` macro usages in the quoted strings [#1849](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1849)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/ImpExLexer.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/ImpExLexer.java
@@ -1851,7 +1851,7 @@ class ImpExLexer implements FlexLexer {
           case 168: break;
           case 61:
             { var macroName = yytext().toString().trim();
-                                                                return macroDeclarations.contains(macroName)
+                                                                return macroDeclarations.contains(macroName) || macroName.startsWith("$config-")
                                                                     ? ImpExTypes.MACRO_USAGE
                                                                     : ImpExTypes.STRING_LITERAL;
             }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.flex
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.flex
@@ -214,7 +214,7 @@ end_userrights                    = [$]END_USERRIGHTS
 
     {macro_usage}                                           {
                                                                 var macroName = yytext().toString().trim();
-                                                                return macroDeclarations.contains(macroName)
+                                                                return macroDeclarations.contains(macroName) || macroName.startsWith("$config-")
                                                                     ? ImpExTypes.MACRO_USAGE
                                                                     : ImpExTypes.STRING_LITERAL;
                                                             }
@@ -306,7 +306,7 @@ end_userrights                    = [$]END_USERRIGHTS
     {double_quote}                                          { yybegin(SCRIPT_BODY); return ImpExTypes.DOUBLE_QUOTE_CLOSE; }
     {macro_usage}                                           {
                                                                 var macroName = yytext().toString().trim();
-                                                                return macroDeclarations.contains(macroName)
+                                                                return macroDeclarations.contains(macroName) || macroName.startsWith("$config-")
                                                                     ? ImpExTypes.MACRO_USAGE
                                                                     : ImpExTypes.STRING_LITERAL;
                                                             }
@@ -337,7 +337,7 @@ end_userrights                    = [$]END_USERRIGHTS
 
     {macro_usage}                                           {
                                                                 var macroName = yytext().toString().trim();
-                                                                return macroDeclarations.contains(macroName)
+                                                                return macroDeclarations.contains(macroName) || macroName.startsWith("$config-")
                                                                     ? ImpExTypes.MACRO_USAGE
                                                                     : ImpExTypes.STRING_LITERAL;
                                                             }


### PR DESCRIPTION
before
<img width="711" height="425" alt="Screenshot 2026-04-05 at 15 49 02" src="https://github.com/user-attachments/assets/c5306b99-7f4f-4f45-94de-aee8ad7a6674" />


after
<img width="828" height="393" alt="Screenshot 2026-04-05 at 15 52 45" src="https://github.com/user-attachments/assets/88682486-70fd-45a0-96d3-d6b5489559b0" />
