### PR TITLE
ImpEx | Adjusted range for reference resolution to ComposedTypes within value cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## [2026.0.8]
 
 <cite>Release contributors</cite>
-- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3Amlytvyn+is%3Apr)
+- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Stefan Kruk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3AStefanKruk+is%3Apr+)
 
 ### `Project Import` enhancements
 - Add Compiler Parameter `-parameters` to keep Method Names during compilation for Reflection [#1865](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1865)
+
+### `ImpEx` enhancements
+- Adjusted range for reference resolution to ComposedTypes within value cells [#1867](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1867)
 
 ### `CCv2` enhancements
 - Persist builds cleanup settings [#1866](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1866)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
@@ -264,7 +264,7 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
                          *
                          * To be injected into -> Address
                          */
-                        listOf(ImpExValueTSClassifierReference(targetElement, TextRange.create(0, textLength)))
+                        listOf(ImpExValueTSClassifierReference(targetElement, TextRange.create(0, targetElement.textLength)))
                     }
                 }
         }


### PR DESCRIPTION
before
<img width="539" height="75" alt="Screenshot 2026-04-10 at 12 09 32" src="https://github.com/user-attachments/assets/c1f86b82-0536-4b1a-b35d-fbc84f5ff85d" />

after
<img width="934" height="137" alt="Screenshot 2026-04-10 at 12 10 41" src="https://github.com/user-attachments/assets/d175c142-ac41-4efc-b537-e76f7018519f" />
