### PR TITLE
ImpEx | Inspection Rules | Inspection: allow email-like values in the unquoted value strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.7]
 
 <cite>Release contributors</cite>
-- 69 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
+- 70 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Fabio Filpi](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3Afabiofilpi+is%3Apr+)
 - 1 PR(s) by [Mihai Sprinceana](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.7+author%3AMihaiSprinceana+is%3Apr+)
 
@@ -61,6 +61,7 @@
 - Inspection: validate various references used in the ImpEx [#1835](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1835)
 - Inspection: do not enforce index for parameters as macro or abbreviation [#1847](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1847)
 - Inspection: allow single macro as a value for string columns [#1848](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1848)
+- Inspection: allow email-like values in the unquoted value strings [#1861](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1861)
 - Local fix: quote value strings for non-unique string columns & localized string columns [#1798](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1798)
 - Local fix: exclude attribute of the specific type from the wrap value string in quotes rule [#1799](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1799)
 - Local fix: enable value to be quoted for string attribute of the specific type [#1801](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1801)

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
@@ -29,7 +29,7 @@ data class ImpExSettingsState(
     @JvmField @OptionTag val documentation: ImpExDocumentationSettingsState = ImpExDocumentationSettingsState(),
     // Type name to > set of attribute names
     @JvmField @OptionTag val quoteStringWhitelist: Boolean = true,
-    @JvmField @OptionTag val quoteStringWhitelistPattern: Regex = Regex("^[a-zA-Z0-9_$/\\-]+$"),
+    @JvmField @OptionTag val quoteStringWhitelistPattern: Regex = Regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"),
     @JvmField @OptionTag val quoteStringExclusions: Map<String, Set<String>> = mapOf(),
 ) {
     fun mutable() = Mutable(

--- a/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/settings/state/ImpExSettingsState.kt
@@ -29,7 +29,7 @@ data class ImpExSettingsState(
     @JvmField @OptionTag val documentation: ImpExDocumentationSettingsState = ImpExDocumentationSettingsState(),
     // Type name to > set of attribute names
     @JvmField @OptionTag val quoteStringWhitelist: Boolean = true,
-    @JvmField @OptionTag val quoteStringWhitelistPattern: Regex = Regex("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}\$"),
+    @JvmField @OptionTag val quoteStringWhitelistPattern: Regex = Regex("^([a-zA-Z0-9_$/\\-]+|[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})$"),
     @JvmField @OptionTag val quoteStringExclusions: Map<String, Set<String>> = mapOf(),
 ) {
     fun mutable() = Mutable(


### PR DESCRIPTION
before
<img width="331" height="100" alt="Screenshot 2026-04-07 at 13 33 31" src="https://github.com/user-attachments/assets/1120d8d6-0fd5-447d-bc3c-98499e0ceabd" />

after
<img width="329" height="69" alt="Screenshot 2026-04-07 at 14 11 32" src="https://github.com/user-attachments/assets/17857cbe-1260-4cde-b167-8892331d192f" />
