### PR TITLE
Project Import | Check if file exists before generating `sha1` for maven coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [2026.0.14]
 
 <cite>Release contributors</code>
-- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.14+author%3Amlytvyn+is%3Apr)
+- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.14+author%3Amlytvyn+is%3Apr)
+
+### `Project Import` enhancements
+- Check if file exists before generating `sha1` for maven coordinates [#1941](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1941)
 
 ### Other enhancements
 - Migrated obsolete `invokeLater` to `runInEdt` [#1940](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1940)

--- a/TECH_NOTES.md
+++ b/TECH_NOTES.md
@@ -39,6 +39,13 @@ project.directory
 PathMacroManager.getInstance(project).expandPath("\$PROJECT_DIR$")
 ```
 
+### Do not init plugin extensions
+```kotlin
+init {
+    if (project.isNotHybrisProject) throw ExtensionNotApplicableException.create()
+}
+```
+
 ### Invoke AnAction
 
 ```kotlin

--- a/modules/java/core/src/sap/commerce/toolset/java/jarFinder/LibraryRootLookupService.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/jarFinder/LibraryRootLookupService.kt
@@ -31,6 +31,7 @@ import com.intellij.util.io.HttpRequests
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import sap.commerce.toolset.util.fileExists
 import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
@@ -81,7 +82,11 @@ class LibraryRootLookupService {
     private suspend fun getExternalMavenCoords(libraryJar: VirtualFile): SolrMavenArtifactCoords? {
         checkCanceled()
 
-        val sha1 = libraryJar.toNioPath().toFile().sha1()
+        val sha1 = libraryJar.toNioPath()
+            .takeIf { it.fileExists }
+            ?.toFile()
+            ?.sha1()
+            ?: return null
         val url = "https://central.sonatype.com/solrsearch/select?rows=1&wt=json&q=1:$sha1"
 
         try {


### PR DESCRIPTION
addresses:

```
com.intellij.openapi.diagnostic.UnhandledException: CXCOMM2211/hybris/bin/platform/lib/dbdriver/postgresql-42.6.2.jar (No such file or directory)
	at com.intellij.openapi.application.impl.ExceptionsKt.processUnhandledException(exceptions.kt:55)
	at com.intellij.openapi.application.impl.CoroutineExceptionHandlerImpl.handleException(CoroutineExceptionHandlerImpl.kt:27)
	at kotlinx.coroutines.internal.CoroutineExceptionHandlerImpl_commonKt.handleUncaughtCoroutineException(CoroutineExceptionHandlerImpl.common.kt:34)
	at kotlinx.coroutines.CoroutineExceptionHandlerKt.handleCoroutineException(CoroutineExceptionHandler.kt:31)
	at kotlinx.coroutines.StandaloneCoroutine.handleJobException(Builders.common.kt:192)
	at kotlinx.coroutines.JobSupport.finalizeFinishingState(JobSupport.kt:229)
	at kotlinx.coroutines.JobSupport.tryMakeCompletingSlowPath(JobSupport.kt:953)
	at kotlinx.coroutines.JobSupport.tryMakeCompleting(JobSupport.kt:901)
	at kotlinx.coroutines.JobSupport.makeCompletingOnce$kotlinx_coroutines_core(JobSupport.kt:866)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:99)
	at kotlinx.coroutines.debug.internal.DebugProbesImpl$CoroutineOwner.resumeWith(DebugProbesImpl.kt:545)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:36)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:101)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:36)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:101)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
	at kotlinx.coroutines.UndispatchedCoroutine.afterResume(CoroutineContext.kt:277)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:101)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:36)
	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:101)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:47)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:98)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:610)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runDefaultDispatcherTask(CoroutineScheduler.kt:1194)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:906)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:775)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:762)
Caused by: java.io.FileNotFoundException: CXCOMM2211/hybris/bin/platform/lib/dbdriver/postgresql-42.6.2.jar (No such file or directory)
	at java.base/java.io.IoOverNioFileSystem.convertNioToIoExceptionInStreams(IoOverNioFileSystem.java:123)
	at java.base/java.io.IoOverNioFileSystem.initializeStreamsUsingNio0(IoOverNioFileSystem.java:375)
	at java.base/java.io.IoOverNioFileSystem.initializeStreamUsingNio(IoOverNioFileSystem.java:342)
	at java.base/java.io.FileInputStream.<init>(FileInputStream.java:163)
	at sap.commerce.toolset.java.jarFinder.LibraryRootLookupService.sha1(LibraryRootLookupService.kt:205)
	at sap.commerce.toolset.java.jarFinder.LibraryRootLookupService.getExternalMavenCoords(LibraryRootLookupService.kt:84)
	at sap.commerce.toolset.java.jarFinder.LibraryRootLookupService.findJarUrls(LibraryRootLookupService.kt:65)
	at sap.commerce.toolset.java.jarFinder.LibraryRootLookupService$findJarUrls$1.invokeSuspend(LibraryRootLookupService.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	... 6 more
	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelled}@4615e223, Dispatchers.Default]
Caused by: java.nio.file.NoSuchFileException: CXCOMM2211/hybris/bin/platform/lib/dbdriver/postgresql-42.6.2.jar
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:108)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:114)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:213)
	at com.intellij.platform.core.nio.fs.DelegatingFileSystemProvider.newFileChannel(DelegatingFileSystemProvider.java:97)
	at java.base/java.io.IoOverNioFileSystem.initializeStreamsUsingNio0(IoOverNioFileSystem.java:357)
	... 13 more
```