### PR TITLE
Module Selection: Mandatory modules can be deselected if replacement is selected

### DIFF
--- a/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/SelectHybrisModulesStep.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/SelectHybrisModulesStep.kt
@@ -45,6 +45,18 @@ class SelectHybrisModulesStep(context: WizardContext) : AbstractSelectModulesSte
     init {
         fileChooser.addElementsMarkListener(ElementsChooser.ElementsMarkListener { element, isMarked ->
             if (element is YModuleDescriptor) {
+                if (!isMarked && element !is YSubModuleDescriptor) {
+                    val duplicates = this.context.list
+                        .filter { it.name == element.name }
+
+                    if (duplicates.any { it.importStatus == ModuleDescriptorImportStatus.MANDATORY }
+                        && duplicates.none { fileChooser.isElementMarked(it) }) {
+                        fileChooser.setElementMarked(element, true)
+                        fileChooser.repaint()
+                        return@ElementsMarkListener
+                    }
+                }
+
                 if (isMarked) {
                     val elementMarkStates = fileChooser.elementMarkStates
                     element.getAllDependencies()
@@ -69,10 +81,6 @@ class SelectHybrisModulesStep(context: WizardContext) : AbstractSelectModulesSte
 
         // init the tree
         super.updateStep()
-
-        context.list
-            .filter { it.importStatus == ModuleDescriptorImportStatus.MANDATORY }
-            .forEach { if (!isInConflict(it)) fileChooser.disableElement(it) }
 
         fileChooser.sort(compareBy<ModuleDescriptor> { orderByType[it.type] ?: Integer.MAX_VALUE }
             .thenComparing { it.name }


### PR DESCRIPTION
Hey,

### I was having the following problem:

When importing a project in which I have OOTB modules for which I have custom modules, I was able to select the custom ones but not able to deselect the OOTB ones.

But it seems like someone has already though about this:
```
context.list
            .filter { it.importStatus == ModuleDescriptorImportStatus.MANDATORY }
            .forEach { if (!isInConflict(it)) fileChooser.disableElement(it) }
```

however, this can only work if the other modules with the same name are also enabled during initialization (in my case they weren't)
... so all of the OOTB modules were disabled and I was not able to use my custom ones.

### The solution:

Instead of disabling modules (their checkboxes), I now check during clicking (unmarking) if a module with the name as the clicked element is mandatory... and if there's no other element with that name selected we effectivly revert the change and set it back to "marked".

Would like to know what you think

Justin Klaußnitzer
