### PR TITLE
AI | Expose type system Atomic types as MCP tool (name/extension filters, JSON)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <cite>Release contributors</code>
 - 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.14+author%3Amlytvyn+is%3Apr)
-- 4 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.14+author%3Aekalenchuk+is%3Apr)
+- 5 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.14+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
 - Check if file exists before generating `sha1` for maven coordinates [#1941](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1941)
@@ -12,6 +12,7 @@
 - Reject HAC connections with Manual authentication in logger MCP tools [#1943](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1943)
 - Add an optional logger-name filter (regex or substring) to list loggers tool [#1944](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1944)
 - Expose type system Item types as MCP tool (name/extension filters, TYPES/ATTRIBUTES/FULL detail) [#1945](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1945)
+- Expose type system Atomic types as MCP tool (name/extension filters, JSON) [#1946](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1946)
 
 ### Other enhancements
 - Migrated obsolete `invokeLater` to `runInEdt` [#1940](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1940)

--- a/modules/ai/mcp/src/sap/commerce/toolset/ai/mcp/TypeSystemMcpToolset.kt
+++ b/modules/ai/mcp/src/sap/commerce/toolset/ai/mcp/TypeSystemMcpToolset.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.serialization.json.*
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelStateService
+import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaAtomic
 import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaItem
 import sap.commerce.toolset.typeSystem.meta.model.TSMetaPersistence
 import sap.commerce.toolset.typeSystem.meta.model.TSMetaType

--- a/modules/ai/mcp/src/sap/commerce/toolset/ai/mcp/TypeSystemMcpToolset.kt
+++ b/modules/ai/mcp/src/sap/commerce/toolset/ai/mcp/TypeSystemMcpToolset.kt
@@ -83,13 +83,7 @@ class TypeSystemMcpToolset : McpToolset {
 
         val normalizedFilter = filter?.trim()?.takeIf { it.isNotEmpty() }
         val matcher = normalizedFilter?.let { regexOrContainsMatcher(it) }
-
-        val extensionFilter = extensions
-            ?.split(',')
-            ?.map { it.trim().lowercase() }
-            ?.filter { it.isNotEmpty() }
-            ?.toSet()
-            ?.takeIf { it.isNotEmpty() }
+        val extensionFilter = parseExtensionFilter(extensions)
 
         ensureTypeSystemReady(project)
 
@@ -115,6 +109,73 @@ class TypeSystemMcpToolset : McpToolset {
 
         return json.encodeToString(JsonObject.serializer(), payload)
     }
+
+    @McpTool(name = "sap_commerce_list_atomic_types")
+    @McpDescription(
+        """Lists the Atomic types defined in the current project's SAP Commerce (Hybris) type system, as shown in the "Type System" tool window.
+        |Atomic types are the primitive/scalar building blocks (e.g. 'java.lang.String', 'java.lang.Boolean', 'java.util.Date'); their name and 'extends' are fully-qualified Java class names.
+        |This is the project's LOCAL model, parsed from the `*-items.xml` definitions — it does NOT query a remote server and does NOT require a HAC connection.
+        |Returns a JSON object: {"filter", "extensions", "matched", "total", "atomicTypes": [{"name", "extends", "extension", "custom", "autoCreate", "generate"}]}. Boolean flags are present only when true and omitted otherwise.
+        |Use 'filter' (by name) and/or 'extensions' (by owning extension) to narrow the result and keep the response (and token usage) small."""
+    )
+    suspend fun listAtomicTypes(
+        @McpDescription(
+            """Optional atomic-type-name filter used to shrink the response and save tokens.
+            |If the value is a valid regular expression it is matched against each atomic type name with a regex search (e.g. '^java\.lang\.' or '(?i)date'); otherwise it is treated as a plain, case-insensitive substring ('contains').
+            |Omit to return all atomic types."""
+        )
+        filter: String? = null,
+        @McpDescription(
+            """Optional comma-separated list of extension names to restrict the result to atomic types owned by those extensions (e.g. 'core,basecommerce').
+            |Matched case-insensitively and exactly against each atomic type's owning 'extension'. Combined with 'filter' using AND (both must match).
+            |Omit to include atomic types from all extensions."""
+        )
+        extensions: String? = null,
+    ): String {
+        val project = currentCoroutineContext().mcpProject
+
+        val normalizedFilter = filter?.trim()?.takeIf { it.isNotEmpty() }
+        val matcher = normalizedFilter?.let { regexOrContainsMatcher(it) }
+        val extensionFilter = parseExtensionFilter(extensions)
+
+        ensureTypeSystemReady(project)
+
+        val payload = readAction {
+            val allAtomics = TSMetaModelAccess.getInstance(project).getAll<TSGlobalMetaAtomic>(TSMetaType.META_ATOMIC)
+            val matched = allAtomics
+                .filter { atomic -> matcher?.invoke(atomic.name) ?: true }
+                .filter { atomic -> extensionFilter == null || atomic.extensionName.lowercase() in extensionFilter }
+                .sortedBy { it.name }
+
+            buildJsonObject {
+                normalizedFilter?.let { put("filter", it) }
+                extensionFilter?.let { exts -> putJsonArray("extensions") { exts.sorted().forEach { add(it) } } }
+                put("matched", matched.size)
+                put("total", allAtomics.size)
+                putJsonArray("atomicTypes") {
+                    matched.forEach { add(atomicTypeJson(it)) }
+                }
+            }
+        }
+
+        return json.encodeToString(JsonObject.serializer(), payload)
+    }
+
+    private fun atomicTypeJson(atomic: TSGlobalMetaAtomic): JsonObject = buildJsonObject {
+        put("name", atomic.name)
+        atomic.extends.takeIf { it.isNotBlank() }?.let { put("extends", it) }
+        atomic.extensionName.takeIf { it.isNotBlank() }?.let { put("extension", it) }
+        if (atomic.isCustom) put("custom", true)
+        if (atomic.isAutoCreate) put("autoCreate", true)
+        if (atomic.isGenerate) put("generate", true)
+    }
+
+    private fun parseExtensionFilter(extensions: String?): Set<String>? = extensions
+        ?.split(',')
+        ?.map { it.trim().lowercase() }
+        ?.filter { it.isNotEmpty() }
+        ?.toSet()
+        ?.takeIf { it.isNotEmpty() }
 
     private fun itemTypeJson(item: TSGlobalMetaItem, detail: ItemTypeDetail): JsonObject = buildJsonObject {
         put("name", item.name!!)


### PR DESCRIPTION
### List atomic types
<img width="1009" height="449" alt="image" src="https://github.com/user-attachments/assets/4a0d0438-45a9-49b5-adc4-90e67d5d24f2" />

### List atomic types defined in the "commerceservices" extension
<img width="894" height="236" alt="image" src="https://github.com/user-attachments/assets/f0efd09a-1506-4617-9cf6-aa37a878c734" />

### List atomic types with "java.lang" package:
<img width="827" height="336" alt="image" src="https://github.com/user-attachments/assets/801dc87c-155c-4dee-9068-242045c92812" />

