### PR TITLE
ImpEx | Hide `ImpEx to FlexibleSearch` for statements with unique docId columns

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GitSharedSettings">
+    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
+      <list />
+    </option>
+  </component>
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="GitSharedSettings">
-    <option name="FORCE_PUSH_PROHIBITED_PATTERNS">
-      <list />
-    </option>
-  </component>
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.15]
 
 <cite>Release contributors</code>
-- 4 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
+- 5 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
 - 5 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
@@ -16,6 +16,9 @@
 
 ### `ImpEx` enhancements
 - Copy ImpEx value line into an executable FlexibleSearch query [#1960](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1960)
+- Hide `ImpEx to FlexibleSearch` for statements with unique docId columns [#1963](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1963)
+
+### `FlexibleSearch` enhancements
 - New action to `Introduce Bind Parameters` for query with exact values in the expressions [#1962](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1962)
 
 ### Other enhancements

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/daemon/ImpExToFlexibleSearchLineMarkerProvider.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInsight/daemon/ImpExToFlexibleSearchLineMarkerProvider.kt
@@ -27,12 +27,14 @@ import com.intellij.openapi.editor.markup.MarkupEditorFilter
 import com.intellij.openapi.editor.markup.MarkupEditorFilterFactory
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.childrenOfType
 import com.intellij.psi.util.firstLeaf
 import com.intellij.psi.util.parentOfType
 import com.intellij.util.Function
 import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.HybrisIcons
 import sap.commerce.toolset.Notifications
+import sap.commerce.toolset.impex.psi.ImpExDocumentIdUsage
 import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
 import sap.commerce.toolset.impex.psi.ImpExValueLine
 import sap.commerce.toolset.scratch.createScratchFile
@@ -48,12 +50,21 @@ class ImpExToFlexibleSearchLineMarkerProvider : LineMarkerProvider {
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         if (element !is ImpExValueLine) return null
+        if (element.headerLine?.uniqueFullHeaderParameters?.any { it.hasDocIdQualifier() } == true) return null
 
         return ImpExLineMarkerInfo(
             element.firstLeaf(),
             HybrisIcons.ImpEx.Actions.COPY_TO_FLEXIBLE_SEARCH
         )
     }
+
+    private fun ImpExFullHeaderParameter.hasDocIdQualifier(): Boolean = parametersList
+        .firstOrNull()
+        ?.parameterList
+        ?.takeIf { it.size == 1 }
+        ?.firstOrNull()
+        ?.childrenOfType<ImpExDocumentIdUsage>()
+        ?.firstOrNull() != null
 
     /**
      * Builds a FlexibleSearch SELECT with JOINs, resolving qualifier columns


### PR DESCRIPTION
<img width="925" height="507" alt="Screenshot 2026-07-15 at 20 24 52" src="https://github.com/user-attachments/assets/7c46100b-b55f-4f32-8aab-74757b6569e5" />
