### PR TITLE
HAC | Keep credentials of the HAC and Solr connections which were not opened before saving the settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 ### `Other` enhancements
 - Updated tooltip according to new 2026.2 API to render html-description [#1986](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1986)
 
+### Fixes
+- Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings
+
 ## [2026.2.0]
 
 <cite>Release contributors</code>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Updated tooltip according to new 2026.2 API to render html-description [#1986](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1986)
 
 ### Fixes
-- Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings
+- Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
 
 ## [2026.2.0]
 

--- a/modules/exec/core/build.gradle.kts
+++ b/modules/exec/core/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation(project(":shared-core"))
     implementation(project(":project-core"))
 
+    testImplementation(kotlin("test"))
+
     intellijPlatform {
         intellijIdea(properties("intellij.version")) {
             useInstaller = true

--- a/modules/exec/core/src/sap/commerce/toolset/exec/ExecConnectionService.kt
+++ b/modules/exec/core/src/sap/commerce/toolset/exec/ExecConnectionService.kt
@@ -39,55 +39,70 @@ abstract class ExecConnectionService<T : ExecConnectionSettingsState>(protected 
 
     abstract fun defaultCredentials(settings: T): Credentials
     abstract fun default(): T
-    abstract fun delete(settings: T, notify: Boolean = true)
-    abstract fun create(settings: Pair<T, ExecConnectionCredentials>, notify: Boolean = true)
-    abstract fun save(settings: Map<T, ExecConnectionCredentials>)
+    abstract fun delete(settings: T, notify: Boolean = true, purgeCredentials: Boolean = true)
+    abstract fun create(settings: Pair<T, ExecConnectionCredentials?>, notify: Boolean = true)
+    abstract fun save(settings: Map<T, ExecConnectionCredentials?>)
 
     fun getCredentials(settings: T) = PasswordSafe.instance.get(CredentialAttributes("SAP CX - ${settings.uuid}"))
         ?: defaultCredentials(settings)
 
     fun getProxyCredentials(settings: T) = PasswordSafe.instance.get(CredentialAttributes("SAP CX - proxy - ${settings.uuid}"))
 
-    fun update(settings: Pair<T, ExecConnectionCredentials>) = update(mapOf(settings))
+    fun update(settings: Pair<T, ExecConnectionCredentials?>) = update(mapOf(settings))
 
-    fun update(settings: Map<T, ExecConnectionCredentials>) {
-        settings.keys.forEach { delete(it, notify = false) }
+    /**
+     * The delete/create cycle must not touch the credential store, [onUpdate] is the single writer:
+     * purging here would drop the credentials of a connection with unknown ones and would race
+     * with the write of the very same credential attributes.
+     */
+    fun update(settings: Map<T, ExecConnectionCredentials?>) {
+        settings.keys.forEach { delete(it, notify = false, purgeCredentials = false) }
         settings.forEach { create(it.key to it.value, notify = false) }
 
         onUpdate(settings)
     }
 
-    protected fun removeCredentials(settings: T) = saveCredentials(settings to null)
+    protected fun removeCredentials(settings: T) = writeCredentials(settings, null)
 
     protected fun onActivate(settings: T, notify: Boolean = true) = if (notify) listener.onActive(settings) else Unit
-    protected fun onDelete(settings: T, notify: Boolean = true) {
-        removeCredentials(settings)
+    protected fun onDelete(settings: T, notify: Boolean = true, purgeCredentials: Boolean = true) {
+        if (purgeCredentials) removeCredentials(settings)
         if (notify) listener.onDelete(settings) else Unit
     }
 
-    protected fun onCreate(settings: Pair<T, ExecConnectionCredentials>, notify: Boolean = true) = if (notify) {
-        saveCredentials(settings)
+    protected fun onCreate(settings: Pair<T, ExecConnectionCredentials?>, notify: Boolean = true) = if (notify) {
+        saveCredentials(settings.first, settings.second)
         listener.onCreate(settings.first)
     } else Unit
 
-    protected fun onUpdate(settings: Map<T, ExecConnectionCredentials>, notify: Boolean = true) {
-        settings.forEach { saveCredentials(it.key to it.value) }
+    protected fun onUpdate(settings: Map<T, ExecConnectionCredentials?>, notify: Boolean = true) {
+        settings.forEach { saveCredentials(it.key, it.value) }
         if (notify) listener.onUpdate(settings.keys)
     }
 
-    protected fun onSave(settings: Map<T, ExecConnectionCredentials>) {
-        settings.forEach { saveCredentials(it.key to it.value) }
+    protected fun onSave(settings: Map<T, ExecConnectionCredentials?>) {
+        settings.forEach { saveCredentials(it.key, it.value) }
         listener.onSave(settings.keys)
     }
 
-    private fun saveCredentials(settings: Pair<T, ExecConnectionCredentials?>) {
+    /**
+     * Unknown credentials must never overwrite the credential store, otherwise saving the settings of one connection
+     * wipes the credentials of every connection the user did not open in the very same settings session.
+     */
+    private fun saveCredentials(settings: T, credentials: ExecConnectionCredentials?) {
+        if (credentials == null) return
+
+        writeCredentials(settings, credentials)
+    }
+
+    private fun writeCredentials(settings: T, credentials: ExecConnectionCredentials?) {
         ProgressManager.getInstance().run(object : Task.Backgroundable(project, "Persisting credentials", false) {
             override fun run(indicator: ProgressIndicator) {
-                val credentialAttributes = CredentialAttributes("SAP CX - ${settings.first.uuid}")
-                PasswordSafe.instance.set(credentialAttributes, settings.second?.credentials)
+                val credentialAttributes = CredentialAttributes("SAP CX - ${settings.uuid}")
+                PasswordSafe.instance.set(credentialAttributes, credentials?.credentials)
 
-                val proxyCredentialAttributes = CredentialAttributes("SAP CX - proxy - ${settings.first.uuid}")
-                PasswordSafe.instance.set(proxyCredentialAttributes, settings.second?.proxyCredentials)
+                val proxyCredentialAttributes = CredentialAttributes("SAP CX - proxy - ${settings.uuid}")
+                PasswordSafe.instance.set(proxyCredentialAttributes, credentials?.proxyCredentials)
             }
         })
     }

--- a/modules/exec/core/src/sap/commerce/toolset/exec/settings/state/ExecConnectionSettingsState.kt
+++ b/modules/exec/core/src/sap/commerce/toolset/exec/settings/state/ExecConnectionSettingsState.kt
@@ -49,7 +49,11 @@ interface ExecConnectionSettingsState : ConnectionSettingsState {
         val proxyUsername: ObservableMutableProperty<String>
         val proxyPassword: ObservableMutableProperty<String>
 
-        fun immutable(): Pair<ExecConnectionSettingsState, ExecConnectionCredentials>
+        /**
+         * Credentials are `null` until they were loaded from the credential store or entered by the user,
+         * see [modified]. A `null` value means "unknown" and must leave the persisted credentials untouched.
+         */
+        fun immutable(): Pair<ExecConnectionSettingsState, ExecConnectionCredentials?>
 
         val generatedURL: String
             get() = generateUrl(ssl.get(), host.get(), port.get(), webroot.get())

--- a/modules/exec/core/src/sap/commerce/toolset/exec/settings/state/Util.kt
+++ b/modules/exec/core/src/sap/commerce/toolset/exec/settings/state/Util.kt
@@ -27,3 +27,15 @@ fun connectionPresentationName(scope: ExecConnectionScope, name: String?, fallba
         .takeIf { it.isNotBlank() }
     )
     .let { scope.shortTitle + " : " + it }
+
+/**
+ * Persisted connections of the receiver which are not part of [retained] anymore, matched by [ConnectionSettingsState.uuid].
+ *
+ * Credentials of such connections are not referenced by any connection and have to be purged from the credential store,
+ * whereas credentials of the retained ones must survive, even when the user did not open them before saving the settings.
+ */
+fun <T : ExecConnectionSettingsState> Collection<T>.obsoleteFor(retained: Collection<ExecConnectionSettingsState>): List<T> {
+    val retainedUUIDs = retained.mapTo(mutableSetOf()) { it.uuid }
+
+    return filterNot { retainedUUIDs.contains(it.uuid) }
+}

--- a/modules/exec/core/tests/sap/commerce/toolset/exec/settings/state/UtilTest.kt
+++ b/modules/exec/core/tests/sap/commerce/toolset/exec/settings/state/UtilTest.kt
@@ -1,0 +1,99 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.exec.settings.state
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Tests for [obsoleteFor] — no IntelliJ platform required.
+ *
+ * The credentials of a connection are keyed by [ConnectionSettingsState.uuid], therefore saving the connection
+ * settings may purge the credential store only for the connections which are not persisted anymore. Purging
+ * anything else wipes the credentials of the connections the user did not open before saving the settings.
+ */
+class UtilTest {
+
+    private fun connection(uuid: String, scope: ExecConnectionScope = ExecConnectionScope.PROJECT_PERSONAL) = TestConnectionSettingsState(uuid, scope)
+
+    @Test
+    fun obsoleteFor_allRetained_isEmpty() {
+        val persisted = listOf(connection("a"), connection("b"))
+
+        assertTrue(persisted.obsoleteFor(persisted).isEmpty())
+    }
+
+    @Test
+    fun obsoleteFor_removedConnection_isReported() {
+        val persisted = listOf(connection("a"), connection("b"))
+
+        val obsolete = persisted.obsoleteFor(listOf(connection("a")))
+
+        assertEquals(listOf("b"), obsolete.map { it.uuid })
+    }
+
+    @Test
+    fun obsoleteFor_nothingRetained_reportsEverything() {
+        val persisted = listOf(connection("a"), connection("b"))
+
+        val obsolete = persisted.obsoleteFor(emptyList())
+
+        assertEquals(listOf("a", "b"), obsolete.map { it.uuid })
+    }
+
+    @Test
+    fun obsoleteFor_changedScope_isRetained() {
+        val persisted = listOf(connection("a", ExecConnectionScope.PROJECT))
+
+        val obsolete = persisted.obsoleteFor(listOf(connection("a", ExecConnectionScope.PROJECT_PERSONAL)))
+
+        assertTrue(obsolete.isEmpty())
+    }
+
+    @Test
+    fun obsoleteFor_newConnection_isNotReported() {
+        val persisted = listOf(connection("a"))
+
+        val obsolete = persisted.obsoleteFor(listOf(connection("a"), connection("new")))
+
+        assertTrue(obsolete.isEmpty())
+    }
+
+    @Test
+    fun obsoleteFor_noPersistedConnections_isEmpty() {
+        val persisted = emptyList<TestConnectionSettingsState>()
+
+        assertTrue(persisted.obsoleteFor(listOf(connection("a"))).isEmpty())
+    }
+}
+
+private data class TestConnectionSettingsState(
+    override val uuid: String,
+    override val scope: ExecConnectionScope,
+    override val name: String? = null,
+    override val host: String = "localhost",
+    override val port: String? = null,
+    override val webroot: String = "",
+    override val ssl: Boolean = true,
+    override val timeout: Int = 0,
+) : ExecConnectionSettingsState {
+
+    override fun mutable() = error("mutable() is not exercised by these tests")
+}

--- a/modules/hac/exec/build.gradle.kts
+++ b/modules/hac/exec/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation(project(":shared-core"))
     implementation(project(":exec-core"))
 
+    testImplementation(kotlin("test"))
+
     intellijPlatform {
         intellijIdea(properties("intellij.version")) {
             useInstaller = true

--- a/modules/hac/exec/src/sap/commerce/toolset/hac/exec/HacExecConnectionService.kt
+++ b/modules/hac/exec/src/sap/commerce/toolset/hac/exec/HacExecConnectionService.kt
@@ -26,6 +26,7 @@ import sap.commerce.toolset.HybrisConstants
 import sap.commerce.toolset.exec.ExecConnectionService
 import sap.commerce.toolset.exec.settings.state.ExecConnectionCredentials
 import sap.commerce.toolset.exec.settings.state.ExecConnectionScope
+import sap.commerce.toolset.exec.settings.state.obsoleteFor
 import sap.commerce.toolset.hac.exec.settings.HacExecDeveloperSettings
 import sap.commerce.toolset.hac.exec.settings.HacExecProjectSettings
 import sap.commerce.toolset.hac.exec.settings.event.HacConnectionSettingsListener
@@ -59,7 +60,7 @@ class HacExecConnectionService(project: Project) : ExecConnectionService<HacConn
     override val listener: HacConnectionSettingsListener
         get() = project.messageBus.syncPublisher(HacConnectionSettingsListener.TOPIC)
 
-    override fun create(settings: Pair<HacConnectionSettingsState, ExecConnectionCredentials>, notify: Boolean) = when (settings.first.scope) {
+    override fun create(settings: Pair<HacConnectionSettingsState, ExecConnectionCredentials?>, notify: Boolean) = when (settings.first.scope) {
         ExecConnectionScope.PROJECT_PERSONAL -> with(HacExecDeveloperSettings.getInstance(project)) {
             connections = connections + settings.first
 
@@ -73,7 +74,7 @@ class HacExecConnectionService(project: Project) : ExecConnectionService<HacConn
         }
     }
 
-    override fun delete(settings: HacConnectionSettingsState, notify: Boolean) {
+    override fun delete(settings: HacConnectionSettingsState, notify: Boolean, purgeCredentials: Boolean) {
         val developerSettings = HacExecDeveloperSettings.getInstance(project)
         val projectSettings = HacExecProjectSettings.getInstance(project)
         developerSettings.connections = developerSettings.connections
@@ -81,17 +82,18 @@ class HacExecConnectionService(project: Project) : ExecConnectionService<HacConn
         projectSettings.connections = projectSettings.connections
             .filterNot { it.uuid == settings.uuid }
 
-        onDelete(settings, notify)
+        onDelete(settings, notify, purgeCredentials)
     }
 
-    override fun save(settings: Map<HacConnectionSettingsState, ExecConnectionCredentials>) {
+    override fun save(settings: Map<HacConnectionSettingsState, ExecConnectionCredentials?>) {
         val groupedSettings = settings.keys.groupBy { it.scope }
         val projectSettings = HacExecProjectSettings.getInstance(project)
         val developerSettings = HacExecDeveloperSettings.getInstance(project)
 
-        // remove persisted credentials for previous connections
-        projectSettings.connections.forEach { removeCredentials(it) }
-        developerSettings.connections.forEach { removeCredentials(it) }
+        // remove persisted credentials only for the connections which are gone
+        (projectSettings.connections + developerSettings.connections)
+            .obsoleteFor(settings.keys)
+            .forEach { removeCredentials(it) }
 
         projectSettings.connections = groupedSettings.getOrElse(ExecConnectionScope.PROJECT) { emptyList() }
         developerSettings.connections = groupedSettings.getOrElse(ExecConnectionScope.PROJECT_PERSONAL) { emptyList() }

--- a/modules/hac/exec/src/sap/commerce/toolset/hac/exec/settings/state/HacConnectionSettingsState.kt
+++ b/modules/hac/exec/src/sap/commerce/toolset/hac/exec/settings/state/HacConnectionSettingsState.kt
@@ -86,7 +86,7 @@ data class HacConnectionSettingsState(
         var sessionCookieName: String,
     ) : ExecConnectionSettingsState.Mutable {
 
-        override fun immutable(): Pair<HacConnectionSettingsState, ExecConnectionCredentials> = HacConnectionSettingsState(
+        override fun immutable(): Pair<HacConnectionSettingsState, ExecConnectionCredentials?> = HacConnectionSettingsState(
             uuid = uuid,
             scope = scope,
             name = name.get(),
@@ -100,9 +100,12 @@ data class HacConnectionSettingsState(
             sessionCookieName = sessionCookieName,
             proxyAuthMode = proxyAuthMode.get(),
             authMode = authMode.get(),
-        ) to ExecConnectionCredentials(
+        ) to credentials()
+
+        // credentials are lazily loaded by the connection dialog, an untouched connection knows nothing about them
+        private fun credentials() = if (modified) ExecConnectionCredentials(
             Credentials(username.get(), password.get()),
             Credentials(proxyUsername.get(), proxyPassword.get())
-        )
+        ) else null
     }
 }

--- a/modules/hac/exec/tests/sap/commerce/toolset/hac/exec/settings/state/HacConnectionSettingsStateTest.kt
+++ b/modules/hac/exec/tests/sap/commerce/toolset/hac/exec/settings/state/HacConnectionSettingsStateTest.kt
@@ -1,0 +1,90 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.hac.exec.settings.state
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [HacConnectionSettingsState.Mutable.immutable].
+ *
+ * Credentials of a connection are loaded lazily by the connection dialog, therefore an untouched `Mutable`
+ * carries blank credentials which must never reach the credential store.
+ */
+class HacConnectionSettingsStateTest {
+
+    private fun mutable(host: String = "localhost") = HacConnectionSettingsState(host = host).mutable()
+
+    @Test
+    fun immutable_notModified_hasNoCredentials() {
+        val (_, credentials) = mutable().immutable()
+
+        assertNull(credentials)
+    }
+
+    @Test
+    fun immutable_notModified_stillHasSettings() {
+        val (settings, _) = mutable(host = "hac.example.com").immutable()
+
+        assertEquals("hac.example.com", settings.host)
+    }
+
+    @Test
+    fun immutable_modified_hasCredentials() {
+        val mutable = mutable().apply {
+            username.set("admin")
+            password.set("nimda")
+            modified = true
+        }
+
+        val credentials = assertNotNull(mutable.immutable().second).credentials
+
+        assertEquals("admin", credentials.userName)
+        assertEquals("nimda", credentials.getPasswordAsString())
+    }
+
+    @Test
+    fun immutable_modified_hasProxyCredentials() {
+        val mutable = mutable().apply {
+            proxyUsername.set("proxyUser")
+            proxyPassword.set("proxyPass")
+            modified = true
+        }
+
+        val proxyCredentials = assertNotNull(assertNotNull(mutable.immutable().second).proxyCredentials)
+
+        assertEquals("proxyUser", proxyCredentials.userName)
+        assertEquals("proxyPass", proxyCredentials.getPasswordAsString())
+    }
+
+    @Test
+    fun immutable_modifiedWithBlankPassword_hasCredentials() {
+        val mutable = mutable().apply {
+            username.set("admin")
+            modified = true
+        }
+
+        val credentials = assertNotNull(mutable.immutable().second).credentials
+
+        assertEquals("admin", credentials.userName)
+        assertEquals("", credentials.getPasswordAsString())
+    }
+}

--- a/modules/solr/exec/build.gradle.kts
+++ b/modules/solr/exec/build.gradle.kts
@@ -45,6 +45,8 @@ dependencies {
     implementation(project(":exec-core"))
     implementation(project(":console-core"))
 
+    testImplementation(kotlin("test"))
+
     intellijPlatform {
         intellijIdea(properties("intellij.version")) {
             useInstaller = true

--- a/modules/solr/exec/src/sap/commerce/toolset/solr/exec/SolrExecConnectionService.kt
+++ b/modules/solr/exec/src/sap/commerce/toolset/solr/exec/SolrExecConnectionService.kt
@@ -25,6 +25,7 @@ import com.intellij.openapi.project.Project
 import sap.commerce.toolset.exec.ExecConnectionService
 import sap.commerce.toolset.exec.settings.state.ExecConnectionCredentials
 import sap.commerce.toolset.exec.settings.state.ExecConnectionScope
+import sap.commerce.toolset.exec.settings.state.obsoleteFor
 import sap.commerce.toolset.solr.SolrConstants
 import sap.commerce.toolset.solr.exec.settings.SolrExecDeveloperSettings
 import sap.commerce.toolset.solr.exec.settings.SolrExecProjectSettings
@@ -59,7 +60,7 @@ class SolrExecConnectionService(project: Project) : ExecConnectionService<SolrCo
     override val listener: SolrConnectionSettingsListener
         get() = project.messageBus.syncPublisher(SolrConnectionSettingsListener.TOPIC)
 
-    override fun create(settings: Pair<SolrConnectionSettingsState, ExecConnectionCredentials>, notify: Boolean) = when (settings.first.scope) {
+    override fun create(settings: Pair<SolrConnectionSettingsState, ExecConnectionCredentials?>, notify: Boolean) = when (settings.first.scope) {
         ExecConnectionScope.PROJECT_PERSONAL -> with(SolrExecDeveloperSettings.getInstance(project)) {
             connections = connections + settings.first
 
@@ -73,7 +74,7 @@ class SolrExecConnectionService(project: Project) : ExecConnectionService<SolrCo
         }
     }
 
-    override fun delete(settings: SolrConnectionSettingsState, notify: Boolean) {
+    override fun delete(settings: SolrConnectionSettingsState, notify: Boolean, purgeCredentials: Boolean) {
         val developerSettings = SolrExecDeveloperSettings.getInstance(project)
         val projectSettings = SolrExecProjectSettings.getInstance(project)
         developerSettings.connections = developerSettings.connections
@@ -81,22 +82,23 @@ class SolrExecConnectionService(project: Project) : ExecConnectionService<SolrCo
         projectSettings.connections = projectSettings.connections
             .filterNot { it.uuid == settings.uuid }
 
-        onDelete(settings, notify)
+        onDelete(settings, notify, purgeCredentials)
     }
 
     override fun default() = SolrConnectionSettingsState(
         port = getPropertyOrDefault(project, SolrConstants.PROPERTY_SOLR_DEFAULT_PORT, "8983"),
     )
 
-    override fun save(settings: Map<SolrConnectionSettingsState, ExecConnectionCredentials>) {
+    override fun save(settings: Map<SolrConnectionSettingsState, ExecConnectionCredentials?>) {
         val groupedSettings = settings.keys.groupBy { it.scope }
             .mapValues { (_, v) -> v.toList() }
         val projectSettings = SolrExecProjectSettings.getInstance(project)
         val developerSettings = SolrExecDeveloperSettings.getInstance(project)
 
-        // remove persisted credentials for previous connections
-        projectSettings.connections.forEach { removeCredentials(it) }
-        developerSettings.connections.forEach { removeCredentials(it) }
+        // remove persisted credentials only for the connections which are gone
+        (projectSettings.connections + developerSettings.connections)
+            .obsoleteFor(settings.keys)
+            .forEach { removeCredentials(it) }
 
         projectSettings.connections = groupedSettings.getOrElse(ExecConnectionScope.PROJECT) { emptyList() }
         developerSettings.connections = groupedSettings.getOrElse(ExecConnectionScope.PROJECT_PERSONAL) { emptyList() }

--- a/modules/solr/exec/src/sap/commerce/toolset/solr/exec/settings/state/SolrConnectionSettingsState.kt
+++ b/modules/solr/exec/src/sap/commerce/toolset/solr/exec/settings/state/SolrConnectionSettingsState.kt
@@ -72,7 +72,7 @@ data class SolrConnectionSettingsState(
         var socketTimeout: Int,
     ) : ExecConnectionSettingsState.Mutable {
 
-        override fun immutable() = SolrConnectionSettingsState(
+        override fun immutable(): Pair<SolrConnectionSettingsState, ExecConnectionCredentials?> = SolrConnectionSettingsState(
             uuid = uuid,
             scope = scope,
             name = name.get(),
@@ -82,6 +82,9 @@ data class SolrConnectionSettingsState(
             ssl = ssl.get(),
             timeout = timeout,
             socketTimeout = socketTimeout,
-        ) to ExecConnectionCredentials(Credentials(username.get(), password.get()))
+        ) to credentials()
+
+        // credentials are lazily loaded by the connection dialog, an untouched connection knows nothing about them
+        private fun credentials() = if (modified) ExecConnectionCredentials(Credentials(username.get(), password.get())) else null
     }
 }

--- a/modules/solr/exec/tests/sap/commerce/toolset/solr/exec/settings/state/SolrConnectionSettingsStateTest.kt
+++ b/modules/solr/exec/tests/sap/commerce/toolset/solr/exec/settings/state/SolrConnectionSettingsStateTest.kt
@@ -1,0 +1,63 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.solr.exec.settings.state
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for [SolrConnectionSettingsState.Mutable.immutable].
+ *
+ * Credentials of a connection are loaded lazily by the connection dialog, therefore an untouched `Mutable`
+ * carries blank credentials which must never reach the credential store.
+ */
+class SolrConnectionSettingsStateTest {
+
+    private fun mutable(host: String = "localhost") = SolrConnectionSettingsState(host = host).mutable()
+
+    @Test
+    fun immutable_notModified_hasNoCredentials() {
+        val (_, credentials) = mutable().immutable()
+
+        assertNull(credentials)
+    }
+
+    @Test
+    fun immutable_notModified_stillHasSettings() {
+        val (settings, _) = mutable(host = "solr.example.com").immutable()
+
+        assertEquals("solr.example.com", settings.host)
+    }
+
+    @Test
+    fun immutable_modified_hasCredentials() {
+        val mutable = mutable().apply {
+            username.set("solr")
+            password.set("solrRocks")
+            modified = true
+        }
+
+        val credentials = assertNotNull(mutable.immutable().second).credentials
+
+        assertEquals("solr", credentials.userName)
+        assertEquals("solrRocks", credentials.getPasswordAsString())
+    }
+}


### PR DESCRIPTION
Saving the hAC / Solr connection settings wiped the stored credentials of every connection the user did not open in that same settings session.

### Cause

`ConnectionSettingsDialog` loads credentials lazily — an untouched `Mutable` carries blank `username`/`password`. `immutable()` turned those blanks into an `ExecConnectionCredentials` regardless, and `save()` first purged the credentials of *all* persisted connections and then wrote back whatever each `Mutable` carried. For an untouched connection that meant blanks overwriting the real credentials, after which hAC silently fell back to `defaultCredentials` (`admin`/`nimda`).

### Fix

- `Mutable.immutable()` now returns `null` credentials unless `modified` is set, i.e. unless the credentials were actually loaded or entered. `null` means *unknown* and leaves the credential store untouched — the same guard `CCv2ProjectSettingsConfigurableProvider.apply()` already uses.
- `save()` purges credentials only for connections that are genuinely gone, via the new `obsoleteFor` helper (matched by `uuid`, so a scope change keeps the credentials).
- `update()` no longer purges credentials during its delete/create cycle — `onUpdate` is the single writer. This keeps unknown credentials intact on that path too, and removes a race where the erase and the write were queued as two unordered background tasks against the same `CredentialAttributes`.

### Tests

14 unit tests, no IntelliJ platform fixtures required:

- `UtilTest` (6) — `obsoleteFor`: all retained, one removed, nothing retained, scope changed but UUID kept, new connection added, empty persisted list.
- `HacConnectionSettingsStateTest` (5) / `SolrConnectionSettingsStateTest` (3) — `immutable()` yields `null` credentials when untouched and real credentials once `modified`.

### Verification

- `:exec-core:test`, `:hac-exec:test`, `:solr-exec:test` — 14 passed, 0 failed
- `:hac-ui`, `:solr-ui`, `:exec-ui`, `:ccv2-ui` compile

> Labels `HAC` + `Solr` and milestone `2026.2.2` still need to be applied by a maintainer — I do not have triage rights on this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
