### PR TITLE
ImpEx | Show resolved value of the possible external macro in the data cell inlay hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Support complex nested parameters in the `ImpEx to FlexibleSearch` logic [#1965](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1965)
 - Resolve references to macros possible defined in the external ImpEx files imported via `impex.includeExtenalData` [#1967](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1967)
 - Show resolved value of the possible external macro as folded region [#1968](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1968)
+- Show resolved value of the possible external macro in the data cell inlay hint [#1969](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1969)
 
 ### `FlexibleSearch` enhancements
 - New action to `Introduce Bind Parameters` for query with exact values in the expressions [#1962](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1962)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.15]
 
 <cite>Release contributors</code>
-- 9 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
+- 10 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
 - 8 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements

--- a/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExLanguageIsNotSupportedInspection.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/codeInspection/ImpExLanguageIsNotSupportedInspection.kt
@@ -25,10 +25,7 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.asSafely
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.impex.constants.modifier.AttributeModifier
-import sap.commerce.toolset.impex.psi.ImpExAnyAttributeName
-import sap.commerce.toolset.impex.psi.ImpExAnyAttributeValue
-import sap.commerce.toolset.impex.psi.ImpExMacroUsageDec
-import sap.commerce.toolset.impex.psi.ImpExVisitor
+import sap.commerce.toolset.impex.psi.*
 import sap.commerce.toolset.project.PropertyService
 
 class ImpExLanguageIsNotSupportedInspection : LocalInspectionTool() {
@@ -44,6 +41,8 @@ class ImpExLanguageIsNotSupportedInspection : LocalInspectionTool() {
             val language = psi.firstChild.asSafely<ImpExMacroUsageDec>()
                 ?.resolveValue(HashSet())
                 ?.trim()
+                ?: psi.firstChild.asSafely<ImpExPossibleMacroUsageDec>()
+                    ?.resolveValue()
                 ?: psi.text
 
             val propertyService = PropertyService.getInstance(psi.project)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExFullHeaderParameterMixin.kt
@@ -189,6 +189,7 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
                 ?.joinToString("") {
                     when (it) {
                         is ImpExMacroUsageDec -> it.resolveValue(HashSet())
+                        is ImpExPossibleMacroUsageDec -> it.resolveValue()
                         else -> it.text
                     }
                 }
@@ -240,6 +241,9 @@ abstract class ImpExFullHeaderParameterMixin(node: ASTNode) : ASTWrapperPsiEleme
                     ?.joinToString("") {
                         if (it.elementType == ImpExTypes.MACRO_USAGE) it.parentOfType<ImpExMacroUsageDec>()
                             ?.resolveValue(HashSet())
+                            ?: it.text
+                        else if (it.elementType == ImpExTypes.POSSIBLE_MACRO_USAGE) it.parentOfType<ImpExPossibleMacroUsageDec>()
+                            ?.resolveValue()
                             ?: it.text
                         else it.text
                     }

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
@@ -83,8 +83,11 @@ abstract class ImpExValueGroupMixin(node: ASTNode) : ASTWrapperPsiElement(node),
                 child = child.parent
             }
 
-            if (child is ImpExMacroUsageDec) values.add(child.resolveValue(HashSet()))
-            else values.add(child.text)
+            when (child) {
+                is ImpExMacroUsageDec -> values.add(child.resolveValue(HashSet()))
+                is ImpExPossibleMacroUsageDec -> values.add(child.resolveValue())
+                else -> values.add(child.text)
+            }
 
             child = child.prevLeaf()
 


### PR DESCRIPTION
Example ImpEx:
```impex
UPDATE GenericItem[processor = de.hybris.platform.commerceservices.impex.impl.ConfigPropertyImportProcessor]; pk[unique = true]

#%import dev.setup.SampleDataSystemSetup
#%impex.enableCodeExecution(true)
#%impex.enableExternalSyntaxParsing(true)
#%impex.includeExternalData(SampleDataSystemSetup.class.getResourceAsStream("/sampledata/import/solr.impex"), "utf-8", 0, 0);;

$x = $solrIndexedType
$y = $xtest

UPDATE Currency; &currency; isocode[unique = true]
               ; CAD      ; $x
UPDATE Country; &countryRef; isocode[unique = true][default=$solrIndexedType]
              ; CA         ;
```