### PR TITLE
Project Import | Display detected module root as multiline text in the `Mandatory Module Not Found` dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## [2026.0.9]
 
 <cite>Release contributors</code>
-- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
+- 3 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
 - 1 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
 - Enable `externalDependencies.xml` as a restoration entry on project reimport [#1884](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1884)
 - Improved Angular module detection for Ultimate IDEA [#1885](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1885)
+- Display detected module root as multiline text in the `Mandatory Module Not Found` dialog [#1887](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1887)
 
-### `Welcome Screen` enchancements
+### `Welcome Screen` enhancements
 - Introduced the new `Welcome Screen` tab with the list of SAP Commerce projects [1882](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1882)
 
 ## [2026.0.8]

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ModuleNotFoundDialog.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/ui/ModuleNotFoundDialog.kt
@@ -60,7 +60,7 @@ class ModuleNotFoundDialog(
                         descriptors.forEach { descriptor ->
                             row {
                                 label(descriptor.name)
-                                label(descriptor.moduleRootPath.pathString)
+                                text(descriptor.moduleRootPath.pathString)
                             }.layout(RowLayout.PARENT_GRID)
                         }
                     }


### PR DESCRIPTION
<img width="786" height="785" alt="Screenshot 2026-04-16 at 12 39 12" src="https://github.com/user-attachments/assets/82e66965-bbb4-4017-bd2a-b408e8eb6468" />
