### PR TITLE
FlexibleSearch | Support `IN`, `BETWEEN`, `DATE` expressions in the `Introduce Bind Parameters` action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <cite>Release contributors</code>
 - 7 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
-- 8 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Aekalenchuk+is%3Apr)
+- 9 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
 - Preselect recursive modules on project import [#1951](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1951)
@@ -25,6 +25,7 @@
 
 ### `FlexibleSearch` enhancements
 - New action to `Introduce Bind Parameters` for query with exact values in the expressions [#1962](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1962)
+- Support `IN`, `BETWEEN`, `DATE` expressions in the `Introduce Bind Parameters` action [#1966](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1966)
 
 ### Other enhancements
 - Updated project libraries [#1955](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1955)

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchVirtualParameter.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchVirtualParameter.kt
@@ -92,10 +92,27 @@ data class FlexibleSearchVirtualParameter(
                     .split("\n")
                     .map { it.trim() }
                     .filter { it.isNotBlank() }
-                    .joinToString(",")
-                else plainValue
+                    .joinToString(",") { toSqlLiteral(it) }
+                else toSqlLiteral(plainValue)
             }
             ?: ""
+    }
+
+    // untyped values: emit numbers and booleans as-is, quote everything else to keep the SQL valid
+    private fun toSqlLiteral(value: String): String = when {
+        value.toBigDecimalOrNull() != null -> value
+        value.equals("true", ignoreCase = true) || value.equals("false", ignoreCase = true) -> value
+        else -> "'${value.replace("'", "''")}'"
+    }
+
+    private fun coerceRawValue(value: Any?): Any? {
+        val stringValue = value?.asSafely<String>() ?: return value
+
+        return when (type) {
+            Boolean::class -> stringValue == "1" || stringValue.equals("true", ignoreCase = true)
+            Date::class -> parseDate(stringValue) ?: value
+            else -> value
+        }
     }
 
     private fun evaluatePresentationValue(): String = when (type) {
@@ -113,6 +130,8 @@ data class FlexibleSearchVirtualParameter(
 
         const val DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSS"
 
+        private val PARSE_DATE_FORMATS = listOf(DATE_FORMAT, "yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd")
+
         fun of(bindParameter: FlexibleSearchBindParameter, currentParameters: Map<String, FlexibleSearchVirtualParameter>) = of(
             bindParameter = bindParameter,
             rawValue = currentParameters[bindParameter.value]?.rawValue
@@ -123,7 +142,11 @@ data class FlexibleSearchVirtualParameter(
             operand = bindParameter.expression?.elementType,
             rawType = bindParameter.itemType,
         ).apply {
-            this.rawValue = rawValue
+            this.rawValue = coerceRawValue(rawValue)
+        }
+
+        private fun parseDate(value: String): Date? = PARSE_DATE_FORMATS.firstNotNullOfOrNull { format ->
+            runCatching { SimpleDateFormat(format).apply { isLenient = false }.parse(value) }.getOrNull()
         }
     }
 }

--- a/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/psi/impl/FlexibleSearchBindParameterMixin.kt
+++ b/modules/flexibleSearch/core/src/sap/commerce/toolset/flexibleSearch/psi/impl/FlexibleSearchBindParameterMixin.kt
@@ -51,7 +51,7 @@ abstract class FlexibleSearchBindParameterMixin(node: ASTNode) : ASTWrapperPsiEl
         ?.asSafely<FlexibleSearchExpression>()
 
     override fun getItemType(): String? = expression
-        ?.let { PsiTreeUtil.getChildOfType(it, FlexibleSearchColumnRefYExpression::class.java) }
+        ?.let { PsiTreeUtil.findChildOfType(it, FlexibleSearchColumnRefYExpression::class.java) }
         ?.let { PsiTreeUtil.getChildOfType(it, FlexibleSearchYColumnName::class.java) }
         ?.reference
         ?.asSafely<FxSYColumnReference>()

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchEditorService.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/editor/FlexibleSearchEditorService.kt
@@ -23,8 +23,11 @@ import com.intellij.openapi.application.readAction
 import com.intellij.openapi.command.writeCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.asSafely
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -32,6 +35,7 @@ import kotlinx.coroutines.withContext
 import sap.commerce.toolset.Notifications
 import sap.commerce.toolset.flexibleSearch.psi.*
 import sap.commerce.toolset.i18n
+import sap.commerce.toolset.typeSystem.meta.TSMetaModelStateService
 
 @Service(Service.Level.PROJECT)
 class FlexibleSearchEditorService(
@@ -43,58 +47,45 @@ class FlexibleSearchEditorService(
         coroutineScope.launch {
             if (project.isDisposed) return@launch
 
-            // Phase 1: collect literal expressions, create seed virtual parameters with original values
-            val usedNames = mutableMapOf<String, Int>()
-            val bindParameters = readAction {
-                PsiTreeUtil.collectElementsOfType(psiFile, FlexibleSearchLiteralExpression::class.java)
-                    .filter { it.bindParameter == null }
-                    .sortedBy { it.textOffset }
-                    .map {
-                        BindParameter(
-                            literal = it,
-                            name = resolveBindParamName(it, usedNames),
-                            rawValue = extractLiteralValue(it)
-                        )
-                    }
+            // Phase 1: collect replacements and seed named parameters with original values
+            val collected = readAction { collectReplacements(psiFile) }
+
+            if (collected.replacements.isEmpty()) {
+                Notifications
+                    .info(
+                        i18n("hybris.fxs.actions.introduce_bind_parameters"),
+                        i18n("hybris.fxs.actions.introduce_bind_parameters.no_literals")
+                    )
+                    .hideAfter(10)
+                    .notify(project)
+                return@launch
             }
-                .takeIf { it.isNotEmpty() }
-                ?.sortedByDescending { it.literal.textOffset }
-                ?: run {
-                    Notifications
-                        .info(
-                            i18n("hybris.fxs.actions.introduce_bind_parameters"),
-                            i18n("hybris.fxs.actions.introduce_bind_parameters.no_literals")
-                        )
-                        .hideAfter(10)
-                        .notify(project)
-                    return@launch
-                }
 
             // Phase 2: replace literals with bind parameters (undoable)
-            val newVirtualParameters = writeCommandAction(project, i18n("hybris.fxs.actions.introduce_bind_parameters")) {
-                bindParameters
-                    .filter { it.literal.isValid }
-                    .mapNotNull { currentBindParameter ->
-                        val newBindParameter = FlexibleSearchElementFactory.createBindParameterLiteral(project, currentBindParameter.name)
-                            ?: return@mapNotNull null
-
-                        currentBindParameter.literal.replace(newBindParameter)
-                        currentBindParameter.name to FlexibleSearchVirtualParameter.of(newBindParameter, currentBindParameter.rawValue)
-                    }
-                    .toMap()
+            val appliedParameterNames = writeCommandAction(project, i18n("hybris.fxs.actions.introduce_bind_parameters")) {
+                collected.replacements
+                    .sortedByDescending { it.anchorOffset }
+                    .mapNotNull { applyReplacement(it) }
+                    .toSet()
             }
 
-            // Phase 3: build seed map, then create proper instances via of() — picks up operand/rawType from
-            // actual bind parameter PSI; existing user-entered values take priority over seeds
-            val existingVirtualParameters = splitEditor.virtualParameters ?: emptyMap()
-            val mergedVirtualParameters = existingVirtualParameters + newVirtualParameters
+            val newVirtualParameters = collected.parameters
+                .filterKeys { it in appliedParameterNames }
+                .mapValues { (_, seed) ->
+                    FlexibleSearchVirtualParameter(
+                        name = seed.name,
+                        operand = seed.operand,
+                    ).apply { rawValue = seed.rawValue }
+                }
 
-            splitEditor.virtualParameters = readAction {
+            // Phase 3: re-create parameters from actual bind parameter PSI — picks up operand/rawType via the
+            // Type System meta model, so only when it is ready; existing user-entered values take priority over seeds
+            val mergedVirtualParameters = (splitEditor.virtualParameters ?: emptyMap()) + newVirtualParameters
+
+            splitEditor.virtualParameters = if (isTypeSystemInitialized()) readAction {
                 PsiTreeUtil.collectElementsOfType(psiFile, FlexibleSearchBindParameter::class.java)
-                    .associate { bindParam ->
-                        bindParam.value to FlexibleSearchVirtualParameter.of(bindParam, mergedVirtualParameters)
-                    }
-            }
+                    .associate { it.value to FlexibleSearchVirtualParameter.of(it, mergedVirtualParameters) }
+            } else mergedVirtualParameters
 
             // Phase 4: open (or refresh) the In-Editor Virtual Parameters panel
             withContext(Dispatchers.EDT) {
@@ -107,12 +98,71 @@ class FlexibleSearchEditorService(
         }
     }
 
-    private fun resolveBindParamName(literal: FlexibleSearchLiteralExpression, usedNames: MutableMap<String, Int>): String {
-        val baseName = extractColumnName(literal) ?: "param"
-        val count = usedNames.getOrDefault(baseName, 0)
-        usedNames[baseName] = count + 1
-        return if (count == 0) baseName else "$baseName$count"
+    private fun collectReplacements(psiFile: FlexibleSearchPsiFile): CollectedReplacements {
+        val inListCollapses = PsiTreeUtil.collectElementsOfType(psiFile, FlexibleSearchInExpression::class.java)
+            .mapNotNull { collapsibleInList(it) }
+        val collapseByFirstLiteral = inListCollapses.associateBy { it.literals.first() }
+        val collapsedLiterals = inListCollapses.flatMapTo(hashSetOf()) { it.literals }
+        val betweenBaseNames = collectBetweenBaseNames(psiFile)
+
+        val collected = CollectedReplacements()
+
+        PsiTreeUtil.collectElementsOfType(psiFile, FlexibleSearchLiteralExpression::class.java)
+            .filter { it.bindParameter == null }
+            .sortedBy { it.textOffset }
+            .forEach { literal ->
+                val collapse = collapseByFirstLiteral[literal]
+                when {
+                    collapse != null -> collected.addInListReplacement(collapse)
+                    literal in collapsedLiterals -> Unit
+                    else -> collected.addLiteralReplacement(
+                        literal = literal,
+                        baseName = betweenBaseNames[literal] ?: extractColumnName(literal) ?: FALLBACK_BASE_NAME,
+                        rawValue = extractLiteralValue(literal),
+                    )
+                }
+            }
+
+        return collected
     }
+
+    private fun collapsibleInList(expression: FlexibleSearchInExpression): InListCollapse? {
+        if (expression.selectSubqueryCombinedList.isNotEmpty() || expression.bindParameterList.isNotEmpty()) return null
+
+        val operands = expression.expressionList
+        val literals = operands.drop(1)
+            .filterIsInstance<FlexibleSearchLiteralExpression>()
+            .takeIf { it.isNotEmpty() && it.size == operands.size - 1 && it.all { literal -> literal.bindParameter == null } }
+            ?: return null
+        val values = literals.mapNotNull { extractLiteralValue(it) }
+            .takeIf { it.size == literals.size }
+            ?: return null
+
+        return InListCollapse(
+            inExpression = expression,
+            literals = literals,
+            baseName = findColumnRef(operands.take(1))?.columnRefName() ?: FALLBACK_BASE_NAME,
+            rawValue = values.joinToString("\n"),
+        )
+    }
+
+    private fun collectBetweenBaseNames(psiFile: FlexibleSearchPsiFile): Map<FlexibleSearchLiteralExpression, String> = PsiTreeUtil
+        .collectElementsOfType(psiFile, FlexibleSearchBetweenExpression::class.java)
+        .mapNotNull { expression ->
+            expression.expressionList
+                .filterIsInstance<FlexibleSearchLiteralExpression>()
+                .filter { it.bindParameter == null }
+                .takeIf { it.size == 2 }
+                ?.let { literals ->
+                    val baseName = findColumnRef(expression.expressionList)?.columnRefName() ?: FALLBACK_BASE_NAME
+                    listOf(
+                        literals[0] to "${baseName}_from",
+                        literals[1] to "${baseName}_to",
+                    )
+                }
+        }
+        .flatten()
+        .toMap()
 
     private fun extractColumnName(literal: FlexibleSearchLiteralExpression): String? {
         val columnExpr = when (val parent = literal.parent) {
@@ -120,32 +170,31 @@ class FlexibleSearchEditorService(
             is FlexibleSearchComparisonExpression -> findColumnRef(parent.expressionList)
             is FlexibleSearchLikeExpression -> findColumnRef(parent.expressionList)
             is FlexibleSearchInExpression -> findColumnRef(parent.expressionList)
+            is FlexibleSearchBetweenExpression -> findColumnRef(parent.expressionList)
             else -> null
         }
         return columnExpr?.columnRefName()
     }
 
     private fun findColumnRef(expressions: List<FlexibleSearchExpression>): FlexibleSearchExpression? = expressions
-        .filterIsInstance<FlexibleSearchColumnRefYExpression>().firstOrNull()
-        ?: expressions.filterIsInstance<FlexibleSearchColumnRefExpression>().firstOrNull()
+        .firstNotNullOfOrNull { expression ->
+            expression.asSafely<FlexibleSearchColumnRefYExpression>()
+                ?: PsiTreeUtil.findChildOfType(expression, FlexibleSearchColumnRefYExpression::class.java)
+                ?: expression.asSafely<FlexibleSearchColumnRefExpression>()
+                ?: PsiTreeUtil.findChildOfType(expression, FlexibleSearchColumnRefExpression::class.java)
+        }
 
     private fun FlexibleSearchExpression.columnRefName(): String? = when (this) {
-        is FlexibleSearchColumnRefYExpression -> {
-            val alias = selectedTableName?.name
-            val column = yColumnName?.text
-            if (alias != null && column != null) "${alias}_$column"
-            else column
-        }
-
-        is FlexibleSearchColumnRefExpression -> {
-            val alias = selectedTableName?.name
-            val column = columnName?.name
-            if (alias != null && column != null) "${alias}_$column"
-            else column
-        }
-
+        is FlexibleSearchColumnRefYExpression -> toBindParameterName(selectedTableName?.text, yColumnName?.text)
+        is FlexibleSearchColumnRefExpression -> toBindParameterName(selectedTableName?.text, columnName?.text)
         else -> null
     }
+
+    private fun toBindParameterName(tableAlias: String?, columnName: String?): String? = listOfNotNull(tableAlias, columnName)
+        .joinToString("_")
+        .map { if (it.isLetterOrDigit()) it else '_' }
+        .joinToString("")
+        .takeIf { it.isNotBlank() }
 
     private fun extractLiteralValue(literal: FlexibleSearchLiteralExpression): String? {
         val singleQuote = literal.singleQuoteStringLiteral
@@ -170,13 +219,110 @@ class FlexibleSearchEditorService(
         }
     }
 
-    private data class BindParameter(
-        val literal: FlexibleSearchLiteralExpression,
+    private fun applyReplacement(replacement: Replacement): String? = when (replacement) {
+        is LiteralReplacement -> replaceLiteral(replacement)
+        is InListReplacement -> replaceInList(replacement)
+    }
+
+    private fun replaceLiteral(replacement: LiteralReplacement): String? {
+        val literal = replacement.literal.takeIf { it.isValid } ?: return null
+        val newBindParameter = FlexibleSearchElementFactory.createBindParameterLiteral(project, replacement.parameter.name)
+            ?: return null
+
+        literal.replace(newBindParameter)
+        return replacement.parameter.name
+    }
+
+    private fun replaceInList(replacement: InListReplacement): String? {
+        val literals = replacement.literals.takeIf { all -> all.all { it.isValid } } ?: return null
+        val inExpression = replacement.inExpression.takeIf { it.isValid } ?: return null
+        val newBindParameter = FlexibleSearchElementFactory.createBindParameterLiteral(project, replacement.parameter.name)
+            ?: return null
+
+        // collapse `IN ('a', 'b', 'c')` into `IN (?param)`: drop everything after the first literal
+        // (commas, whitespace and remaining literals are all direct children of the IN expression),
+        // then swap the still-valid first literal for the bind parameter
+        if (literals.size > 1) {
+            inExpression.deleteChildRange(literals.first().nextSibling, literals.last())
+        }
+        literals.first().replace(newBindParameter)
+        return replacement.parameter.name
+    }
+
+    private fun isTypeSystemInitialized(): Boolean = !project.isDisposed
+        && !DumbService.isDumb(project)
+        && TSMetaModelStateService.getInstance(project).initialized()
+
+    private data class ParameterSeed(
         val name: String,
         val rawValue: String?,
+        val operand: IElementType? = null,
     )
 
+    private sealed interface Replacement {
+        val anchorOffset: Int
+        val parameter: ParameterSeed
+    }
+
+    private data class LiteralReplacement(
+        val literal: FlexibleSearchLiteralExpression,
+        override val anchorOffset: Int,
+        override val parameter: ParameterSeed,
+    ) : Replacement
+
+    private data class InListReplacement(
+        val inExpression: FlexibleSearchInExpression,
+        val literals: List<FlexibleSearchLiteralExpression>,
+        override val anchorOffset: Int,
+        override val parameter: ParameterSeed,
+    ) : Replacement
+
+    private data class InListCollapse(
+        val inExpression: FlexibleSearchInExpression,
+        val literals: List<FlexibleSearchLiteralExpression>,
+        val baseName: String,
+        val rawValue: String,
+    )
+
+    private class CollectedReplacements {
+
+        val replacements = mutableListOf<Replacement>()
+        val parameters = linkedMapOf<String, ParameterSeed>()
+
+        fun addLiteralReplacement(literal: FlexibleSearchLiteralExpression, baseName: String, rawValue: String?) {
+            replacements += LiteralReplacement(
+                literal = literal,
+                anchorOffset = literal.textOffset,
+                parameter = resolveParameter(baseName, rawValue),
+            )
+        }
+
+        fun addInListReplacement(collapse: InListCollapse) {
+            replacements += InListReplacement(
+                inExpression = collapse.inExpression,
+                literals = collapse.literals,
+                anchorOffset = collapse.literals.first().textOffset,
+                parameter = resolveParameter(collapse.baseName, collapse.rawValue, FlexibleSearchTypes.IN_EXPRESSION),
+            )
+        }
+
+        // same base name + same value -> reuse the parameter, so one input drives all occurrences;
+        // NULL values never merge — each occurrence keeps its own parameter
+        private fun resolveParameter(baseName: String, rawValue: String?, operand: IElementType? = null): ParameterSeed {
+            var name = baseName
+            var index = 0
+            while (true) {
+                val existing = parameters[name] ?: break
+                if (rawValue != null && existing.rawValue == rawValue && existing.operand == operand) return existing
+                name = "$baseName${++index}"
+            }
+            return ParameterSeed(name, rawValue, operand).also { parameters[name] = it }
+        }
+    }
+
     companion object {
+        private const val FALLBACK_BASE_NAME = "param"
+
         fun getInstance(project: Project): FlexibleSearchEditorService = project.service()
     }
 }


### PR DESCRIPTION
<img width="2554" height="880" alt="image" src="https://github.com/user-attachments/assets/2122ed8e-5c70-47b4-8d89-434278b92245" />
<img width="1111" height="199" alt="image" src="https://github.com/user-attachments/assets/92f4d899-41cc-4c94-aa54-0fe664dc3b10" />
<img width="1881" height="236" alt="image" src="https://github.com/user-attachments/assets/6276c494-7b94-4fb0-8e4f-002b6eca6269" />

