### PR TITLE
Type System | Show parent for item type in the `items.xml` code completion items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.9]
 
 <cite>Release contributors</code>
-- 12 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
+- 13 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
 - 6 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
@@ -29,6 +29,7 @@
 
 ### `Type System` enhancements
 - Improved inspection & code completion for attribute types [#1902](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1902)
+- Show parent for item type in the `items.xml` code completion items [#1903](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1903)
 
 ## [2026.0.8]
 

--- a/modules/typeSystem/core/src/sap/commerce/toolset/typeSystem/util/xml/ItemTypeConverter.kt
+++ b/modules/typeSystem/core/src/sap/commerce/toolset/typeSystem/util/xml/ItemTypeConverter.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -37,5 +37,8 @@ open class ItemTypeConverter : AbstractTSConverterBase<ItemType>(ItemType::class
     override fun getPsiElement(resolvedValue: ItemType?): PsiElement? = navigateToValue(resolvedValue) { it.code }
 
     override fun createLookupElement(dom: ItemType?) = dom
+        ?.module
+        ?.project
+        ?.let { TSMetaModelAccess.getInstance(it).findMetaItemByName(dom.code.stringValue) }
         ?.let { TSLookupElementFactory.build(it) }
 }


### PR DESCRIPTION
before
<img width="782" height="153" alt="Screenshot 2026-04-17 at 11 30 39" src="https://github.com/user-attachments/assets/ff62116e-cc93-491b-b510-9eca576e381d" />


after
<img width="802" height="168" alt="Screenshot 2026-04-17 at 11 31 39" src="https://github.com/user-attachments/assets/2af69c62-c4bd-42bd-8350-98e700fe5f8d" />
