### PR TITLE
ImpEx | Improved code completion for top-level elements, such as `Header Modes` & `User Rights`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 64 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 65 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -43,6 +43,7 @@
 - Expand complex attribute values and resolve expanded parameter modifiers [#1851](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1851)
 - Ensure that `&docId` usages respect `ONE` cardinality on an `Item.attribute` [#1852](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1852)
 - Improved code completion for macro usages across ImpEx element [#1855](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1855)
+- Improved code completion for top-level elements, such as `Header Modes` & `User Rights` [#1856](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1856)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/ImpExCompletionContributor.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/ImpExCompletionContributor.kt
@@ -98,6 +98,7 @@ class ImpExCompletionContributor : CompletionContributor() {
                 .andNot(PlatformPatterns.psiElement().withParent(PlatformPatterns.psiElement().withElementType(ImpExTypes.PARAMETER))),
             ImpExHeaderItemTypeAttributeNameCompletionProvider()
         )
+
         // case: item's attribute
         extend(
             CompletionType.BASIC,
@@ -107,18 +108,23 @@ class ImpExCompletionContributor : CompletionContributor() {
                 .and(PlatformPatterns.psiElement().withElementType(ImpExTypes.HEADER_PARAMETER_NAME)),
             ImpExHeaderItemTypeParameterNameCompletionProvider()
         )
-        // case: impex keywords
+
+        // case: impex header mode keywords
         extend(
             CompletionType.BASIC,
-            topLevel(),
+            PlatformPatterns.psiElement()
+                .withLanguage(ImpExLanguage)
+                .withElementType(ImpExTypes.VALUE_SUBTYPE),
             ImpExKeywordModeCompletionProvider()
         )
 
-        // case: macros keywords
+        // case: user rights keywords
         extend(
             CompletionType.BASIC,
-            topLevel(),
-            ImpExKeywordMacroCompletionProvider()
+            PlatformPatterns.psiElement()
+                .withLanguage(ImpExLanguage)
+                .withElementType(ImpExTypes.VALUE_SUBTYPE),
+            ImpExUserRightsCompletionProvider()
         )
 
         // case: impex macros
@@ -153,24 +159,4 @@ class ImpExCompletionContributor : CompletionContributor() {
             ImpExMacrosConfigCompletionProvider()
         )
     }
-
-    private fun topLevel() = PlatformPatterns.psiElement()
-        .withLanguage(ImpExLanguage)
-        .andNot(
-            PlatformPatterns.psiElement() // FIXME bad code, but working
-                .andOr(
-                    PlatformPatterns.psiElement(ImpExTypes.HEADER_TYPE),
-                    PlatformPatterns.psiElement(ImpExTypes.MACRO_NAME_DECLARATION),
-                    PlatformPatterns.psiElement(ImpExTypes.ROOT_MACRO_USAGE),
-                    PlatformPatterns.psiElement(ImpExTypes.MACRO_DECLARATION),
-                    PlatformPatterns.psiElement(ImpExTypes.ASSIGN_VALUE),
-                    PlatformPatterns.psiElement(ImpExTypes.MACRO_VALUE),
-                    PlatformPatterns.psiElement(ImpExTypes.ATTRIBUTE),
-                    PlatformPatterns.psiElement(ImpExTypes.HEADER_TYPE_NAME),
-                    PlatformPatterns.psiElement(ImpExTypes.HEADER_PARAMETER_NAME),
-                    PlatformPatterns.psiElement(ImpExTypes.ATTRIBUTE_NAME),
-                    PlatformPatterns.psiElement(ImpExTypes.FIELD_VALUE),
-                    PlatformPatterns.psiElement(ImpExTypes.ATTRIBUTE_VALUE)
-                )
-        )
 }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/provider/ImpExUserRightsCompletionProvider.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/completion/provider/ImpExUserRightsCompletionProvider.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -24,10 +24,9 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.util.ProcessingContext
 import sap.commerce.toolset.impex.codeInsight.lookup.ImpExLookupElementFactory
 
-class ImpExKeywordMacroCompletionProvider : CompletionProvider<CompletionParameters>() {
+class ImpExUserRightsCompletionProvider : CompletionProvider<CompletionParameters>() {
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         result.addElement(ImpExLookupElementFactory.buildUserRights())
     }
-
 }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/lookup/ImpExLookupElementFactory.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/lookup/ImpExLookupElementFactory.kt
@@ -37,7 +37,10 @@ object ImpExLookupElementFactory {
 
     private const val PRIORITY_2_0 = 2.0
     private const val PRIORITY_1_0 = 1.0
+    private const val PRIORITY_0_2 = 0.2
+    private const val PRIORITY_0_1 = 0.1
     private const val MACRO_USAGE_GROUP = 1
+    private const val HEADER_MODE_GROUP = 2
 
     fun build(element: PsiElement, modifier: TypeModifier, completionSettings: ImpExCompletionSettingsState) = build(
         element,
@@ -72,15 +75,18 @@ object ImpExLookupElementFactory {
     )
         .withPresentableText("\$START_USERRIGHTS")
         .withIcon(HybrisIcons.ImpEx.USER_RIGHTS)
+        .let { PrioritizedLookupElement.withPriority(it, PRIORITY_0_1) }
+        .let { PrioritizedLookupElement.withGrouping(it, HEADER_MODE_GROUP) }
 
     fun buildMacro(lookupElement: String) = LookupElementBuilder.create(lookupElement)
         .withIcon(HybrisIcons.ImpEx.MACRO_USAGE)
+        .withTypeText("macro", true)
         .let { PrioritizedLookupElement.withPriority(it, PRIORITY_1_0) }
         .let { PrioritizedLookupElement.withGrouping(it, MACRO_USAGE_GROUP) }
 
     fun buildMacroConfig() = LookupElementBuilder.create($$"$config-")
         .withIcon(HybrisIcons.ImpEx.MACRO_CONFIG)
-        .withTailText(" config property access", true)
+        .withTypeText("config property access", true)
         .withInsertHandler(AutoPopupInsertHandler.INSTANCE)
         .let { PrioritizedLookupElement.withPriority(it, PRIORITY_2_0) }
         .let { PrioritizedLookupElement.withGrouping(it, MACRO_USAGE_GROUP) }
@@ -89,6 +95,8 @@ object ImpExLookupElementFactory {
         .withPresentableText(mode)
         .withIcon(HybrisIcons.ImpEx.MODE)
         .withInsertHandler(AutoPopupInsertHandler.INSTANCE)
+        .let { PrioritizedLookupElement.withPriority(it, PRIORITY_0_2) }
+        .let { PrioritizedLookupElement.withGrouping(it, HEADER_MODE_GROUP) }
 
     private fun build(element: PsiElement, modifierName: String, completionSettings: ImpExCompletionSettingsState) =
         if (completionSettings.addEqualsAfterModifier && !hasAssignValueLeaf(element))


### PR DESCRIPTION
before:
<img width="977" height="210" alt="Screenshot 2026-04-06 at 18 43 13" src="https://github.com/user-attachments/assets/310d0c63-521a-4752-a445-baf955043179" />


after:
<img width="423" height="218" alt="Screenshot 2026-04-06 at 18 45 14" src="https://github.com/user-attachments/assets/eecc4a93-64e5-4e8e-bec6-6fe7eea7acf0" />
<img width="947" height="149" alt="Screenshot 2026-04-06 at 18 45 20" src="https://github.com/user-attachments/assets/d4fb5aeb-7fbd-4cb0-8f01-a3a1270d9338" />
<img width="371" height="250" alt="Screenshot 2026-04-06 at 18 45 26" src="https://github.com/user-attachments/assets/ae8ceadb-5659-44da-8e52-acdba742c385" />
<img width="478" height="324" alt="Screenshot 2026-04-06 at 18 51 20" src="https://github.com/user-attachments/assets/adc5c4a1-a0fd-4ec4-a3f1-2c9fc5c3ca1f" />
