### PR TITLE
Groovy | Fix HAC response formatting by removing jsoup parsing

### DIFF
--- a/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/GroovyExecClient.kt
+++ b/modules/groovy/exec/src/sap/commerce/toolset/groovy/exec/GroovyExecClient.kt
@@ -29,7 +29,6 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.apache.http.HttpStatus
 import org.apache.http.message.BasicNameValuePair
-import org.jsoup.Jsoup
 import sap.commerce.toolset.exec.DefaultExecClient
 import sap.commerce.toolset.exec.context.DefaultExecResult
 import sap.commerce.toolset.groovy.exec.context.GroovyExecContext
@@ -58,8 +57,7 @@ class GroovyExecClient(project: Project, coroutineScope: CoroutineScope) : Defau
         )
 
         try {
-            val document = Jsoup.parse(response.entity.content, Charsets.UTF_8.name(), "")
-            val jsonAsString = document.getElementsByTag("body").text()
+            val jsonAsString = response.entity.content.readBytes().toString(Charsets.UTF_8)
             val json = Json.parseToJsonElement(jsonAsString)
 
             json.jsonObject["stacktraceText"]


### PR DESCRIPTION
Remove jsoup HTML parsing that was corrupting the formatting of HAC script output. Jsoup was collapsing whitespace and reformatting the response content, making it difficult to read when scripts generate:
- Indented code or output
- Pretty-printed JSON or XML

Direct UTF-8 string conversion preserves the original formatting from the HAC response, improving readability of script execution results.

Signed-off-by: Your Real Name your.email@email.com
