### PR TITLE
Project Import | Attach sources for OOTB and EXT modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,14 @@
 <cite>Release contributors</cite>
 - 8 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Stefan Kruk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3AStefanKruk+is%3Apr+)
+- 2 PR(s) by [Alessandro Antonini](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.8+author%3Aninopg+is%3Apr)
+
+### `Groovy` enhancements
+- Fix HAC response formatting by removing jsoup parsing [#1874](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1874)
 
 ### `Project Import` enhancements
 - Add Compiler Parameter `-parameters` to keep Method Names during compilation for Reflection [#1865](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1865)
+- Attach sources for OOTB modules during project import (supports both zip files and folders) [#1875](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1875)
 
 ### `ImpEx` enhancements
 - Adjusted range for reference resolution to ComposedTypes within value cells [#1867](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1867)

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/library/CompileModuleLibraryConfigurator.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/library/CompileModuleLibraryConfigurator.kt
@@ -19,6 +19,7 @@
 package sap.commerce.toolset.java.configurator.library
 
 import com.intellij.platform.workspace.storage.url.VirtualFileUrlManager
+import com.intellij.util.containers.addIfNotNull
 import sap.commerce.toolset.java.JavaConstants
 import sap.commerce.toolset.java.configurator.library.util.*
 import sap.commerce.toolset.project.ProjectConstants
@@ -26,6 +27,7 @@ import sap.commerce.toolset.project.configurator.ModuleLibraryConfigurator
 import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.context.ProjectModuleConfigurationContext
 import sap.commerce.toolset.project.descriptor.ModuleDescriptor
+import sap.commerce.toolset.project.descriptor.ModuleDescriptorType
 import sap.commerce.toolset.project.descriptor.YModuleDescriptor
 import sap.commerce.toolset.project.descriptor.ifNonCustomModuleDescriptor
 import sap.commerce.toolset.project.descriptor.impl.YCommonWebSubModuleDescriptor
@@ -48,6 +50,9 @@ class CompileModuleLibraryConfigurator : ModuleLibraryConfigurator<YModuleDescri
         val virtualFileUrlManager = importContext.workspace.getVirtualFileUrlManager()
         val libraryRoots = buildList {
             addAll(moduleDescriptor.serverJarFiles(virtualFileUrlManager))
+            if (moduleDescriptor.type == ModuleDescriptorType.OOTB || moduleDescriptor.type == ModuleDescriptorType.EXT) {
+                addIfNotNull(context.importContext.sourceCode(virtualFileUrlManager))
+            }
             addAll(moduleDescriptor.docSources(virtualFileUrlManager))
             addAll(moduleDescriptor.lib(virtualFileUrlManager))
 

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/library/PlatformBootstrapProjectLibraryConfigurator.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/library/PlatformBootstrapProjectLibraryConfigurator.kt
@@ -24,15 +24,15 @@ import com.intellij.platform.workspace.storage.url.VirtualFileUrlManager
 import com.intellij.util.containers.addIfNotNull
 import sap.commerce.toolset.java.JavaConstants
 import sap.commerce.toolset.java.configurator.library.util.configureProjectLibrary
+import sap.commerce.toolset.java.configurator.library.util.sourceCode
 import sap.commerce.toolset.java.configurator.library.util.sources
 import sap.commerce.toolset.project.ProjectConstants
 import sap.commerce.toolset.project.configurator.ProjectLibraryConfigurator
 import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.descriptor.PlatformModuleDescriptor
+import sap.commerce.toolset.project.fromPath
 import sap.commerce.toolset.util.directoryExists
-import sap.commerce.toolset.util.fileExists
 import kotlin.io.path.listDirectoryEntries
-import kotlin.io.path.pathString
 
 class PlatformBootstrapProjectLibraryConfigurator : ProjectLibraryConfigurator {
 
@@ -57,11 +57,6 @@ class PlatformBootstrapProjectLibraryConfigurator : ProjectLibraryConfigurator {
         )
     }
 
-    private fun ProjectImportContext.sourceCode(virtualFileUrlManager: VirtualFileUrlManager) = this.sourceCodeFile
-        ?.takeIf { it.fileExists }
-        ?.let { virtualFileUrlManager.fromPath(it.pathString) }
-        ?.let { LibraryRoot(it, LibraryRootTypeId.SOURCES) }
-
     private fun PlatformModuleDescriptor.libraryDirectories(virtualFileUrlManager: VirtualFileUrlManager) = buildList {
         val moduleRootPath = this@libraryDirectories.moduleRootPath
 
@@ -81,6 +76,6 @@ class PlatformBootstrapProjectLibraryConfigurator : ProjectLibraryConfigurator {
         add(moduleRootPath.resolve(ProjectConstants.Paths.TOMCAT_6_LIB))
     }
         .filter { it.directoryExists }
-        .map { virtualFileUrlManager.fromPath(it.pathString) }
+        .mapNotNull { virtualFileUrlManager.fromPath(it) }
         .map { LibraryRoot(it, LibraryRootTypeId.COMPILED, LibraryRoot.InclusionOptions.ARCHIVES_UNDER_ROOT) }
 }

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/library/util/LibraryRootUtil.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/library/util/LibraryRootUtil.kt
@@ -25,6 +25,7 @@ import com.intellij.platform.workspace.storage.url.VirtualFileUrlManager
 import com.intellij.util.asSafely
 import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.project.ProjectConstants
+import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.descriptor.ModuleDescriptor
 import sap.commerce.toolset.project.descriptor.YSubModuleDescriptor
 import sap.commerce.toolset.project.fromJar
@@ -35,6 +36,7 @@ import kotlin.io.path.Path
 import kotlin.io.path.extension
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
+import kotlin.io.path.pathString
 
 fun ModuleDescriptor.lib(virtualFileUrlManager: VirtualFileUrlManager) = this.compiledArchives(
     virtualFileUrlManager, Path(ProjectConstants.Directory.LIB)
@@ -137,3 +139,14 @@ private fun ModuleDescriptor.libraryRoots(
     .mapNotNull { virtualFileUrlManager.fromPath(moduleRootPath.resolve(it)) }
     .map { LibraryRoot(it, type, inclusionOptions) }
 
+fun ProjectImportContext.sourceCode(virtualFileUrlManager: VirtualFileUrlManager): LibraryRoot? {
+    // Scenario 1: ZIP file selected - sourceCodeFile is set
+    // Scenario 2: Directory selected - only sourceCodePath is set
+    val path = sourceCodeFile ?: sourceCodePath ?: return null
+
+    return when {
+        path.extension == "zip" -> virtualFileUrlManager.fromJar(path)
+        path.directoryExists -> virtualFileUrlManager.fromPath(path)
+        else -> null
+    }?.let { LibraryRoot(it, LibraryRootTypeId.SOURCES) }
+}

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectImportCoreContextStepUi.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ProjectImportCoreContextStepUi.kt
@@ -162,7 +162,7 @@ internal fun uiCoreStep(context: ProjectImportCoreContext): DialogPanel {
                             path.fileExists -> {
                                 context.sourceCodeFile.set(textField.text)
                                 sourceCodeInfoToggle.set(true)
-                                sourceCodeInfoLabel.set("The selected file will be used as a source in the Bootstrap Library.")
+                                sourceCodeInfoLabel.set("The selected file will be used as a source for OOTB modules.")
                             }
 
                             path.directoryExists -> {

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/ProjectImportCoreContextStep.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/ProjectImportCoreContextStep.kt
@@ -200,7 +200,13 @@ class ProjectImportCoreContextStep(context: WizardContext) : ProjectImportWizard
                 ?.takeIf { it.isNotBlank() }
                 ?: projectSettings.javadocUrl
             this.sourceCodePath = projectSettings.sourceCodePath?.toNioPathOrNull()
-            this.sourceCodeFile = this.sourceCodePath?.findSourceCodeFile(platformVersion, platformApiVersion)
+            this.sourceCodeFile = this.sourceCodePath?.let { path ->
+                when {
+                    path.fileExists -> path // Already a file (zip)
+                    path.directoryExists -> path.findSourceCodeFile(platformVersion, platformApiVersion) // Directory, search for zip
+                    else -> null
+                }
+            }
 
             this.externalExtensionsDirectory = projectSettings.externalExtensionsDirectory?.toNioPathOrNull()
             this.externalConfigDirectory = projectSettings.externalConfigDirectory?.toNioPathOrNull()


### PR DESCRIPTION
Add support for attaching SAP Commerce source code to module libraries:
- Handle both ZIP file and directory source code paths
- Attach sources to `OOTB` and `EXT` modules in `CompileModuleLibraryConfigurator`
- Extract `sourceCode()` utility function to LibraryRootUtil for reusability

This enables developers to navigate to SAP Commerce source code directly
from their IDE when working with platform and extension modules.
