### PR TITLE
Project Import | Advanced support of the extensions preselection for recursive dependencies based on defined order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.9]
 
 <cite>Release contributors</code>
-- 19 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
+- 20 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Amlytvyn+is%3Apr)
 - 13 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.9+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
@@ -17,6 +17,7 @@
 - Use sticky headers for `Project Details` & `Reuse settings` wizard steps [#1899](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1899)
 - Enhanced extensions load & preselection order based on `localextensions.xml` [#1911](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1911)
 - Support `dir`-only dependency declaration via `localextensions.xml` [#1915](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1915)
+- Advanced support of the extensions preselection for recursive dependencies based on defined order [#1919](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1919)
 
 ### `Project View` enhancements
 - Show `.github` as a project node [#1907](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1907)

--- a/modules/angular/project/src/sap/commerce/toolset/angular/project/descriptor/AngularModuleDescriptor.kt
+++ b/modules/angular/project/src/sap/commerce/toolset/angular/project/descriptor/AngularModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -37,8 +37,7 @@ class AngularModuleDescriptor(
     }
 
     override fun isPreselected() = true
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = moduleDescriptors.values
-        .flatten()
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = moduleDescriptors.values
         .asSequence()
         .filter { this.moduleRootPath.toString().startsWith(it.moduleRootPath.toString()) }
         .filter { this != it }

--- a/modules/project/core/src/sap/commerce/toolset/project/context/ProjectImportContext.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/context/ProjectImportContext.kt
@@ -26,6 +26,7 @@ import com.intellij.platform.workspace.jps.entities.ModuleEntityBuilder
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import sap.commerce.toolset.exceptions.HybrisConfigurationException
+import sap.commerce.toolset.localextensions.context.LocalExtensionsContext
 import sap.commerce.toolset.project.descriptor.ConfigModuleDescriptor
 import sap.commerce.toolset.project.descriptor.ModuleDescriptor
 import sap.commerce.toolset.project.descriptor.ModuleDescriptorImportStatus
@@ -129,6 +130,7 @@ data class ProjectImportContext(
         var externalDbDriversDirectory: Path? = null,
         var javadocUrl: String? = null,
         var platformVersion: String? = null,
+        var localExtensionsContext: LocalExtensionsContext = LocalExtensionsContext.EMPTY,
         var hostingEnvironment: HostingEnvironment = HostingEnvironment.ON_PREMISE,
 
         private val _foundModules: MutableCollection<ModuleDescriptor> = mutableListOf(),

--- a/modules/project/core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptor.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -42,8 +42,8 @@ interface ModuleDescriptor : Comparable<ModuleDescriptor> {
     fun getRelativePath(rootDirectory: Path): String
     fun getRequiredExtensionNames(): Set<String>
     fun addRequiredExtensionNames(extensions: Collection<YModuleDescriptor>): Boolean
-    fun computeRequiredExtensionNames(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>)
-    fun getAllDependencies(): Set<ModuleDescriptor>
+    fun computeRequiredExtensionNames(moduleDescriptors: Map<String, ModuleDescriptor>)
+    fun getRecursiveDependencies(): Set<ModuleDescriptor>
     fun getDirectDependencies(): Set<ModuleDescriptor>
     fun addDirectDependencies(dependencies: Collection<ModuleDescriptor>): Boolean
 }

--- a/modules/project/import-core/src/sap/commerce/toolset/project/configurator/GroupModuleConfigurator.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/configurator/GroupModuleConfigurator.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -38,7 +38,7 @@ class GroupModuleConfigurator : ProjectImportConfigurator {
                 .filter { it.isPreselected() }
                 .forEach {
                     add(it)
-                    addAll(it.getAllDependencies())
+                    addAll(it.getRecursiveDependencies())
                 }
         }
 

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/MainConfigModuleDescriptorResolver.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/MainConfigModuleDescriptorResolver.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -43,7 +43,10 @@ import kotlin.io.path.pathString
 class MainConfigModuleDescriptorResolver {
 
     @Throws(HybrisConfigurationException::class)
-    fun resolve(context: ProjectImportContext.Mutable) = find(context)
+    fun resolve(context: ProjectImportContext.Mutable, foundModuleDescriptors: Collection<ModuleDescriptor>) = find(
+        context = context,
+        foundModuleDescriptors = foundModuleDescriptors
+    )
         ?.apply {
             importStatus = ModuleDescriptorImportStatus.MANDATORY
             isMainConfig = true
@@ -58,10 +61,10 @@ class MainConfigModuleDescriptorResolver {
                  """.trimIndent()
         )
 
-    private fun find(context: ProjectImportContext.Mutable): ConfigModuleDescriptor? {
-        val foundConfigModules = context.foundModules
+    private fun find(context: ProjectImportContext.Mutable, foundModuleDescriptors: Collection<ModuleDescriptor>): ConfigModuleDescriptor? {
+        val foundConfigModules = foundModuleDescriptors
             .filterIsInstance<ConfigModuleDescriptor>()
-        val platformHybrisModuleDescriptor = context.foundModules
+        val platformHybrisModuleDescriptor = foundModuleDescriptors
             .filterIsInstance<PlatformModuleDescriptor>()
             .firstOrNull() ?: return null
 

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptorsDependenciesResolver.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptorsDependenciesResolver.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -23,6 +23,9 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.util.application
 import sap.commerce.toolset.extensioninfo.EiConstants
+import sap.commerce.toolset.localextensions.LocalExtensionsProcessor
+import sap.commerce.toolset.localextensions.context.FoundExtension
+import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.descriptor.impl.*
 
 @Service
@@ -30,10 +33,10 @@ class ModuleDescriptorsDependenciesResolver {
 
     private val logger = thisLogger()
 
-    fun resolve(foundModuleDescriptors: Collection<ModuleDescriptor>): Collection<ModuleDescriptor> {
+    fun resolve(context: ProjectImportContext.Mutable, foundModuleDescriptors: Collection<ModuleDescriptor>): Collection<ModuleDescriptor> {
         val moduleDescriptors = foundModuleDescriptors.toMutableList()
 
-        buildDependencies(moduleDescriptors)
+        buildDependencies(context, moduleDescriptors)
         processWebSubModules(moduleDescriptors)
         val addons = processAddons(moduleDescriptors)
         removeNotInstalledAddons(moduleDescriptors, addons)
@@ -42,9 +45,18 @@ class ModuleDescriptorsDependenciesResolver {
         return moduleDescriptors
     }
 
-    private fun buildDependencies(moduleDescriptors: MutableCollection<ModuleDescriptor>) {
+    private fun buildDependencies(context: ProjectImportContext.Mutable, moduleDescriptors: MutableCollection<ModuleDescriptor>) {
+        val localExtensionsProcessor = LocalExtensionsProcessor.getInstance()
         val moduleDescriptorsMap = moduleDescriptors
             .groupBy { it.name }
+            .mapValues { (_, group) ->
+                val foundExtensions = group.map { FoundExtension(it.name, it.moduleRootPath) }
+
+                if (foundExtensions.size == 1) foundExtensions.first()
+                else localExtensionsProcessor.getSuitableExtension(foundExtensions, context.localExtensionsContext)
+            }
+            .filterValues { it != null }
+            .mapValues { (_, suitableExtension) -> moduleDescriptors.first { it.moduleRootPath == suitableExtension?.moduleRootPath } }
         for (moduleDescriptor in moduleDescriptors) {
             val dependencies = buildDependencies(moduleDescriptor, moduleDescriptorsMap)
             moduleDescriptor.addDirectDependencies(dependencies)
@@ -53,7 +65,7 @@ class ModuleDescriptorsDependenciesResolver {
 
     private fun buildDependencies(
         moduleDescriptor: ModuleDescriptor,
-        moduleDescriptors: Map<String, Collection<ModuleDescriptor>>
+        moduleDescriptors: Map<String, ModuleDescriptor>
     ) = moduleDescriptor
         .apply { computeRequiredExtensionNames(moduleDescriptors) }
         .getRequiredExtensionNames()
@@ -67,7 +79,6 @@ class ModuleDescriptorsDependenciesResolver {
                     logger.trace("Module '${moduleDescriptor.name}' contains unsatisfied dependency '$requiresExtensionName'.")
                 }
         }
-        ?.mapNotNull { it.firstOrNull() }
         ?: emptyList()
 
     private fun processWebSubModules(moduleDescriptors: Collection<ModuleDescriptor>) {
@@ -77,11 +88,10 @@ class ModuleDescriptorsDependenciesResolver {
                 webSubModuleDescriptor.getDirectDependencies()
                     .asSequence()
                     .filterIsInstance<YModuleDescriptor>()
-                    .flatMap { it.getAllDependencies() }
+                    .flatMap { it.getRecursiveDependencies() }
                     .filterIsInstance<YCustomRegularModuleDescriptor>()
                     .flatMap { it.getSubModules() }
                     .filterIsInstance<YCommonWebSubModuleDescriptor>()
-                    .toList()
                     .forEach { it.addDependantWebExtension(webSubModuleDescriptor) }
             }
     }

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptorsSelector.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/ModuleDescriptorsSelector.kt
@@ -20,35 +20,24 @@ package sap.commerce.toolset.project.descriptor
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.util.application
-import sap.commerce.toolset.localextensions.LeExtension
-import sap.commerce.toolset.localextensions.LeExtensionsCollector
 import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.settings.ProjectSettings
 
 @Service
 class ModuleDescriptorsSelector {
 
-    suspend fun preselect(context: ProjectImportContext.Mutable, configModuleDescriptor: ConfigModuleDescriptor) {
-        val foundExtensions = context.foundModules
-            .map { LeExtension(it.name, it.moduleRootPath) }
-        val platformDirectory = context.platformDistributionPath
-            ?: run { thisLogger().warn("Unable to preselect modules, platform directory is not detected"); return }
-        val extensionsInLocalExtensions = LeExtensionsCollector.getInstance().collect(
-            foundExtensions,
-            configModuleDescriptor.moduleRootPath,
-            platformDirectory
-        )
+    fun preselect(context: ProjectImportContext.Mutable) {
+        val localExtensions = context.localExtensionsContext.extensions
         val preselectedExtensionNames = mutableSetOf<String>()
 
         context.foundModules
             .asSequence()
             .filterNot { preselectedExtensionNames.contains(it.name) }
-            .filter { extensionsInLocalExtensions.contains(it.name) }
+            .filter { localExtensions.contains(it.name) }
             .filterIsInstance<YRegularModuleDescriptor>()
             .filter { moduleDescriptor ->
-                val preferredLoadPath = extensionsInLocalExtensions[moduleDescriptor.name]?.directory
+                val preferredLoadPath = localExtensions[moduleDescriptor.name]?.path
                 moduleDescriptor.moduleRootPath.normalize().equals(preferredLoadPath)
             }
             .forEach { moduleDescriptor ->
@@ -58,7 +47,7 @@ class ModuleDescriptorsSelector {
                 moduleDescriptor.importStatus = ModuleDescriptorImportStatus.MANDATORY
                 moduleDescriptor.getSubModules()
                     .forEach { subModule -> subModule.importStatus = ModuleDescriptorImportStatus.MANDATORY }
-                moduleDescriptor.getAllDependencies()
+                moduleDescriptor.getRecursiveDependencies()
                     .asSequence()
                     .filterIsInstance<YRegularModuleDescriptor>()
                     .filterNot { preselectedExtensionNames.contains(it.name) }
@@ -111,7 +100,7 @@ class ModuleDescriptorsSelector {
         while (!moduleToCheck.isEmpty()) {
             val currentModule = moduleToCheck.iterator().next()
             if (currentModule is YModuleDescriptor) {
-                for (moduleDescriptor in currentModule.getAllDependencies()) {
+                for (moduleDescriptor in currentModule.getRecursiveDependencies()) {
                     if (!moduleToImport.contains(moduleDescriptor)) {
                         moduleToImport.add(moduleDescriptor)
                         moduleDescriptor.importStatus = selectionMode

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/AbstractModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/AbstractModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -44,7 +44,7 @@ abstract class AbstractModuleDescriptor(
     override var importStatus = ModuleDescriptorImportStatus.UNUSED
     private lateinit var requiredExtensionNames: MutableSet<String>
     private val directDependencies = mutableSetOf<ModuleDescriptor>()
-    private val dependencies: Set<ModuleDescriptor> by lazy {
+    private val _recursiveDependencies: Set<ModuleDescriptor> by lazy {
         recursivelyCollectDependenciesPlainSet(this, TreeSet())
             .toImmutableSet()
     }
@@ -101,21 +101,21 @@ abstract class AbstractModuleDescriptor(
         ?.getRelativePath(rootDirectory, moduleRootPath)
         ?: moduleRootPath.pathString
 
-    override fun getAllDependencies() = dependencies
+    override fun getRecursiveDependencies() = _recursiveDependencies
 
     override fun getRequiredExtensionNames() = requiredExtensionNames
     override fun addRequiredExtensionNames(extensions: Collection<YModuleDescriptor>) = extensions
         .map { it.name }
         .let { requiredExtensionNames.addAll(it) }
 
-    override fun computeRequiredExtensionNames(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) {
+    override fun computeRequiredExtensionNames(moduleDescriptors: Map<String, ModuleDescriptor>) {
         requiredExtensionNames = initDependencies(moduleDescriptors).toMutableSet()
     }
 
     override fun getDirectDependencies() = directDependencies
 
     override fun addDirectDependencies(dependencies: Collection<ModuleDescriptor>) = this.directDependencies.addAll(dependencies)
-    open fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>): Set<String> = emptySet()
+    open fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>): Set<String> = emptySet()
 
     override fun toString() = "${javaClass.simpleName} {name=$name, path=$moduleRootPath}"
 

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/AbstractYSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/AbstractYSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -35,6 +35,6 @@ abstract class AbstractYSubModuleDescriptor(
     extensionInfo = owner.extensionInfo
 ), YSubModuleDescriptor {
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = setOf(owner.name)
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = setOf(owner.name)
     override fun isPreselected() = owner.isPreselected()
 }

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/PlatformModuleDescriptorImpl.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/PlatformModuleDescriptorImpl.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -33,8 +33,7 @@ class PlatformModuleDescriptorImpl(
     override var importStatus = ModuleDescriptorImportStatus.MANDATORY
     override fun isPreselected() = true
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = moduleDescriptors.values
-        .flatten()
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = moduleDescriptors.values
         .filterIsInstance<YPlatformExtModuleDescriptor>()
         .map { it.name }
         .toSet()

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YAcceleratorAddonSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YAcceleratorAddonSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -50,7 +50,7 @@ class YAcceleratorAddonSubModuleDescriptor(
         )
     }
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>): Set<String> {
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>): Set<String> {
         val webNames = owner.getRequiredExtensionNames()
             .map { it + "." + EiConstants.Extension.WEB }
         // Strange, but acceleratoraddon may rely on another acceleratoraddon

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YBackofficeSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YBackofficeSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -33,7 +33,7 @@ class YBackofficeSubModuleDescriptor(
 
     val hasWebModule = moduleRootPath.resolve(EiConstants.Extension.WEB).directoryExists
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>): Set<String> {
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>): Set<String> {
         val webNames = owner.getRequiredExtensionNames()
             .map { it + "." + EiConstants.Extension.BACK_OFFICE }
         return setOf(owner.name) + webNames

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YCoreExtModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YCoreExtModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -28,5 +28,5 @@ class YCoreExtModuleDescriptor(
 ) : YPlatformExtModuleDescriptor(moduleRootPath, extensionInfo) {
 
     override var importStatus = ModuleDescriptorImportStatus.MANDATORY
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = emptySet<String>()
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = emptySet<String>()
 }

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YHacSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YHacSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -30,7 +30,7 @@ class YHacSubModuleDescriptor(
     override val subModuleDescriptorType: SubModuleDescriptorType = SubModuleDescriptorType.HAC,
 ) : AbstractYSubModuleDescriptor(owner, moduleRootPath) {
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = setOf(
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = setOf(
         owner.name,
         EiConstants.Extension.HAC + "." + EiConstants.Extension.WEB
     )

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YHmcSubModuleDescriptor.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YHmcSubModuleDescriptor.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -30,7 +30,7 @@ class YHmcSubModuleDescriptor(
     override val subModuleDescriptorType: SubModuleDescriptorType = SubModuleDescriptorType.HMC,
 ) : AbstractYSubModuleDescriptor(owner, moduleRootPath) {
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>) = setOf(
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>) = setOf(
         owner.name,
         EiConstants.Extension.HMC + "." + EiConstants.Extension.WEB
     )

--- a/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YRegularModuleDescriptorImpl.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/descriptor/impl/YRegularModuleDescriptorImpl.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -36,7 +36,7 @@ abstract class YRegularModuleDescriptorImpl protected constructor(
 
     override fun isPreselected() = isInLocalExtensions || isNeededDependency
 
-    override fun initDependencies(moduleDescriptors: Map<String, Collection<ModuleDescriptor>>): Set<String> = extensionInfo.requiredExtensions
+    override fun initDependencies(moduleDescriptors: Map<String, ModuleDescriptor>): Set<String> = extensionInfo.requiredExtensions
         .takeIf { it.isNotEmpty() }
         ?.map { it.name }
         ?.let { directRequiredExtensions ->

--- a/modules/project/import-core/src/sap/commerce/toolset/project/tasks/LookupModuleDescriptorsTask.kt
+++ b/modules/project/import-core/src/sap/commerce/toolset/project/tasks/LookupModuleDescriptorsTask.kt
@@ -20,11 +20,14 @@ package sap.commerce.toolset.project.tasks
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.platform.ide.progress.ModalTaskOwner
 import com.intellij.platform.ide.progress.runWithModalProgressBlocking
 import com.intellij.util.application
 import sap.commerce.toolset.exceptions.HybrisConfigurationException
 import sap.commerce.toolset.i18n
+import sap.commerce.toolset.localextensions.LocalExtensionsProcessor
+import sap.commerce.toolset.localextensions.context.FoundExtension
 import sap.commerce.toolset.project.context.ProjectImportContext
 import sap.commerce.toolset.project.descriptor.MainConfigModuleDescriptorResolver
 import sap.commerce.toolset.project.descriptor.ModuleDescriptorsCollector
@@ -41,12 +44,25 @@ class LookupModuleDescriptorsTask() {
         title = i18n("hybris.project.import.scanning"),
     ) {
         val foundModuleDescriptors = ModuleDescriptorsCollector.getInstance().collect(context)
-        val moduleDescriptors = ModuleDescriptorsDependenciesResolver.getInstance().resolve(foundModuleDescriptors)
+        val mainConfigModuleDescriptor = MainConfigModuleDescriptorResolver.getInstance().resolve(context, foundModuleDescriptors)
+
+        val platformDirectory = context.platformDistributionPath
+            ?: run { thisLogger().warn("Unable to preselect modules, platform directory is not detected"); return@runWithModalProgressBlocking }
+        val foundExtensions = foundModuleDescriptors
+            .map { FoundExtension(it.name, it.moduleRootPath) }
+
+        LocalExtensionsProcessor.getInstance().getContext(
+            mainConfigModuleDescriptor.moduleRootPath,
+            platformDirectory,
+            foundExtensions
+        )
+            ?.let { context.localExtensionsContext = it }
+            ?: return@runWithModalProgressBlocking
+
+        val moduleDescriptors = ModuleDescriptorsDependenciesResolver.getInstance().resolve(context, foundModuleDescriptors)
         moduleDescriptors.forEach { context.addModule(it) }
 
-        val mainConfigModuleDescriptor = MainConfigModuleDescriptorResolver.getInstance().resolve(context)
-
-        ModuleDescriptorsSelector.getInstance().preselect(context, mainConfigModuleDescriptor)
+        ModuleDescriptorsSelector.getInstance().preselect(context)
     }
 
     companion object {

--- a/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/SelectHybrisModulesStep.kt
+++ b/modules/project/import-ui/src/sap/commerce/toolset/project/wizard/SelectHybrisModulesStep.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -47,7 +47,7 @@ class SelectHybrisModulesStep(context: WizardContext) : AbstractSelectModulesSte
             if (element is YModuleDescriptor) {
                 if (isMarked) {
                     val elementMarkStates = fileChooser.elementMarkStates
-                    element.getAllDependencies()
+                    element.getRecursiveDependencies()
                         .filterNot { BooleanUtils.isNotFalse(elementMarkStates[it]) }
                         .forEach { fileChooser.setElementMarked(it, true) }
                 }

--- a/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
+++ b/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
@@ -26,6 +26,8 @@ import com.intellij.openapi.util.PropertiesUtil
 import com.intellij.util.application
 import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.extensioninfo.EiModelAccess
+import sap.commerce.toolset.localextensions.context.FoundExtension
+import sap.commerce.toolset.localextensions.context.LocalExtensionsContext
 import sap.commerce.toolset.localextensions.jaxb.Hybrisconfig
 import sap.commerce.toolset.util.directoryExists
 import sap.commerce.toolset.util.fileExists
@@ -36,27 +38,28 @@ import java.nio.file.Paths
 import kotlin.io.path.pathString
 
 @Service
-class LeExtensionsCollector {
+class LocalExtensionsProcessor {
 
-    suspend fun collect(
-        foundExtensions: Collection<LeExtension>,
+    suspend fun getContext(
         configDirectory: Path,
-        platformDirectory: Path
-    ): Map<String, LeExtension> = readAction {
+        platformDirectory: Path,
+        foundExtensions: List<FoundExtension>
+    ): LocalExtensionsContext? = readAction {
         val hybrisConfig = LeUnmarshaller.getInstance().unmarshal(configDirectory)
-            ?: return@readAction mapOf()
+            ?: return@readAction null
         val expandedProperties = getExpandedProperties(platformDirectory)
-            ?: return@readAction mapOf()
+            ?: return@readAction null
+
         val scanTypes = getScanTypes(hybrisConfig, expandedProperties)
             ?: run {
                 thisLogger().warn("No scan types defined in the localextensions.xml.")
-                return@readAction mapOf()
+                return@readAction null
             }
 
-        buildMap {
+        val extensions = buildMap {
             // declared via `path autoload="true"`
-            processAutoloadPaths(foundExtensions, scanTypes).forEach { leExtension ->
-                put(leExtension.name, leExtension)
+            processAutoloadPaths(foundExtensions, scanTypes).forEach { extension ->
+                put(extension.name, extension)
             }
 
             // declared via:
@@ -68,7 +71,27 @@ class LeExtensionsCollector {
                 }
             }
         }
+
+        LocalExtensionsContext(expandedProperties, scanTypes, extensions)
     }
+
+    /*
+    This method accepts several extensions of the same name and returns only 1,
+    which will be loaded according to the order logic defined by the scan types.
+    null returns if extension will not be loaded at all
+     */
+    fun getSuitableExtension(
+        foundExtensions: Collection<FoundExtension>,
+        context: LocalExtensionsContext,
+    ): FoundExtension? = context.scanTypes.values
+        .firstNotNullOfOrNull { scanType ->
+            foundExtensions.firstOrNull { extension ->
+                val moduleDir = extension.moduleRootPath.normalize().pathString
+                val scanTypeNormalizedPath = scanType.normalizedPath.pathString
+                moduleDir.startsWith(scanTypeNormalizedPath)
+                    && Paths.get(moduleDir.substring(scanTypeNormalizedPath.length)).nameCount <= scanType.depth
+            }
+        }
 
     private fun getScanTypes(
         hybrisConfig: Hybrisconfig,
@@ -104,24 +127,25 @@ class LeExtensionsCollector {
     }
 
     private fun processAutoloadPaths(
-        foundExtensions: Collection<LeExtension>,
+        foundExtensions: Collection<FoundExtension>,
         scanTypes: Map<String, ScanType>,
-    ): Collection<LeExtension> = scanTypes.values
+    ): Collection<LocalExtensionsContext.Extension> = scanTypes.values
         .filter { it.autoload }
         .takeIf { it.isNotEmpty() }
         ?.let { autoloadScanTypes ->
             foundExtensions.filter { extension ->
                 autoloadScanTypes.firstOrNull { scanType ->
-                    val moduleDir = extension.directory.normalize().pathString
+                    val moduleDir = extension.moduleRootPath.normalize().pathString
                     moduleDir.startsWith(scanType.normalizedPath.pathString)
                         && Paths.get(moduleDir.substring(scanType.dir.length)).nameCount <= scanType.depth
                 } != null
             }
         }
+        ?.map { LocalExtensionsContext.Extension(it.name, it.moduleRootPath) }
         ?: emptyList()
 
     private fun processExtensions(
-        foundExtensions: Collection<LeExtension>,
+        foundExtensions: Collection<FoundExtension>,
         scanTypes: Map<String, ScanType>,
         hybrisConfig: Hybrisconfig,
         expandedProperties: Map<String, String>,
@@ -144,15 +168,16 @@ class LeExtensionsCollector {
                     .filterNot { it.autoload }
                     .firstNotNullOfOrNull { scanType ->
                         suitableFoundExtensions.firstOrNull { extension ->
-                            val moduleDir = extension.directory.normalize().pathString
-                            moduleDir.startsWith(scanType.normalizedPath.pathString)
-                                && Paths.get(moduleDir.substring(scanType.dir.length)).nameCount <= scanType.depth
+                            val moduleDir = extension.moduleRootPath.normalize().pathString
+                            val scanTypeNormalizedPath = scanType.normalizedPath.pathString
+                            moduleDir.startsWith(scanTypeNormalizedPath)
+                                && Paths.get(moduleDir.substring(scanTypeNormalizedPath.length)).nameCount <= scanType.depth
                         }
                     }
-                    ?.directory
+                    ?.moduleRootPath
                 ?: return@mapNotNull null
 
-            LeExtension(extensionName, extensionPath)
+            LocalExtensionsContext.Extension(extensionName, extensionPath)
         }
 
     private fun String.toNormalizedPath(expandedProperties: Map<String, String>): Path {
@@ -190,6 +215,6 @@ class LeExtensionsCollector {
     }
 
     companion object {
-        fun getInstance(): LeExtensionsCollector = application.service()
+        fun getInstance(): LocalExtensionsProcessor = application.service()
     }
 }

--- a/modules/project/localextensions/src/sap/commerce/toolset/localextensions/context/LocalExtensionsContext.kt
+++ b/modules/project/localextensions/src/sap/commerce/toolset/localextensions/context/LocalExtensionsContext.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -16,11 +16,27 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package sap.commerce.toolset.localextensions
+package sap.commerce.toolset.localextensions.context
 
+import sap.commerce.toolset.localextensions.ScanType
 import java.nio.file.Path
 
-data class LeExtension(
+data class LocalExtensionsContext(
+    val expandedProperties: Map<String, String> = emptyMap(),
+    val scanTypes: Map<String, ScanType> = emptyMap(),
+    val extensions: Map<String, Extension> = emptyMap(),
+) {
+    data class Extension(
+        val name: String,
+        val path: Path,
+    )
+
+    companion object {
+        val EMPTY = LocalExtensionsContext()
+    }
+}
+
+data class FoundExtension(
     val name: String,
-    val directory: Path,
+    val moduleRootPath: Path,
 )


### PR DESCRIPTION
example:

`localextensions.xml`
```xml
<?xml version="1.0" encoding="UTF-8"?>
<hybrisconfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:noNamespaceSchemaLocation="../bin/platform/resources/schemas/extensions.xsd">
    <extensions>

        <path dir="/Users/Mykhailo_Lytvyn/Documents/projects/training_2211_48/instance/hybris/bin/_sap-commerce" autoload="false"/>
        <path dir='${HYBRIS_BIN_DIR}/modules/' autoload='false'/>
dir="/Users/Mykhailo_Lytvyn/Documents/projects/training_2211_48/instance/hybris/bin/_sap-commerce/nested/b2bacceleratoraddon"/>-->

        <extension dir="../_sap-commerce/trainingstorefront"/>
    </extensions>
</hybrisconfig>
```

`trainingstorefront` -> `extensioninfo.xml`
```xml
....
<requires-extension name="trainingfacades"/>
....
```

`trainingfacades ` -> `extensioninfo.xml`
```xml
....
<requires-extension name="b2bacceleratoraddon"/>
....
```

-----
Result -> properly preselected "custom" `b2bacceleratoraddon` due order of the scan types as defined in the `localextensions.xml`. When those scan paths are swapped, OOTB `b2bacceleratoraddon` will be preselected.

<img width="840" height="813" alt="image" src="https://github.com/user-attachments/assets/7ce2a985-7488-4222-afdf-f8054e90e15c" />
