### PR TITLE
Other | Updated tooltip according to new 2026.2 API to render html-description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## [2026.2.1]
 
 <cite>Release contributors</code>
-- 2 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.1+author%3Amlytvyn+is%3Apr)
+- 3 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.1+author%3Amlytvyn+is%3Apr)
 
 ### `CCv2` enhancements
 - Show informative message when authentication failed [#1984](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1984)
 
 ### `Spring` enhancements
 - Improved "Simple Spring" and added parent beans resolution in Non-Ultimate edition [#1985](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1985)
+
+### `Other` enhancements
+- Updated tooltip according to new 2026.2 API to render html-description [#1986](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1986)
 
 ## [2026.2.0]
 

--- a/modules/flexibleSearch/mcp/src/sap/commerce/toolset/flexibleSearch/mcp/FxSMcpService.kt
+++ b/modules/flexibleSearch/mcp/src/sap/commerce/toolset/flexibleSearch/mcp/FxSMcpService.kt
@@ -80,7 +80,7 @@ class FxSMcpService(private val project: Project) {
             psiFile.putUserData(FlexibleSearchExecConstants.Transform.EXEC_RESULTS, result)
         }
 
-        val transformationResult = transformer.transform(psiFile)
+        val transformationResult = transformer.transform(project, psiFile)
 
         return FxSExecResultDto(
             connectionName = connection.connectionName,

--- a/modules/flexibleSearch/transform/src/sap/commerce/toolset/flexibleSearch/transform/FxSToImpExTransformer.kt
+++ b/modules/flexibleSearch/transform/src/sap/commerce/toolset/flexibleSearch/transform/FxSToImpExTransformer.kt
@@ -20,6 +20,7 @@ package sap.commerce.toolset.flexibleSearch.transform
 
 import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.Project
 import sap.commerce.toolset.flexibleSearch.FlexibleSearchLanguage
 import sap.commerce.toolset.flexibleSearch.psi.FlexibleSearchPsiFile
 import sap.commerce.toolset.flexibleSearch.transform.impex.ImpExTransformationService
@@ -38,9 +39,9 @@ class FxSToImpExTransformer : Transformer<FlexibleSearchPsiFile> {
 
     override fun isApplicable(language: Language) = language is FlexibleSearchLanguage
 
-    override fun transform(psiElement: FlexibleSearchPsiFile, onComplete: (TransformationResult) -> Unit) = ImpExTransformationService.getInstance(psiElement.project)
+    override fun transform(project: Project, psiElement: FlexibleSearchPsiFile, onComplete: (TransformationResult) -> Unit) = ImpExTransformationService.getInstance(project)
         .transform(outputFileType, psiElement, onComplete)
 
-    override suspend fun transform(psiElement: FlexibleSearchPsiFile): TransformationResult = ImpExTransformationService.getInstance(psiElement.project)
+    override suspend fun transform(project: Project, psiElement: FlexibleSearchPsiFile): TransformationResult = ImpExTransformationService.getInstance(project)
         .transform(outputFileType, psiElement)
 }

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchShowRestrictionsAction.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchShowRestrictionsAction.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.actionSystem.impl.ActionButton
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.lastLeaf
@@ -51,6 +52,7 @@ import sap.commerce.toolset.hac.exec.HacExecConnectionService
 import sap.commerce.toolset.settings.state.TransactionMode
 import sap.commerce.toolset.typeSystem.meta.TSMetaModelStateService
 import java.awt.Dimension
+import java.awt.event.HierarchyEvent
 
 class FlexibleSearchShowRestrictionsAction : AnAction(
     "Show Search Restrictions",
@@ -149,7 +151,13 @@ class FlexibleSearchShowRestrictionsAction : AnAction(
     }
 
     override fun createCustomComponent(presentation: Presentation, place: String) = ActionButton(this, presentation, place, Dimension())
-        .also {
+        .also { component ->
+            val disposable = Disposer.newDisposable()
+            component.addHierarchyListener { e ->
+                if (e.changeFlags and HierarchyEvent.DISPLAYABILITY_CHANGED.toLong() != 0L && !component.isDisplayable) {
+                    Disposer.dispose(disposable)
+                }
+            }
             GotItTooltip(
                 id = GotItTooltips.FlexibleSearch.SEARCH_RESTRICTIONS,
                 textSupplier = {
@@ -158,16 +166,16 @@ class FlexibleSearchShowRestrictionsAction : AnAction(
                     <br><br>You can copy the detected restrictions as an ${code("ImpEx")} file or open them directly in a new Scratch File.
                     <br><br>A running SAP Commerce server and valid ${
                         link("connection configuration") {
-                            DataManager.getInstance().getDataContext(it).getData(CommonDataKeys.PROJECT)
+                            DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
                                 ?.triggerAction("sap.commerce.toolset.hac.openSettings")
                         }
                     } are required.
                 """.trimIndent()
                 },
-                parentDisposable = null
+                parentDisposable = disposable
             )
                 .withHeader("Search restrictions for FlexibleSearch!")
-                .show(it, GotItTooltip.BOTTOM_MIDDLE)
+                .show(component, GotItTooltip.BOTTOM_MIDDLE)
         }
 
     private fun showNoRestrictions(editor: Editor, userUid: String) {

--- a/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchTransformAction.kt
+++ b/modules/flexibleSearch/ui/src/sap/commerce/toolset/flexibleSearch/actionSystem/FlexibleSearchTransformAction.kt
@@ -148,7 +148,7 @@ class FlexibleSearchTransformAction : AnAction() {
                         psiFile.putUserData(FlexibleSearchExecConstants.Transform.EXEC_RESULTS, execResult)
 
                         val transformer = applicableTransformers[selectedTransformerIndex]
-                        transformer.transform(psiFile) { result ->
+                        transformer.transform(project, psiFile) { result ->
                             notify(project, result)
                         }
                     }

--- a/modules/groovy/mcp/src/sap/commerce/toolset/groovy/mcp/GroovyMcpService.kt
+++ b/modules/groovy/mcp/src/sap/commerce/toolset/groovy/mcp/GroovyMcpService.kt
@@ -28,12 +28,12 @@ import org.apache.http.HttpStatus
 import org.jetbrains.plugins.groovy.GroovyLanguage
 import sap.commerce.toolset.groovy.GroovyConstants
 import sap.commerce.toolset.groovy.exec.GroovyExecClient
-import sap.commerce.toolset.groovy.psi.GroovyElementFactory
 import sap.commerce.toolset.groovy.exec.context.GroovyExecContext
 import sap.commerce.toolset.groovy.mcp.context.GroovyExecMcpRequest
 import sap.commerce.toolset.groovy.mcp.context.GroovyTransformMcpRequest
 import sap.commerce.toolset.groovy.mcp.dto.GroovyExecResultDto
 import sap.commerce.toolset.groovy.mcp.dto.GroovyTransformResultDto
+import sap.commerce.toolset.groovy.psi.GroovyElementFactory
 import sap.commerce.toolset.transform.Transformer
 
 @Service(Service.Level.PROJECT)
@@ -76,7 +76,7 @@ class GroovyMcpService(private val project: Project) {
 
         psiFile.putUserData(GroovyConstants.Transform.SCRIPT_NAME, request.scriptName)
 
-        val result = transformer.transform(psiFile)
+        val result = transformer.transform(project, psiFile)
 
         return GroovyTransformResultDto(
             success = true,

--- a/modules/groovy/transform/src/sap/commerce/toolset/groovy/transform/GroovyToImpExScriptTransformer.kt
+++ b/modules/groovy/transform/src/sap/commerce/toolset/groovy/transform/GroovyToImpExScriptTransformer.kt
@@ -20,6 +20,7 @@ package sap.commerce.toolset.groovy.transform
 
 import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.Project
 import org.jetbrains.plugins.groovy.GroovyLanguage
 import org.jetbrains.plugins.groovy.lang.psi.GroovyFile
 import sap.commerce.toolset.impex.file.ImpExFileType
@@ -39,9 +40,9 @@ class GroovyToImpExScriptTransformer : Transformer<GroovyFile> {
 
     override fun isApplicable(language: Language) = language === GroovyLanguage
 
-    override fun transform(psiElement: GroovyFile, onComplete: (TransformationResult) -> Unit) = GroovyImpExScriptTransformationService.getInstance(psiElement.project)
+    override fun transform(project: Project, psiElement: GroovyFile, onComplete: (TransformationResult) -> Unit) = GroovyImpExScriptTransformationService.getInstance(project)
         .transform(outputFileType, psiElement, onComplete)
 
-    override suspend fun transform(psiElement: GroovyFile): TransformationResult = GroovyImpExScriptTransformationService.getInstance(psiElement.project)
+    override suspend fun transform(project: Project, psiElement: GroovyFile): TransformationResult = GroovyImpExScriptTransformationService.getInstance(project)
         .transform(outputFileType, psiElement)
 }

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecuteAction.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyExecuteAction.kt
@@ -126,12 +126,14 @@ class GroovyExecuteAction : ExecuteStatementAction<HybrisGroovyConsole, GroovySp
         when (transactionMode) {
             TransactionMode.ROLLBACK -> {
                 e.presentation.icon = HybrisIcons.Console.Actions.EXECUTE_ROLLBACK
-                e.presentation.text = "Execute Groovy Script<br/>Commit Mode <strong><font color='#C75450'>OFF</font></strong>"
+                e.presentation.text = "Execute Groovy Script"
+                e.presentation.description = "Commit Mode <strong><font color='#C75450'>OFF</font></strong>"
             }
 
             TransactionMode.COMMIT -> {
                 e.presentation.icon = HybrisIcons.Console.Actions.EXECUTE
-                e.presentation.text = "Execute Groovy Script<br/>Commit Mode <strong><font color='#57965C'>ON</font></strong>"
+                e.presentation.text = "Execute Groovy Script"
+                e.presentation.description = "Commit Mode <strong><font color='#57965C'>ON</font></strong>"
             }
         }
     }

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovySpringContextModeActionGroup.kt
@@ -22,6 +22,7 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction
+import com.intellij.openapi.util.Disposer
 import com.intellij.ui.GotItTooltip
 import com.intellij.ui.scale.JBUIScale
 import sap.commerce.toolset.GotItTooltips
@@ -30,6 +31,7 @@ import sap.commerce.toolset.groovy.getSpringContextMode
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.settings.state.SpringContextMode
 import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponent
+import java.awt.event.HierarchyEvent
 
 class GroovySpringContextModeActionGroup : DefaultActionGroup(), CustomComponentAction {
 
@@ -55,7 +57,7 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup(), CustomComponent
         place = place,
         title = "Spring Context Mode"
     )
-        .also {
+        .also { component ->
             val before = """<pre class="code">
                 import de.hybris.platform.core.Registry
                 import de.hybris.platform.product.ProductService
@@ -67,6 +69,12 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup(), CustomComponent
             """.trimIndent()
             val after = "<pre class=\"code\">productService.getProduct('test')</pre>"
 
+            val disposable = Disposer.newDisposable()
+            component.addHierarchyListener { e ->
+                if (e.changeFlags and HierarchyEvent.DISPLAYABILITY_CHANGED.toLong() != 0L && !component.isDisplayable) {
+                    Disposer.dispose(disposable)
+                }
+            }
             GotItTooltip(
                 id = GotItTooltips.Groovy.SPRING_CONTEXT_MODE,
                 textSupplier = {
@@ -75,7 +83,7 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup(), CustomComponent
                     <br>${icon(SpringContextMode.REMOTE.icon)} ${code(SpringContextMode.REMOTE.presentationText)} resolves beans by fetching them from the remote HAC.
                     <br>Resolution of the Spring Context is a heavy operation, that's why it is ${icon(SpringContextMode.DISABLED.icon)} ${code(SpringContextMode.DISABLED.presentationText)} by default for every new Editor, but it can be changed via ${
                         link("Groovy settings") {
-                            DataManager.getInstance().getDataContext(it).getData(CommonDataKeys.PROJECT)
+                            DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
                                 ?.triggerAction("hybris.groovy.openSettings")
                         }
                     }.
@@ -86,11 +94,11 @@ class GroovySpringContextModeActionGroup : DefaultActionGroup(), CustomComponent
                     <br>${after}
                 """.trimIndent()
                 },
-                parentDisposable = null
+                parentDisposable = disposable
             )
                 .withMaxWidth(JBUIScale.scale(420))
                 .withHeader("Welcome Spring Context in Groovy!")
-                .show(it, GotItTooltip.BOTTOM_MIDDLE)
+                .show(component, GotItTooltip.BOTTOM_MIDDLE)
         }
 
 }

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransactionModeActionGroup.kt
@@ -22,6 +22,7 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.*
 import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction
+import com.intellij.openapi.util.Disposer
 import com.intellij.ui.GotItTooltip
 import sap.commerce.toolset.GotItTooltips
 import sap.commerce.toolset.actionSystem.triggerAction
@@ -29,6 +30,7 @@ import sap.commerce.toolset.groovy.exec.GroovyExecService
 import sap.commerce.toolset.i18n
 import sap.commerce.toolset.settings.state.TransactionMode
 import sap.commerce.toolset.ui.ActionButtonWithTextAndDescriptionComponent
+import java.awt.event.HierarchyEvent
 
 class GroovyTransactionModeActionGroup : DefaultActionGroup(), CustomComponentAction {
 
@@ -54,7 +56,13 @@ class GroovyTransactionModeActionGroup : DefaultActionGroup(), CustomComponentAc
         place = place,
         title = "Transaction Mode"
     )
-        .also {
+        .also { component ->
+            val disposable = Disposer.newDisposable()
+            component.addHierarchyListener { e ->
+                if (e.changeFlags and HierarchyEvent.DISPLAYABILITY_CHANGED.toLong() != 0L && !component.isDisplayable) {
+                    Disposer.dispose(disposable)
+                }
+            }
             GotItTooltip(
                 id = GotItTooltips.Groovy.TRANSACTION_MODE,
                 textSupplier = {
@@ -64,16 +72,16 @@ class GroovyTransactionModeActionGroup : DefaultActionGroup(), CustomComponentAc
                     <br>If you want to ensure that no modifications are persisted, switch the mode to ${icon(TransactionMode.ROLLBACK.icon)} ${code(TransactionMode.ROLLBACK.presentationText)}.
                     <br><br>Rollback is the default for newly opened editors, but this behavior can be adjusted in the ${
                         link("Groovy settings") {
-                            DataManager.getInstance().getDataContext(it).getData(CommonDataKeys.PROJECT)
+                            DataManager.getInstance().getDataContext(component).getData(CommonDataKeys.PROJECT)
                                 ?.triggerAction("hybris.groovy.openSettings")
                         }
                     }.
                 """.trimIndent()
                 },
-                parentDisposable = null
+                parentDisposable = disposable
             )
                 .withHeader("Transaction modes for Groovy!")
-                .show(it, GotItTooltip.BOTTOM_MIDDLE)
+                .show(component, GotItTooltip.BOTTOM_MIDDLE)
         }
 
 }

--- a/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransformAction.kt
+++ b/modules/groovy/ui/src/sap/commerce/toolset/groovy/actionSystem/GroovyTransformAction.kt
@@ -124,7 +124,7 @@ class GroovyTransformAction : DumbAwareAction() {
 
                         psiFile.putUserData(GroovyConstants.Transform.SCRIPT_NAME, scriptName.trim().ifEmpty { defaultName })
 
-                        applicableTransformers[selectedTransformerIndex].transform(psiFile) { result ->
+                        applicableTransformers[selectedTransformerIndex].transform(project, psiFile) { result ->
                             notify(project, result)
                         }
                     }

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecuteStatementAction.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecuteStatementAction.kt
@@ -1,6 +1,6 @@
 /*
  * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
- * Copyright (C) 2019-2025 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -23,6 +23,7 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.ex.TooltipDescriptionProvider
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.DumbAware
@@ -42,7 +43,7 @@ abstract class ExecuteStatementAction<C : HybrisConsole<out ExecContext>, F : Fi
     private val name: String,
     private val description: String,
     private val icon: Icon
-) : AnAction(), DumbAware {
+) : AnAction(), DumbAware, TooltipDescriptionProvider {
 
     abstract fun actionPerformed(e: AnActionEvent, project: Project, content: String)
     abstract fun fileEditor(e: AnActionEvent): F?

--- a/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecutionContextSettingsAction.kt
+++ b/modules/hac/ui/src/sap/commerce/toolset/hac/actionSystem/ExecutionContextSettingsAction.kt
@@ -21,6 +21,7 @@ package sap.commerce.toolset.hac.actionSystem
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.ex.TooltipDescriptionProvider
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
@@ -31,7 +32,7 @@ import sap.commerce.toolset.exec.context.ExecContext
 import sap.commerce.toolset.ifNotFromSearchPopup
 import java.awt.event.KeyEvent
 
-abstract class ExecutionContextSettingsAction<M : ExecContext.Settings.Mutable> : DumbAwareAction() {
+abstract class ExecutionContextSettingsAction<M : ExecContext.Settings.Mutable> : DumbAwareAction(), TooltipDescriptionProvider {
 
     protected abstract fun previewSettings(e: AnActionEvent, project: Project, virtualFile: VirtualFile): String
     protected abstract fun settings(e: AnActionEvent, project: Project, virtualFile: VirtualFile): M
@@ -45,7 +46,8 @@ abstract class ExecutionContextSettingsAction<M : ExecContext.Settings.Mutable> 
         val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return@ifNotFromSearchPopup
 
         e.presentation.icon = HybrisIcons.Connection.CONTEXT
-        e.presentation.text = "Execution Context Settings<br>" + previewSettings(e, project, virtualFile)
+        e.presentation.text = "Execution Context Settings"
+        e.presentation.description = previewSettings(e, project, virtualFile)
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/modules/impex/transform/src/sap/commerce/toolset/impex/transform/ImpExValueLineToFxSTransformer.kt
+++ b/modules/impex/transform/src/sap/commerce/toolset/impex/transform/ImpExValueLineToFxSTransformer.kt
@@ -20,6 +20,7 @@ package sap.commerce.toolset.impex.transform
 
 import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.Project
 import sap.commerce.toolset.flexibleSearch.file.FlexibleSearchFileType
 import sap.commerce.toolset.impex.ImpExLanguage
 import sap.commerce.toolset.impex.psi.ImpExValueLine
@@ -38,9 +39,9 @@ class ImpExValueLineToFxSTransformer : Transformer<ImpExValueLine> {
 
     override fun isApplicable(language: Language) = language is ImpExLanguage
 
-    override fun transform(psiElement: ImpExValueLine, onComplete: (TransformationResult) -> Unit) = FxSTransformationService.getInstance(psiElement.project)
+    override fun transform(project: Project, psiElement: ImpExValueLine, onComplete: (TransformationResult) -> Unit) = FxSTransformationService.getInstance(project)
         .transform(outputFileType, psiElement, onComplete)
 
-    override suspend fun transform(psiElement: ImpExValueLine): TransformationResult = FxSTransformationService.getInstance(psiElement.project)
+    override suspend fun transform(project: Project, psiElement: ImpExValueLine): TransformationResult = FxSTransformationService.getInstance(project)
         .transform(outputFileType, psiElement)
 }

--- a/modules/impex/transform/src/sap/commerce/toolset/impex/transform/ImpExValueLineToPgQTransformer.kt
+++ b/modules/impex/transform/src/sap/commerce/toolset/impex/transform/ImpExValueLineToPgQTransformer.kt
@@ -20,6 +20,7 @@ package sap.commerce.toolset.impex.transform
 
 import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.Project
 import sap.commerce.toolset.impex.ImpExLanguage
 import sap.commerce.toolset.impex.psi.ImpExValueLine
 import sap.commerce.toolset.impex.transform.polyglotQuery.PgQTransformationService
@@ -38,9 +39,9 @@ class ImpExValueLineToPgQTransformer : Transformer<ImpExValueLine> {
 
     override fun isApplicable(language: Language) = language is ImpExLanguage
 
-    override fun transform(psiElement: ImpExValueLine, onComplete: (TransformationResult) -> Unit) = PgQTransformationService.getInstance(psiElement.project)
+    override fun transform(project: Project, psiElement: ImpExValueLine, onComplete: (TransformationResult) -> Unit) = PgQTransformationService.getInstance(project)
         .transform(outputFileType, psiElement, onComplete)
 
-    override suspend fun transform(psiElement: ImpExValueLine): TransformationResult = PgQTransformationService.getInstance(psiElement.project)
+    override suspend fun transform(project: Project, psiElement: ImpExValueLine): TransformationResult = PgQTransformationService.getInstance(project)
         .transform(outputFileType, psiElement)
 }

--- a/modules/impex/ui/src/sap/commerce/toolset/impex/codeInsight/daemon/ImpExValueLineTransformLineMarkerProvider.kt
+++ b/modules/impex/ui/src/sap/commerce/toolset/impex/codeInsight/daemon/ImpExValueLineTransformLineMarkerProvider.kt
@@ -124,7 +124,7 @@ class ImpExValueLineTransformLineMarkerProvider : LineMarkerProvider {
                         content.apply()
                         val transformer = transformers[selectedTransformerIndex]
                         element.putUserData(ImpExConstants.Transform.INCLUDE_ALL_ATTRIBUTES, includeAllAttributes.get())
-                        transformer.transform(element) { result ->
+                        transformer.transform(project, element) { result ->
                             notify(project, result)
                         }
                     }

--- a/modules/shared/transform/src/sap/commerce/toolset/transform/Transformer.kt
+++ b/modules/shared/transform/src/sap/commerce/toolset/transform/Transformer.kt
@@ -21,6 +21,7 @@ package sap.commerce.toolset.transform
 import com.intellij.lang.Language
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 
 interface Transformer<T : PsiElement> {
@@ -33,8 +34,8 @@ interface Transformer<T : PsiElement> {
 
     fun isApplicable(language: Language): Boolean
     fun isApplicable(psiElement: PsiElement): Boolean = isApplicable(psiElement.language)
-    fun transform(psiElement: T, onComplete: (TransformationResult) -> Unit)
-    suspend fun transform(psiElement: T): TransformationResult
+    fun transform(project: Project, psiElement: T, onComplete: (TransformationResult) -> Unit)
+    suspend fun transform(project: Project, psiElement: T): TransformationResult
 
     companion object {
         val EP = ExtensionPointName.create<Transformer<in PsiElement>>("sap.commerce.toolset.transformer")


### PR DESCRIPTION
2026.2 regression:
<img width="353" height="180" alt="image" src="https://github.com/user-attachments/assets/1704b29e-1073-409f-9e6b-78b4758b3003" />

adjusted to new API:
<img width="321" height="279" alt="Screenshot 2026-07-28 at 10 01 42" src="https://github.com/user-attachments/assets/8b78db57-5353-49ec-b5e4-aa8a4f67f8bc" />

----

JetBrains tickets:
- Make GotItTooltip API Public: https://youtrack.jetbrains.com/issue/IJPL-251435/Make-GotItTooltip-frequently-used-point-providers-Public
