### PR TITLE
ImpEx | Resolve exact value line meta type in the Document ID `&DocId` usage lookup elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [2026.0.15]
 
 <cite>Release contributors</code>
-- 14 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
+- 15 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Amlytvyn+is%3Apr)
 - 8 PR(s) by [Eugeni Kalenchuk](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.15+author%3Aekalenchuk+is%3Apr)
 
 ### `Project Import` enhancements
@@ -29,6 +29,7 @@
 - Recursively resolve possible external macro used in the locally defined macro [#1971](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1971)
 - Added new icon for `&DocId` usage values [#1972](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1972)
 - Added rename capabilities for Document ID `&DocId` usage values [#1973](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1973)
+- Resolve exact value line meta type in the Document ID `&DocId` usage lookup elements [#1974](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1974)
 
 ### `FlexibleSearch` enhancements
 - New action to `Introduce Bind Parameters` for query with exact values in the expressions [#1962](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1962)

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueGroup.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/ImpExValueGroup.java
@@ -26,6 +26,8 @@ package sap.commerce.toolset.impex.psi;
 import java.util.List;
 import org.jetbrains.annotations.*;
 import com.intellij.psi.PsiElement;
+import com.intellij.util.xml.DomElement;
+import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaClassifier;
 
 public interface ImpExValueGroup extends PsiElement {
 
@@ -41,5 +43,7 @@ public interface ImpExValueGroup extends PsiElement {
   @Nullable String rawValue();
 
   @Nullable String resolveValue();
+
+  @Nullable TSGlobalMetaClassifier<? extends @NotNull DomElement> getValueLineMetaType();
 
 }

--- a/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupImpl.java
+++ b/modules/impex/core/gen/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupImpl.java
@@ -31,6 +31,8 @@ import com.intellij.psi.PsiElementVisitor;
 import com.intellij.psi.util.PsiTreeUtil;
 import static sap.commerce.toolset.impex.psi.ImpExTypes.*;
 import sap.commerce.toolset.impex.psi.*;
+import com.intellij.util.xml.DomElement;
+import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaClassifier;
 
 public class ImpExValueGroupImpl extends ImpExValueGroupMixin implements ImpExValueGroup {
 

--- a/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/ImpEx.bnf
@@ -314,7 +314,7 @@ value_group ::= FIELD_VALUE_SEPARATOR value? MULTILINE_SEPARATOR?
 {
     pin=1
     mixin="sap.commerce.toolset.impex.psi.impl.ImpExValueGroupMixin"
-    methods=[getFullHeaderParameter getColumnNumber getValueLine rawValue resolveValue]
+    methods=[getFullHeaderParameter getColumnNumber getValueLine rawValue resolveValue getValueLineMetaType]
 }
 
 value ::= string

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExHeaderParameterTSContext.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/ImpExHeaderParameterTSContext.kt
@@ -19,14 +19,9 @@
 package sap.commerce.toolset.impex.psi
 
 import com.intellij.util.xml.DomElement
-import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaItem
 import sap.commerce.toolset.typeSystem.meta.model.TSMetaClassifier
 
 data class ImpExHeaderParameterTSContext(
     val meta: TSMetaClassifier<out DomElement>,
     val attributeType: String
-) {
-    val attributeOwnerType: String?
-        get() = if (meta is TSGlobalMetaItem.TSGlobalMetaItemAttribute) meta.owner.name
-        else meta.name
-}
+)

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/impl/ImpExValueGroupMixin.kt
@@ -24,8 +24,14 @@ import com.intellij.openapi.util.Condition
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.psi.util.*
+import com.intellij.util.asSafely
+import com.intellij.util.xml.DomElement
 import sap.commerce.toolset.impex.psi.*
+import sap.commerce.toolset.impex.psi.references.ImpExTSSubTypeItemReference
 import sap.commerce.toolset.impex.utils.ImpExPsiUtils
+import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
+import sap.commerce.toolset.typeSystem.meta.model.TSGlobalMetaClassifier
+import sap.commerce.toolset.typeSystem.psi.reference.result.ItemResolveResult
 import java.io.Serial
 
 abstract class ImpExValueGroupMixin(node: ASTNode) : ASTWrapperPsiElement(node), ImpExValueGroup {
@@ -107,6 +113,24 @@ abstract class ImpExValueGroupMixin(node: ASTNode) : ASTWrapperPsiElement(node),
             this,
         )
     }, false)
+
+    override fun getValueLineMetaType(): TSGlobalMetaClassifier<out DomElement>? {
+        val metaName = valueLine
+            ?.subTypeName
+            ?.reference
+            ?.asSafely<ImpExTSSubTypeItemReference>()
+            ?.multiResolve(false)
+            ?.firstOrNull()
+            ?.asSafely<ItemResolveResult>()
+            ?.meta
+            ?.name
+            ?: fullHeaderParameter
+                ?.headerLine
+                ?.fullHeaderType
+                ?.headerTypeName
+                ?.text
+        return TSMetaModelAccess.getInstance(project).findMetaClassifierByName(metaName)
+    }
 
     companion object {
         val CACHE_KEY_VALUE_LINE = Key.create<CachedValue<ImpExValueLine?>>("SAP_CX_IMPEX_VALUE_LINE")

--- a/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExDocumentIdUsageReference.kt
+++ b/modules/impex/core/src/sap/commerce/toolset/impex/psi/references/ImpExDocumentIdUsageReference.kt
@@ -33,7 +33,6 @@ import sap.commerce.toolset.impex.lang.refactoring.ImpExPsiElementManipulator
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdDec
 import sap.commerce.toolset.impex.psi.ImpExDocumentIdUsage
 import sap.commerce.toolset.impex.psi.ImpExFullHeaderParameter
-import sap.commerce.toolset.typeSystem.meta.TSMetaModelAccess
 
 open class ImpExDocumentIdUsageReference private constructor(
     private val fullHeaderParameter: ImpExFullHeaderParameter,
@@ -73,13 +72,7 @@ open class ImpExDocumentIdUsageReference private constructor(
                 ?.flatten()
                 ?.distinctBy { it.text }
                 ?.map { idDec ->
-                    val meta = idDec.valueGroup
-                        ?.fullHeaderParameter
-                        ?.headerLine
-                        ?.fullHeaderType
-                        ?.headerTypeName
-                        ?.text
-                        ?.let { TSMetaModelAccess.getInstance(project).findMetaClassifierByName(it) }
+                    val meta = idDec.valueGroup?.getValueLineMetaType()
 
                     ImpExLookupElementFactory.buildDocIdUsage(idDec, meta)
                 }


### PR DESCRIPTION
<img width="805" height="403" alt="image" src="https://github.com/user-attachments/assets/e6f941d5-0cf9-4f4b-91a9-c27f38974452" />
