### PR TITLE
ImpEx | Support `&docId` and Type System references in the value of the `default` modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 68 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 69 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -47,6 +47,7 @@
 - Improved code completion for header modifiers [#1857](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1857)
 - Enhanced Language lexer & parser to support macro usages in the `'` escaped modifier value [#1858](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1858)
 - Introduced column-based folding for ImpEx statements [#1859](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1859)
+- Support `&docId` and Type System references in the value of the `default` modifier [#1860](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1860)
 
 ### `ImpEx` inspection rules
 - Inspection: resolve expected macro declarations by abbreviations in the parameter [#1790](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1790)

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameter.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameter.java
@@ -26,6 +26,8 @@ package sap.commerce.toolset.impex.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import kotlin.jvm.functions.Function0;
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier;
 
 public interface ImpExFullHeaderParameter extends PsiElement {
@@ -50,5 +52,13 @@ public interface ImpExFullHeaderParameter extends PsiElement {
   @NotNull List<@NotNull ImpExValueGroup> getValueGroups();
 
   boolean isUnique();
+
+  @Nullable ImpExFullHeaderParameterTSContext getTypeSystemContext();
+
+  @Nullable
+  @NotNull PsiReference @Nullable [] collectDocIdReferences(@NotNull PsiElement targetElement, @NotNull ImpExFullHeaderParameterTSContext tsContext);
+
+  @Nullable
+  @NotNull PsiReference @Nullable [] collectTSReferences(@NotNull PsiElement targetElement, @NotNull ImpExFullHeaderParameterTSContext tsContext, @NotNull Function0<@NotNull PsiElement @NotNull []> valuesProvider);
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterImpl.java
@@ -31,6 +31,8 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import static sap.commerce.toolset.impex.psi.ImpExTypes.*;
 import sap.commerce.toolset.impex.psi.*;
+import com.intellij.psi.PsiReference;
+import kotlin.jvm.functions.Function0;
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier;
 
 public class ImpExFullHeaderParameterImpl extends ImpExFullHeaderParameterMixin implements ImpExFullHeaderParameter {

--- a/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
@@ -383,7 +383,7 @@ full_header_parameter ::= any_header_parameter_name parameters? modifiers* param
     pin=1
     recoverWhile=not_line_break_or_parameters_separator
     mixin="sap.commerce.toolset.impex.psi.impl.ImpExFullHeaderParameterMixin"
-    methods=[getHeaderLine getColumnNumber getAttribute getAttributeValue getValueGroups isUnique]
+    methods=[getHeaderLine getColumnNumber getAttribute getAttributeValue getValueGroups isUnique getTypeSystemContext collectDocIdReferences collectTSReferences]
 }
 
 any_header_parameter_name ::= document_id_dec

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExQuoteValueStringInspection.kt
@@ -101,7 +101,7 @@ class ImpExQuoteValueStringInspection : LocalInspectionTool() {
                     presentationText = "Quote ${whitelistedValues.size} eligible value strings for: '$typeName.$attributeName'"
                 )
 
-                registerInfoQuickFix(
+                if (whitelistedValues.size != unquotedValues.size) registerInfoQuickFix(
                     checkValuePattern = false,
                     presentationText = "Quote all ${unquotedValues.size} value strings for: '$typeName.$attributeName'"
                 )

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnresolvedReferenceInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExUnresolvedReferenceInspection.kt
@@ -48,6 +48,16 @@ class ImpExUnresolvedReferenceInspection : LocalInspectionTool() {
             i18n("hybris.inspections.impex.unresolved.subType.key", canonicalText)
         }
 
+        override fun visitAnyAttributeValue(element: ImpExAnyAttributeValue) = problemsHolder.verifyReferences(element) {
+            when (this) {
+                is ImpExValueTSStaticEnumReference -> "hybris.inspections.impex.unresolved.enumValue.key"
+                is ImpExValueTSClassifierReference -> "hybris.inspections.impex.unresolved.composedType.key"
+                is ImpExDocumentIdUsageReference -> "hybris.inspections.impex.unresolved.docUsage.key"
+                else -> null
+            }
+                ?.let { i18n(it, canonicalText) }
+        }
+
         override fun visitValue(element: ImpExValue) = problemsHolder.verifyReferences(element) {
             when (this) {
                 is ImpExValueTSStaticEnumReference -> "hybris.inspections.impex.unresolved.enumValue.key"

--- a/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/lang/annotation/ImpExAnnotator.kt
@@ -126,6 +126,16 @@ class ImpExAnnotator : AbstractAnnotator() {
                 }
             }
 
+            ImpExTypes.ATTRIBUTE_VALUE -> {
+                element.parent.references.forEach { reference ->
+                    when (reference) {
+                        is ImpExValueTSStaticEnumReference,
+                        is ImpExValueTSClassifierReference,
+                        is ImpExDocumentIdUsageReference -> holder.highlightReference(reference, ImpExHighlighterColors.VALUE_REFERENCE)
+                    }
+                }
+            }
+
             ImpExTypes.USER_RIGHTS_ATTRIBUTE_VALUE -> {
                 val value = element as? ImpExUserRightsValue ?: return
                 val headerParameter = value.headerParameter ?: return

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameterTSContext.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExFullHeaderParameterTSContext.kt
@@ -16,25 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package sap.commerce.toolset.impex
+package sap.commerce.toolset.impex.psi
 
-import com.intellij.psi.tree.IFileElementType
+import com.intellij.util.xml.DomElement
+import sap.commerce.toolset.typeSystem.meta.model.TSMetaClassifier
 
-object ImpExConstants {
-    const val IMPEX = "ImpEx"
-    const val MACRO_MARKER = "$"
-    const val MACRO_CONFIG_MARKER = $$"$config"
-    const val MACRO_CONFIG_COMPLETE_MARKER = "$MACRO_CONFIG_MARKER-"
-    const val DOC_ID_MARKER = "&"
-    const val INVERTED_COMMA = '\''
-
-    val FILE_NODE_TYPE = IFileElementType(ImpExLanguage)
-
-    object Folding {
-        const val GROUP_PREFIX = "impex.columns"
-        const val VALUE_PREFIX = "; <"
-        const val VALUE_POSTFIX = ">"
-        const val HEADER_PREFIX = " <"
-        const val HEADER_POSTFIX = ">"
-    }
-}
+data class ImpExFullHeaderParameterTSContext(
+    val meta: TSMetaClassifier<out DomElement>,
+    val attributeType: String
+)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExAttributeValueMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExAttributeValueMixin.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -22,18 +22,23 @@ import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.removeUserData
 import com.intellij.psi.PsiReference
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
 import com.intellij.psi.util.parentOfType
 import sap.commerce.toolset.HybrisConstants
+import sap.commerce.toolset.impex.ImpExConstants
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier.*
 import sap.commerce.toolset.impex.constants.modifier.InterceptorProvider
 import sap.commerce.toolset.impex.constants.modifier.TypeModifier
 import sap.commerce.toolset.impex.psi.ImpExAnyAttributeValue
 import sap.commerce.toolset.impex.psi.ImpExAttribute
+import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
 import sap.commerce.toolset.impex.psi.references.ImpExJavaClassReference
 import sap.commerce.toolset.impex.psi.references.ImpExJavaEnumValueReference
 import sap.commerce.toolset.impex.psi.references.ImpExTSItemReference
 import sap.commerce.toolset.project.psi.reference.LanguageReference
+import sap.commerce.toolset.typeSystem.meta.TSModificationTracker
 import java.io.Serial
 import javax.lang.model.SourceVersion
 
@@ -43,79 +48,78 @@ abstract class ImpExAttributeValueMixin(astNode: ASTNode) : ASTWrapperPsiElement
     // see https://help.sap.com/docs/SAP_COMMERCE_CLOUD_PUBLIC_CLOUD/aa417173fe4a4ba5a473c93eb730a417/9ce1b60e12714a7dba6ea7e66b4f7acd.html?locale=en-US#disable-interceptors-via-impex
     private val disableInterceptorExclusionRegex = "[,'\"]".toRegex()
 
-    private var myReference: PsiReference? = null
-
-    override fun getReferences(): Array<PsiReference> = myReference
-        ?.takeIf { it.rangeInElement.length == node.textLength }
-        ?.let { arrayOf(it) }
-        ?: computeReference()
-
     override fun getReference() = references.firstOrNull()
-
-    private fun computeReference() = if (parentOfType<ImpExFullHeaderTypeImpl>(false) != null) {
-        computeTypeModifierReference()
-    } else {
-        computeAttributeModifierReference()
+    override fun getReferences(): Array<PsiReference> = CachedValuesManager.getManager(project).getCachedValue(this) {
+        CachedValueProvider.Result.create(
+            collectReferences(),
+            TSModificationTracker.getInstance(project), this
+        )
     }
-        ?.also { myReference = it }
-        ?.let { arrayOf(it) }
-        ?: PsiReference.EMPTY_ARRAY
 
-    private fun computeTypeModifierReference(): PsiReference? {
+    private fun collectReferences() = if (parentOfType<ImpExFullHeaderTypeImpl>(false) != null) {
+        computeTypeModifierReferences()
+    } else {
+        computeAttributeModifierReferences()
+    }
+
+    private fun computeTypeModifierReferences(): Array<PsiReference> {
         val modifierName = (parent as? ImpExAttribute)
             ?.anyAttributeName
             ?.text
             ?.let { TypeModifier.getModifier(it) }
-            ?: return null
+            ?: return emptyArray()
 
         return when (modifierName) {
             TypeModifier.PROCESSOR -> if (SourceVersion.isName(text)) {
                 ImpExJavaClassReference(this)
             } else null
 
-            TypeModifier.DISABLE_INTERCEPTOR_TYPES -> if (node.text.contains(disableInterceptorExclusionRegex)) return null
+            TypeModifier.DISABLE_INTERCEPTOR_TYPES -> if (node.text.contains(disableInterceptorExclusionRegex)) null
             else ImpExJavaEnumValueReference(this, HybrisConstants.CLASS_FQN_INTERCEPTOR_TYPE)
 
-            TypeModifier.DISABLE_INTERCEPTOR_BEANS -> if (node.text.contains(disableInterceptorExclusionRegex)) return null
+            TypeModifier.DISABLE_INTERCEPTOR_BEANS -> if (node.text.contains(disableInterceptorExclusionRegex)) null
             else InterceptorProvider.EP.extensionList
                 .map { it.reference(this, node.text) }
                 .firstOrNull()
 
-            TypeModifier.DISABLE_UNIQUE_ATTRIBUTES_VALIDATOR_FOR_TYPES -> if (node.text.contains(disableInterceptorExclusionRegex)) return null
+            TypeModifier.DISABLE_UNIQUE_ATTRIBUTES_VALIDATOR_FOR_TYPES -> if (node.text.contains(disableInterceptorExclusionRegex)) null
             else ImpExTSItemReference(this)
 
             else -> null
         }
+            ?.let { arrayOf(it) }
+            ?: emptyArray()
     }
 
-    private fun computeAttributeModifierReference(): PsiReference? {
+    private fun computeAttributeModifierReferences(): Array<PsiReference> {
         val modifierName = (parent as? ImpExAttribute)
             ?.anyAttributeName
             ?.text
             ?.let { AttributeModifier.getModifier(it) }
-            ?: return null
+            ?: return emptyArray()
 
         return when (modifierName) {
             TRANSLATOR,
             CELL_DECORATOR -> if (SourceVersion.isName(text)) {
-                ImpExJavaClassReference(this)
+                arrayOf(ImpExJavaClassReference(this))
             } else null
 
-            LANG -> LanguageReference(this)
+            LANG -> arrayOf(LanguageReference(this))
+            DEFAULT -> this.parentOfType<ImpExFullHeaderParameter>()
+                ?.takeUnless { this.text.contains(ImpExConstants.INVERTED_COMMA) }
+                ?.let {
+                    val tsContext = it.typeSystemContext ?: return@let null
+                    it.collectDocIdReferences(this, tsContext)
+                        ?: it.collectTSReferences(this, tsContext) { arrayOf(this) }
+                }
+
             else -> null
         }
+            ?: emptyArray()
     }
 
     override fun subtreeChanged() {
         removeUserData(ImpExTSItemReference.CACHE_KEY)
-
-        myReference = null
-    }
-
-    override fun clone(): Any {
-        val result = super.clone() as ImpExAttributeValueMixin
-        result.myReference = null
-        return result
     }
 
     companion object {

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
@@ -21,10 +21,23 @@ package sap.commerce.toolset.impex.psi.impl
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
 import com.intellij.psi.util.*
+import com.intellij.util.asSafely
+import com.intellij.util.xml.DomElement
+import sap.commerce.toolset.impex.ImpExConstants
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
 import sap.commerce.toolset.impex.psi.*
+import sap.commerce.toolset.impex.psi.references.*
 import sap.commerce.toolset.impex.utils.ImpExPsiUtils
+import sap.commerce.toolset.typeSystem.TSConstants
+import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
+import sap.commerce.toolset.typeSystem.meta.model.*
+import sap.commerce.toolset.typeSystem.model.Cardinality
+import sap.commerce.toolset.typeSystem.psi.reference.result.AttributeResolveResult
+import sap.commerce.toolset.typeSystem.psi.reference.result.RelationEndResolveResult
 import java.io.Serial
 
 abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiElement(node), ImpExFullHeaderParameter {
@@ -37,6 +50,25 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
             this
         )
     }, false)
+
+    override fun getTypeSystemContext(): ImpExFullHeaderParameterTSContext? {
+        val meta: TSMetaClassifier<out DomElement> = resolveTSAttribute()
+            .let {
+                when (it) {
+                    is AttributeResolveResult -> it.meta
+                    is RelationEndResolveResult -> it.meta
+                    else -> return null
+                }
+            }
+
+        val attributeType = when (meta) {
+            is TSGlobalMetaItem.TSGlobalMetaItemAttribute -> meta.type
+            is TSMetaRelation.TSMetaRelationElement -> meta.type
+            else -> null
+        } ?: return null
+
+        return ImpExFullHeaderParameterTSContext(meta, attributeType)
+    }
 
     override fun getValueGroups(): List<ImpExValueGroup> = CachedValuesManager.getManager(project).getCachedValue(this, CACHE_KEY_VALUE_GROUPS, {
         val valueGroups = this
@@ -70,6 +102,73 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
             else it.text
         }
         ?: defaultValue
+
+    override fun collectDocIdReferences(
+        targetElement: PsiElement,
+        tsContext: ImpExFullHeaderParameterTSContext,
+    ): Array<PsiReference>? {
+        val cardinality = when (tsContext.meta) {
+            is TSMetaRelation.TSMetaRelationElement -> tsContext.meta.cardinality
+            is TSGlobalMetaItem.TSGlobalMetaItemAttribute -> when (TSMetaModelAccess.getInstance(project).findMetaClassifierByName(tsContext.attributeType)) {
+                is TSGlobalMetaCollection -> Cardinality.MANY
+                else -> Cardinality.ONE
+            }
+
+            else -> Cardinality.ONE
+        }
+
+        // ensure that column has single parameter as a &DocumentID
+        this.parametersList
+            .firstOrNull()
+            ?.parameterList
+            ?.takeIf { it.size == 1 }
+            ?.firstOrNull()
+            ?.childrenOfType<ImpExDocumentIdUsage>()
+            ?.firstOrNull()
+            ?: return null
+
+        if (cardinality == Cardinality.ONE) {
+            return TextRange(0, targetElement.textLength)
+                .takeUnless { it.isMacro(targetElement.text) }
+                ?.let { ImpExDocumentIdUsageReference.create(this, targetElement, it) }
+                ?.let { arrayOf(it) }
+        }
+
+        /**
+         * INSERT_UPDATE ListAddToCartAction; uid[unique = true]  ; &actionRef
+         *                                  ; ListAddToCartAction ; ListAddToCartAction
+         *                                  ; Action_2            ; Action_2
+         *                                  ; Action_3            ; Action_3
+         *
+         * INSERT_UPDATE SearchResultsGridComponent; actions(&actionRef)[collection-delimiter = |]
+         *                                         ; Action_2 | Action_3 | ListAddToCartAction | Wrong
+         *
+         * Injection -> SearchResultsGridComponent : actions
+         */
+        return collectRanges(targetElement, AttributeModifier.COLLECTION_DELIMITER, ",")
+            .filterNot { it.isMacro(targetElement.text) }
+            .map { ImpExDocumentIdUsageReference.create(this, targetElement, it) }
+            .toTypedArray()
+    }
+
+    override fun collectTSReferences(
+        targetElement: PsiElement,
+        tsContext: ImpExFullHeaderParameterTSContext,
+        valuesProvider: () -> Array<PsiElement>
+    ): Array<PsiReference>? {
+        val metaModelAccess = TSMetaModelAccess.getInstance(project)
+        return metaModelAccess.findMetaClassifierByName(tsContext.attributeType)
+            ?.let {
+                when (it) {
+                    is TSGlobalMetaAtomic -> collectTSReferencesForMetaAtomic(targetElement, tsContext.attributeType)
+                    is TSGlobalMetaEnum -> collectTSReferencesForMetaEnum( targetElement, it, tsContext.attributeType, valuesProvider)
+                    is TSGlobalMetaItem -> collectTSReferencesForMetaItem(targetElement, tsContext.meta, tsContext.attributeType)
+                    is TSGlobalMetaCollection -> collectTSReferencesForMetaCollection(targetElement, it, metaModelAccess)
+                    else -> null
+                }
+                    ?.toTypedArray()
+            }
+    }
 
     // In contrast to the "getAttribute" function, this function will expand any macros, create new temporary file and recreate FullHeaderParameter
     // due that, it will NOT BE PART of the original PsiTree and MUST NOT be accesses outside of this internal logic.
@@ -106,6 +205,160 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
                 this@ImpExFullHeaderParameterMixin
             )
         }, false)
+
+    private fun resolveTSAttribute() = this
+        .anyHeaderParameterName
+        .reference
+        ?.asSafely<ImpExTSAttributeReference>()
+        ?.multiResolve(false)
+        ?.firstOrNull()
+
+    private fun collectRanges(targetElement: PsiElement, modifier: AttributeModifier, defaultDelimiter: String): List<TextRange> {
+        val delimiter = getAttributeValue(modifier, defaultDelimiter)
+
+        return buildList {
+            var previousStart = 0
+
+            targetElement.text.split(delimiter).forEachIndexed { _, part ->
+                val partTrimmed = part.trim()
+                val trimStart = part.trimStart()
+                val startWhitespaces = part.length - trimStart.length
+
+                val start = startWhitespaces + previousStart
+                val end = start + partTrimmed.length
+
+                previousStart += part.length + delimiter.length
+
+                add(TextRange.create(start, end))
+            }
+        }
+    }
+
+    private fun collectTSReferencesForMetaItem(
+        targetElement: PsiElement,
+        meta: TSMetaClassifier<out DomElement>,
+        attributeType: String
+    ): List<PsiReference>? {
+        val parameters = this.parametersList
+            .firstOrNull()
+            ?.parameterList
+            ?: return null
+
+        if (TSConstants.Type.COMPOSED_TYPE == attributeType) {
+            return parameters
+                .takeIf { it.size == 1 }
+                ?.firstOrNull()
+                ?.takeIf { TSConstants.Attribute.CODE == it.text }
+                ?.let { _ ->
+                    if (meta is TSMetaRelation.TSMetaRelationElement && meta.cardinality == Cardinality.MANY) {
+                        /**
+                         * UPDATE CatalogVersionSyncJob; rootTypes(code)
+                         *                             ; CMSItem, CMSRelation, Media, MediaContainer
+                         */
+                        collectRanges(targetElement, AttributeModifier.COLLECTION_DELIMITER, ",")
+                            .map { ImpExValueTSClassifierReference(targetElement, it) }
+                    } else {
+                        /**
+                         * UPDATE BundleTemplateStatus[batchmode = true]; itemtype(code)[unique = true]
+                         *                                              ; Address
+                         *
+                         * To be injected into -> Address
+                         */
+                        listOf(ImpExValueTSClassifierReference(targetElement, TextRange.create(0, textLength)))
+                    }
+                }
+        }
+
+        /**
+         * INSERT AttributeConstraint; descriptor(enclosingType(code), qualifier)
+         *                           ; ConsumedDestination:url
+         *
+         * To be injected into -> ConsumedDestination
+         */
+
+        val ranges = collectRanges(targetElement, AttributeModifier.PATH_DELIMITER, ":")
+        return parameters
+            .mapIndexedNotNull { index, parameter ->
+                parameter.reference.asSafely<ImpExFunctionTSAttributeReference>()
+                    ?.multiResolve(false)
+                    ?.firstOrNull()
+                    ?.let { resolveResult ->
+                        when (resolveResult) {
+                            is AttributeResolveResult -> resolveResult.meta.type
+                            is RelationEndResolveResult -> resolveResult.meta.type
+                            else -> null
+                        }
+                    }
+                    ?.takeIf { TSConstants.Type.COMPOSED_TYPE == it }
+                    ?.let { ranges.getOrNull(index) }
+                    ?.let { ImpExValueTSClassifierReference(targetElement, it) }
+            }
+    }
+
+    private fun collectTSReferencesForMetaAtomic(targetElement: PsiElement, attributeType: String): List<PsiReference>? {
+        if (TSConstants.Type.JAVA_CLASS != attributeType) return null
+
+        return if (text.startsWith(ImpExConstants.MACRO_MARKER)) null
+        else listOf(ImpExJavaClassReference(targetElement))
+    }
+
+    private fun collectTSReferencesForMetaEnum(
+        targetElement: PsiElement,
+        attributeMeta: TSGlobalMetaEnum,
+        attributeType: String,
+        valuesProvider: () -> Array<PsiElement>
+    ): List<PsiReference>? {
+        val ranges = collectRanges(targetElement, AttributeModifier.PATH_DELIMITER, ":")
+
+        return this.parametersList
+            .firstOrNull()
+            ?.parameterList
+            ?.mapIndexedNotNull { index, parameter ->
+                parameter.reference.asSafely<ImpExFunctionTSAttributeReference>()
+                    ?.multiResolve(false)
+                    ?.firstOrNull()
+                    ?.asSafely<AttributeResolveResult>()
+                    ?.meta
+                    ?.let {
+                        val range = ranges.getOrNull(index)
+                            ?.takeUnless { range -> range.isMacro(targetElement.text) }
+                            ?: return@let null
+
+                        when {
+                            it.name == TSConstants.Attribute.CODE -> if (attributeMeta.isDynamic) ImpExValueTSDynamicEnumReference(targetElement, attributeType, range)
+                            else ImpExValueTSStaticEnumReference(targetElement, attributeType, range)
+
+                            it.type == TSConstants.Type.COMPOSED_TYPE -> ImpExValueTSClassifierReference(targetElement, range)
+                            else -> null
+                        }
+                    }
+            }
+            ?.take(valuesProvider().size)
+    }
+
+    private fun collectTSReferencesForMetaCollection(
+        targetElement: PsiElement,
+        attributeMeta: TSGlobalMetaCollection,
+        metaModelAccess: TSMetaModelAccess
+    ): List<PsiReference>? {
+        return metaModelAccess.findMetaClassifierByName(attributeMeta.elementType)
+            ?.let { targetMeta ->
+                when {
+                    targetMeta is TSGlobalMetaItem && targetMeta.name == TSConstants.Type.COMPOSED_TYPE -> collectRanges(
+                        targetElement,
+                        AttributeModifier.COLLECTION_DELIMITER,
+                        ","
+                    )
+                        .filterNot { range -> range.isMacro(targetElement.text) }
+                        .map { ImpExValueTSClassifierReference(targetElement, it) }
+
+                    else -> null
+                }
+            }
+    }
+
+    private fun TextRange.isMacro(text: String): Boolean = substring(text)
+        .startsWith(ImpExConstants.MACRO_MARKER)
 
     companion object {
         val CACHE_KEY_COLUMN_NUMBER = Key.create<CachedValue<Int>>("SAP_CX_IMPEX_COLUMN_NUMBER")

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueMixin.kt
@@ -20,7 +20,6 @@ package sap.commerce.toolset.impex.psi.impl
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.util.text.StringUtilRt
 import com.intellij.psi.LiteralTextEscaper
 import com.intellij.psi.PsiElement
@@ -28,23 +27,13 @@ import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.PsiReference
 import com.intellij.psi.util.*
 import com.intellij.util.asSafely
-import com.intellij.util.xml.DomElement
-import sap.commerce.toolset.impex.ImpExConstants
-import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
-import sap.commerce.toolset.impex.psi.ImpExDocumentIdUsage
-import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
+import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameterTSContext
 import sap.commerce.toolset.impex.psi.ImpExTypes
 import sap.commerce.toolset.impex.psi.ImpExValue
-import sap.commerce.toolset.impex.psi.references.*
 import sap.commerce.toolset.spring.SpringFallbackScope
 import sap.commerce.toolset.spring.psi.reference.SpringReference
-import sap.commerce.toolset.typeSystem.TSConstants
-import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
 import sap.commerce.toolset.typeSystem.meta.TSModificationTracker
-import sap.commerce.toolset.typeSystem.meta.model.*
-import sap.commerce.toolset.typeSystem.model.Cardinality
-import sap.commerce.toolset.typeSystem.psi.reference.result.AttributeResolveResult
-import sap.commerce.toolset.typeSystem.psi.reference.result.RelationEndResolveResult
+import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaItem
 import java.io.Serial
 
 abstract class ImpExValueMixin(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost, ImpExValue {
@@ -83,31 +72,17 @@ abstract class ImpExValueMixin(node: ASTNode) : ASTWrapperPsiElement(node), PsiL
     private fun collectReferences(): Array<PsiReference> {
         val fullHeaderParameter = valueGroup?.fullHeaderParameter
             ?: return emptyArray()
-
-        val meta: TSMetaClassifier<out DomElement> = getAttribute(fullHeaderParameter)
-            .let {
-                when (it) {
-                    is AttributeResolveResult -> it.meta
-                    is RelationEndResolveResult -> it.meta
-                    else -> null
-                }
-            }
+        val tsContext = fullHeaderParameter.typeSystemContext
             ?: return emptyArray()
 
-        val attributeType = when (meta) {
-            is TSGlobalMetaItem.TSGlobalMetaItemAttribute -> meta.type
-            is TSMetaRelation.TSMetaRelationElement -> meta.type
-            else -> null
-        } ?: return emptyArray()
-
-        val metaModelAccess = TSMetaModelAccess.getInstance(project)
-        return collectDocIdValuesReferences(fullHeaderParameter, meta, attributeType, metaModelAccess)
-            ?: collectTSReferences(fullHeaderParameter, meta, attributeType, metaModelAccess)
-            ?: collectSpringReferences(meta)
+        return fullHeaderParameter.collectDocIdReferences(this, tsContext)
+            ?: fullHeaderParameter.collectTSReferences(this, tsContext) { getFieldValues() }
+            ?: collectSpringReferences(tsContext)
             ?: emptyArray()
     }
 
-    private fun collectSpringReferences(meta: TSMetaClassifier<out DomElement>): Array<PsiReference>? = meta.asSafely<TSGlobalMetaItem.TSGlobalMetaItemAttribute>()
+    private fun collectSpringReferences(tsContext: ImpExFullHeaderParameterTSContext): Array<PsiReference>? = tsContext.meta
+        .asSafely<TSGlobalMetaItem.TSGlobalMetaItemAttribute>()
         ?.takeIf { this.macroUsageDecList.isEmpty() }
         ?.takeIf { this.isImportable }
         ?.takeIf { attr ->
@@ -117,224 +92,7 @@ abstract class ImpExValueMixin(node: ASTNode) : ASTWrapperPsiElement(node), PsiL
         }
         ?.let { arrayOf(SpringReference(this, StringUtilRt.unquoteString(this.text), SpringFallbackScope.CUSTOM_MODULES)) }
 
-    private fun collectDocIdValuesReferences(
-        fullHeaderParameter: ImpExFullHeaderParameter,
-        meta: TSMetaClassifier<out DomElement>,
-        attributeType: String,
-        metaModelAccess: TSMetaModelAccess,
-    ): Array<PsiReference>? {
-        val cardinality = when (meta) {
-            is TSMetaRelation.TSMetaRelationElement -> meta.cardinality
-            is TSGlobalMetaItem.TSGlobalMetaItemAttribute -> when (metaModelAccess.findMetaClassifierByName(attributeType)) {
-                is TSGlobalMetaCollection -> Cardinality.MANY
-                else -> Cardinality.ONE
-            }
-
-            else -> Cardinality.ONE
-        }
-
-        // ensure that column has single parameter as a &DocumentID
-        fullHeaderParameter
-            .parametersList
-            .firstOrNull()
-            ?.parameterList
-            ?.takeIf { it.size == 1 }
-            ?.firstOrNull()
-            ?.childrenOfType<ImpExDocumentIdUsage>()
-            ?.firstOrNull()
-            ?: return null
-
-        if (cardinality == Cardinality.ONE) {
-            return TextRange(0, textLength)
-                .takeUnless { it.isMacro(text) }
-                ?.let { ImpExDocumentIdUsageReference(this, it) }
-                ?.let { arrayOf(it) }
-        }
-
-        /**
-         * INSERT_UPDATE ListAddToCartAction; uid[unique = true]  ; &actionRef
-         *                                  ; ListAddToCartAction ; ListAddToCartAction
-         *                                  ; Action_2            ; Action_2
-         *                                  ; Action_3            ; Action_3
-         *
-         * INSERT_UPDATE SearchResultsGridComponent; actions(&actionRef)[collection-delimiter = |]
-         *                                         ; Action_2 | Action_3 | ListAddToCartAction | Wrong
-         *
-         * Injection -> SearchResultsGridComponent : actions
-         */
-
-        return collectRanges(fullHeaderParameter, AttributeModifier.COLLECTION_DELIMITER, ",")
-            .filterNot { it.isMacro(text) }
-            .map { ImpExDocumentIdUsageReference(this, it) }
-            .toTypedArray()
-    }
-
-    private fun collectTSReferences(
-        fullHeaderParameter: ImpExFullHeaderParameter,
-        meta: TSMetaClassifier<out DomElement>,
-        attributeType: String,
-        metaModelAccess: TSMetaModelAccess
-    ) = metaModelAccess.findMetaClassifierByName(attributeType)
-        ?.let {
-            when (it) {
-                is TSGlobalMetaAtomic -> collectTSReferencesForMetaAtomic(attributeType)
-                is TSGlobalMetaEnum -> collectTSReferencesForMetaEnum(fullHeaderParameter, it, attributeType)
-                is TSGlobalMetaItem -> collectTSReferencesForMetaItem(fullHeaderParameter, meta, attributeType)
-                is TSGlobalMetaCollection -> collectTSReferencesForMetaCollection(fullHeaderParameter, it, metaModelAccess)
-                else -> null
-            }
-                ?.toTypedArray()
-        }
-
-    private fun collectTSReferencesForMetaItem(fullHeaderParameter: ImpExFullHeaderParameter, meta: TSMetaClassifier<out DomElement>, attributeType: String): List<PsiReference>? {
-        val parameters = fullHeaderParameter
-            .parametersList
-            .firstOrNull()
-            ?.parameterList
-            ?: return null
-
-        if (TSConstants.Type.COMPOSED_TYPE == attributeType) {
-            return parameters
-                .takeIf { it.size == 1 }
-                ?.firstOrNull()
-                ?.takeIf { TSConstants.Attribute.CODE == it.text }
-                ?.let { _ ->
-                    if (meta is TSMetaRelation.TSMetaRelationElement && meta.cardinality == Cardinality.MANY) {
-                        /**
-                         * UPDATE CatalogVersionSyncJob; rootTypes(code)
-                         *                             ; CMSItem, CMSRelation, Media, MediaContainer
-                         */
-                        collectRanges(fullHeaderParameter, AttributeModifier.COLLECTION_DELIMITER, ",")
-                            .map { ImpExValueTSClassifierReference(this, it) }
-                    } else {
-                        /**
-                         * UPDATE BundleTemplateStatus[batchmode = true]; itemtype(code)[unique = true]
-                         *                                              ; Address
-                         *
-                         * To be injected into -> Address
-                         */
-                        listOf(ImpExValueTSClassifierReference(this, TextRange.create(0, textLength)))
-                    }
-                }
-        }
-
-        /**
-         * INSERT AttributeConstraint; descriptor(enclosingType(code), qualifier)
-         *                           ; ConsumedDestination:url
-         *
-         * To be injected into -> ConsumedDestination
-         */
-
-        val ranges = collectRanges(fullHeaderParameter, AttributeModifier.PATH_DELIMITER, ":")
-        return parameters
-            .mapIndexedNotNull { index, parameter ->
-                parameter.reference.asSafely<ImpExFunctionTSAttributeReference>()
-                    ?.multiResolve(false)
-                    ?.firstOrNull()
-                    ?.let { resolveResult ->
-                        when (resolveResult) {
-                            is AttributeResolveResult -> resolveResult.meta.type
-                            is RelationEndResolveResult -> resolveResult.meta.type
-                            else -> null
-                        }
-                    }
-                    ?.takeIf { TSConstants.Type.COMPOSED_TYPE == it }
-                    ?.let { ranges.getOrNull(index) }
-                    ?.let { ImpExValueTSClassifierReference(this, it) }
-            }
-    }
-
-    private fun collectTSReferencesForMetaAtomic(attributeType: String): List<PsiReference>? {
-        if (TSConstants.Type.JAVA_CLASS != attributeType) return null
-
-        return if (text.startsWith(ImpExConstants.MACRO_MARKER)) null
-        else listOf(ImpExJavaClassReference(this))
-    }
-
-    private fun collectTSReferencesForMetaEnum(
-        fullHeaderParameter: ImpExFullHeaderParameter,
-        attributeMeta: TSGlobalMetaEnum,
-        attributeType: String
-    ): List<PsiReference>? {
-        val ranges = collectRanges(fullHeaderParameter, AttributeModifier.PATH_DELIMITER, ":")
-
-        return fullHeaderParameter
-            .parametersList
-            .firstOrNull()
-            ?.parameterList
-            ?.mapIndexedNotNull { index, parameter ->
-                parameter.reference.asSafely<ImpExFunctionTSAttributeReference>()
-                    ?.multiResolve(false)
-                    ?.firstOrNull()
-                    ?.asSafely<AttributeResolveResult>()
-                    ?.meta
-                    ?.let {
-                        val range = ranges.getOrNull(index)
-                            ?.takeUnless { range -> range.isMacro(text) }
-                            ?: return@let null
-
-                        when {
-                            it.name == TSConstants.Attribute.CODE -> if (attributeMeta.isDynamic) ImpExValueTSDynamicEnumReference(this, attributeType, range)
-                            else ImpExValueTSStaticEnumReference(this, attributeType, range)
-
-                            it.type == TSConstants.Type.COMPOSED_TYPE -> ImpExValueTSClassifierReference(this, range)
-                            else -> null
-                        }
-                    }
-            }
-            ?.take(getFieldValues().size)
-    }
-
-    private fun collectTSReferencesForMetaCollection(
-        fullHeaderParameter: ImpExFullHeaderParameter,
-        attributeMeta: TSGlobalMetaCollection,
-        metaModelAccess: TSMetaModelAccess
-    ): List<PsiReference>? {
-        return metaModelAccess.findMetaClassifierByName(attributeMeta.elementType)
-            ?.let { targetMeta ->
-                when {
-                    targetMeta is TSGlobalMetaItem && targetMeta.name == TSConstants.Type.COMPOSED_TYPE -> collectRanges(
-                        fullHeaderParameter,
-                        AttributeModifier.COLLECTION_DELIMITER,
-                        ","
-                    )
-                        .filterNot { range -> range.isMacro(text) }
-                        .map { ImpExValueTSClassifierReference(this, it) }
-
-                    else -> null
-                }
-            }
-    }
-
-    private fun collectRanges(fullHeaderParameter: ImpExFullHeaderParameter, modifier: AttributeModifier, defaultDelimiter: String): List<TextRange> {
-        val delimiter = fullHeaderParameter.getAttributeValue(modifier, defaultDelimiter)
-
-        return buildList {
-            var previousStart = 0
-
-            text.split(delimiter).forEachIndexed { index, part ->
-                val partTrimmed = part.trim()
-                val trimStart = part.trimStart()
-                val startWhitespaces = part.length - trimStart.length
-
-                val start = startWhitespaces + previousStart
-                val end = start + partTrimmed.length
-
-                previousStart += part.length + delimiter.length
-
-                add(TextRange.create(start, end))
-            }
-        }
-    }
-
-    private fun getAttribute(fullHeaderParameter: ImpExFullHeaderParameter) = fullHeaderParameter
-        .anyHeaderParameterName
-        .reference
-        ?.asSafely<ImpExTSAttributeReference>()
-        ?.multiResolve(false)
-        ?.firstOrNull()
-
-    private fun getFieldValues(): Array<PsiElement> = findChildrenByType(ImpExTypes.FIELD_VALUE, PsiElement::class.java)
+    private fun getFieldValues(): Array<out PsiElement> = findChildrenByType(ImpExTypes.FIELD_VALUE, PsiElement::class.java)
 
     @Suppress("SpellCheckingInspection")
     companion object {
@@ -372,6 +130,3 @@ abstract class ImpExValueMixin(node: ASTNode) : ASTWrapperPsiElement(node), PsiL
         )
     }
 }
-
-private fun TextRange.isMacro(text: String): Boolean = substring(text)
-    .startsWith(ImpExConstants.MACRO_MARKER)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExDocumentIdUsageReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExDocumentIdUsageReference.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
  * Copyright (C) 2014-2016 Alexander Bartash <AlexanderBartash@gmail.com>
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -31,13 +31,14 @@ import com.intellij.util.asSafely
 import sap.commerce.toolset.impex.lang.refactoring.ImpExPsiElementManipulator
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdDec
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdUsage
-import sap.commerce.toolset.impex.psi.ImpExValue
+import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
 
-class ImpExDocumentIdUsageReference(
-    private val impexValue: ImpExValue,
+open class ImpExDocumentIdUsageReference private constructor(
+    private val fullHeaderParameter: ImpExFullHeaderParameter,
+    element: PsiElement,
     textRange: TextRange,
-) : PsiReferenceBase.Poly<PsiElement>(impexValue, textRange, false) {
+) : PsiReferenceBase.Poly<PsiElement>(element, textRange, false) {
 
     private val cacheKeyResolvedResults = Key.create<ParameterizedCachedValue<Array<ResolveResult>, ImpExDocumentIdUsageReference>>("RESOLVED_RESULTS_$textRange")
 
@@ -53,11 +54,8 @@ class ImpExDocumentIdUsageReference(
         private val KEY_LOOKUP_ELEMENTS = Key.create<ParameterizedCachedValue<Array<LookupElementBuilder>, ImpExDocumentIdUsageReference>>("LOOKUP_ELEMENTS")
 
         private val PROVIDER_LOOKUP_ELEMENTS = ParameterizedCachedValueProvider<Array<LookupElementBuilder>, ImpExDocumentIdUsageReference> { ref ->
-            val fullHeaderParameter = ref.impexValue.valueGroup
-                ?.fullHeaderParameter
-                ?: return@ParameterizedCachedValueProvider CachedValueProvider.Result.create(emptyArray(), PsiModificationTracker.MODIFICATION_COUNT)
-
-            val lookupElements = fullHeaderParameter
+            val project = ref.fullHeaderParameter.project
+            val lookupElements = ref.fullHeaderParameter
                 .parametersList
                 .firstOrNull()
                 ?.parameterList
@@ -68,13 +66,19 @@ class ImpExDocumentIdUsageReference(
                 ?.reference
                 ?.asSafely<ImpExDocumentIdReference>()
                 ?.multiResolve(false)
+                ?.asSequence()
                 ?.mapNotNull { it.element as? ImpExDocumentIdDec }
                 ?.flatMap { it.values.values }
                 ?.flatten()
                 ?.distinctBy { it.text }
                 ?.map { idDec ->
-                    val meta = idDec.valueGroup?.fullHeaderParameter?.headerLine?.fullHeaderType?.headerTypeName?.text
-                        ?.let { TSMetaModelAccess.getInstance(ref.impexValue.project).findMetaClassifierByName(it) }
+                    val meta = idDec.valueGroup
+                        ?.fullHeaderParameter
+                        ?.headerLine
+                        ?.fullHeaderType
+                        ?.headerTypeName
+                        ?.text
+                        ?.let { TSMetaModelAccess.getInstance(project).findMetaClassifierByName(it) }
 
                     LookupElementBuilder.createWithSmartPointer(idDec.text, idDec).also { builder ->
                         if (meta != null) {
@@ -84,18 +88,21 @@ class ImpExDocumentIdUsageReference(
                         }
                     }
                 }
+                ?.toList()
                 ?.toTypedArray()
                 ?: emptyArray()
 
-            CachedValueProvider.Result.create(lookupElements, PsiModificationTracker.MODIFICATION_COUNT)
+            CachedValueProvider.Result.create(
+                lookupElements,
+                PsiModificationTracker.MODIFICATION_COUNT
+            )
         }
 
         private val PROVIDER_RESOLVED_RESULTS = ParameterizedCachedValueProvider<Array<ResolveResult>, ImpExDocumentIdUsageReference> { ref ->
             val name = ref.value
-            val results = ref.impexValue.valueGroup
-                ?.fullHeaderParameter
-                ?.parametersList
-                ?.firstOrNull()
+            val results = ref.fullHeaderParameter
+                .parametersList
+                .firstOrNull()
                 ?.parameterList
                 ?.takeIf { it.size == 1 }
                 ?.firstOrNull()
@@ -115,5 +122,11 @@ class ImpExDocumentIdUsageReference(
                 PsiModificationTracker.MODIFICATION_COUNT,
             )
         }
+
+        fun create(fullHeaderParameter: ImpExFullHeaderParameter, targetElement: PsiElement, textRange: TextRange) = ImpExDocumentIdUsageReference(
+            fullHeaderParameter,
+            targetElement,
+            textRange
+        )
     }
 }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExValueTSClassifierReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExValueTSClassifierReference.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -25,7 +25,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.util.*
-import sap.commerce.toolset.impex.psi.ImpExValue
 import sap.commerce.toolset.psi.getValidResults
 import sap.commerce.toolset.typeSystem.codeInsight.completion.TSCompletionService
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
@@ -35,10 +34,10 @@ import sap.commerce.toolset.typeSystem.psi.reference.TSReferenceBase
 import sap.commerce.toolset.typeSystem.psi.reference.result.*
 
 class ImpExValueTSClassifierReference(
-    owner: ImpExValue,
+    owner: PsiElement,
     textRange: TextRange,
     private val allowedTypes: List<TSMetaType> = TSMetaType.entries
-) : TSReferenceBase<ImpExValue>(owner, false, textRange), HighlightedReference {
+) : TSReferenceBase<PsiElement>(owner, false, textRange), HighlightedReference {
 
     private val cacheKey = Key.create<ParameterizedCachedValue<Array<ResolveResult>, ImpExValueTSClassifierReference>>("HYBRIS_TS_CACHED_REFERENCE_$textRange")
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExValueTSEnumReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExValueTSEnumReference.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -25,7 +25,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.ResolveResult
 import com.intellij.psi.util.*
-import sap.commerce.toolset.impex.psi.ImpExValue
 import sap.commerce.toolset.psi.getValidResults
 import sap.commerce.toolset.typeSystem.codeInsight.completion.TSCompletionService
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
@@ -34,23 +33,23 @@ import sap.commerce.toolset.typeSystem.psi.reference.TSReferenceBase
 import sap.commerce.toolset.typeSystem.psi.reference.result.EnumValueResolveResult
 
 class ImpExValueTSDynamicEnumReference(
-    owner: ImpExValue,
+    owner: PsiElement,
     metaName: String,
     textRange: TextRange,
 ) : ImpExValueTSEnumReference(owner, metaName, true, textRange)
 
 class ImpExValueTSStaticEnumReference(
-    owner: ImpExValue,
+    owner: PsiElement,
     metaName: String,
     textRange: TextRange,
 ) : ImpExValueTSEnumReference(owner, metaName, false, textRange)
 
 abstract class ImpExValueTSEnumReference(
-    owner: ImpExValue,
+    owner: PsiElement,
     private val metaName: String,
     soft: Boolean,
     textRange: TextRange,
-) : TSReferenceBase<ImpExValue>(owner, soft, textRange), HighlightedReference {
+) : TSReferenceBase<PsiElement>(owner, soft, textRange), HighlightedReference {
 
     private val cacheKey = Key.create<ParameterizedCachedValue<Array<ResolveResult>, ImpExValueTSEnumReference>>("HYBRIS_TS_CACHED_REFERENCE_$textRange")
 

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/AbstractImpExTableColumnMoveAction.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/actionSystem/AbstractImpExTableColumnMoveAction.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -44,7 +44,6 @@ abstract class AbstractImpExTableColumnMoveAction(private val direction: ImpExCo
         run(project, "Moving the '${headerParameter.text}' column ${direction.name.lowercase(Locale.ROOT)}") {
             WriteCommandAction.runWriteCommandAction(project) {
                 PostprocessReformattingAspect.getInstance(project).disablePostprocessFormattingInside {
-//                    ImpExHighlightingCaretListener.getInstance().clearHighlightedArea(editor)
 
                     val headerLine = headerParameter.headerLine ?: return@disablePostprocessFormattingInside
                     val column = headerParameter.columnNumber


### PR DESCRIPTION
before

<img width="836" height="277" alt="Screenshot 2026-04-07 at 09 56 54" src="https://github.com/user-attachments/assets/f3028dc8-b3fc-4c8d-a7cc-c9f72db26e9f" />

after

<img width="1078" height="99" alt="Screenshot 2026-04-07 at 12 30 36" src="https://github.com/user-attachments/assets/f31c021e-cc20-48db-8152-26fec9930a91" />
<img width="1049" height="63" alt="Screenshot 2026-04-07 at 12 30 54" src="https://github.com/user-attachments/assets/faf5294d-89c3-4796-bb05-46e40931fd9f" />
<img width="822" height="383" alt="Screenshot 2026-04-07 at 12 31 15" src="https://github.com/user-attachments/assets/f4d9bb0e-cc90-4ce4-9c32-47ac8b303539" />
<img width="800" height="358" alt="Screenshot 2026-04-07 at 12 31 39" src="https://github.com/user-attachments/assets/f1ec2933-297e-40e1-a016-178113343614" />
