### PR TITLE
Project Import | Added support of the `localextensions.xml` definition without any scan paths defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 <cite>Release contributors</code>
 - 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Aflup-repo+is%3Apr)
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Amlytvyn+is%3Apr)
+- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
 
 ### `Project Import` enhancements
 - Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
 - Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
+- Added support of the localextensions.xml definition without any scan paths defined [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
 
 ## [2026.2.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,13 @@
-## [2026.2.3]
-
-<cite>Release contributors</code>
-- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
-
-### `Project Import` enhancements
-- Fixed broken project import for localextension files without scan path [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
-
 ## [2026.2.2]
 
 <cite>Release contributors</code>
 - 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Aflup-repo+is%3Apr)
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Amlytvyn+is%3Apr)
+- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
 
 ### Fixes
 - Keep credentials of the `HAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
+- Fixed broken project import for localextension files without scan path [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
 
 ### Other enhancements
 - Unified crud table API [#1993](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1993)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,24 @@
+## [2026.2.3]
+
+<cite>Release contributors</code>
+- 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Aflup-repo+is%3Apr)
+- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Amlytvyn+is%3Apr)
+- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
+
+### `Project Import` enhancements
+- Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
+- Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
+- Added support of the localextensions.xml definition without any scan paths defined [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
+
 ## [2026.2.2]
 
 <cite>Release contributors</code>
 - 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Aflup-repo+is%3Apr)
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Amlytvyn+is%3Apr)
-- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
+
 
 ### Fixes
 - Keep credentials of the `HAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
-- Fixed broken project import for localextension files without scan path [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
 
 ### Other enhancements
 - Unified crud table API [#1993](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1993)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Aflup-repo+is%3Apr)
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.2+author%3Amlytvyn+is%3Apr)
 
-
 ### Fixes
 - Keep credentials of the `HAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2026.2.3]
+
+<cite>Release contributors</code>
+- 1 PR(s) by [Rainer Baun](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Arbaun-berner+is%3Apr)
+
+### `Project Import` enhancements
+- Fixed broken project import for localextension files without scan path [#1995](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1995)
+
 ## [2026.2.2]
 
 <cite>Release contributors</code>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,4 @@
 - Sina Bastani
 - Fabio Elias Filpi
 - Flaviu Lupoian
+- Rainer Baun

--- a/modules/project/localextensions/build.gradle.kts
+++ b/modules/project/localextensions/build.gradle.kts
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+
 fun properties(key: String) = providers.gradleProperty(key)
 
 plugins {
@@ -43,11 +45,14 @@ dependencies {
     implementation(libs.bundles.jaxb)
     implementation(project(":shared-core"))
     implementation(project(":project-extensioninfo"))
+    testImplementation(kotlin("test-junit"))
 
     intellijPlatform {
         intellijIdea(properties("intellij.version")) {
             useInstaller = true
         }
+
+        testFramework(TestFrameworkType.Platform)
 
         bundledModules(
             "intellij.spellchecker",

--- a/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
+++ b/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
@@ -78,9 +78,12 @@ class LocalExtensionsProcessor {
     fun getSuitableExtension(
         foundExtensions: Collection<FoundExtension>,
         context: LocalExtensionsContext,
-    ): FoundExtension? = foundExtensions
-        .firstOrNull { extension ->
-            context.extensions[extension.name]?.path?.normalize() == extension.moduleRootPath.normalize()
+    ): FoundExtension? = context.extensions
+        .takeIf { context.scanTypes.isEmpty() }
+        ?.let { extensions ->
+            foundExtensions.firstOrNull { extension ->
+                extensions[extension.name]?.path?.normalize() == extension.moduleRootPath.normalize()
+            }
         }
         ?: context.scanTypes.values
             .firstNotNullOfOrNull { scanType ->

--- a/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
+++ b/modules/project/localextensions/src/sap/commerce/toolset/localextensions/LocalExtensionsProcessor.kt
@@ -21,7 +21,6 @@ package sap.commerce.toolset.localextensions
 import com.intellij.openapi.application.readAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.util.PropertiesUtil
 import com.intellij.util.application
 import sap.commerce.toolset.HybrisConstants
@@ -51,10 +50,6 @@ class LocalExtensionsProcessor {
             ?: return@readAction null
 
         val scanTypes = getScanTypes(hybrisConfig, expandedProperties)
-            ?: run {
-                thisLogger().warn("No scan types defined in the localextensions.xml.")
-                return@readAction null
-            }
 
         val extensions = buildMap {
             // declared via `path autoload="true"`
@@ -83,20 +78,24 @@ class LocalExtensionsProcessor {
     fun getSuitableExtension(
         foundExtensions: Collection<FoundExtension>,
         context: LocalExtensionsContext,
-    ): FoundExtension? = context.scanTypes.values
-        .firstNotNullOfOrNull { scanType ->
-            foundExtensions.firstOrNull { extension ->
-                val moduleDir = extension.moduleRootPath.normalize().pathString
-                val scanTypeNormalizedPath = scanType.normalizedPath.pathString
-                moduleDir.startsWith(scanTypeNormalizedPath)
-                    && Paths.get(moduleDir.substring(scanTypeNormalizedPath.length)).nameCount <= scanType.depth
-            }
+    ): FoundExtension? = foundExtensions
+        .firstOrNull { extension ->
+            context.extensions[extension.name]?.path?.normalize() == extension.moduleRootPath.normalize()
         }
+        ?: context.scanTypes.values
+            .firstNotNullOfOrNull { scanType ->
+                foundExtensions.firstOrNull { extension ->
+                    val moduleDir = extension.moduleRootPath.normalize().pathString
+                    val scanTypeNormalizedPath = scanType.normalizedPath.pathString
+                    moduleDir.startsWith(scanTypeNormalizedPath)
+                        && Paths.get(moduleDir.substring(scanTypeNormalizedPath.length)).nameCount <= scanType.depth
+                }
+            }
 
     private fun getScanTypes(
         hybrisConfig: Hybrisconfig,
         expandedProperties: Map<String, String>
-    ): Map<String, ScanType>? {
+    ): Map<String, ScanType> {
         val scanTypes = mutableMapOf<String, ScanType>()
 
         hybrisConfig.getExtensions().getPath().forEach { scanType ->
@@ -116,8 +115,6 @@ class LocalExtensionsProcessor {
                 }
             }
         }
-
-        if (scanTypes.isEmpty()) return null
 
         scanTypes.entries.forEach { (dir, scanType) ->
             scanType.normalizedPath = dir.toNormalizedPath(expandedProperties)

--- a/modules/project/localextensions/tests/sap/commerce/toolset/localextensions/LocalExtensionsProcessorTest.kt
+++ b/modules/project/localextensions/tests/sap/commerce/toolset/localextensions/LocalExtensionsProcessorTest.kt
@@ -1,0 +1,103 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.localextensions
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import kotlinx.coroutines.runBlocking
+import sap.commerce.toolset.localextensions.context.FoundExtension
+import sap.commerce.toolset.localextensions.context.LocalExtensionsContext
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.pathString
+import kotlin.io.path.writeText
+
+class LocalExtensionsProcessorTest : BasePlatformTestCase() {
+
+    private lateinit var tempDirectory: Path
+
+    override fun setUp() {
+        super.setUp()
+        tempDirectory = Files.createTempDirectory("localextensions-processor-test")
+    }
+
+    override fun tearDown() {
+        try {
+            tempDirectory.toFile().deleteRecursively()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun testCreatesContextForExplicitDirOnlyExtensions() = runBlocking {
+        val configDirectory = tempDirectory.resolve("config").createDirectories()
+        val platformDirectory = tempDirectory.resolve("hybris")
+        platformDirectory.resolve("bin/platform").createDirectories()
+            .resolve("env.properties")
+            .writeText("")
+        val extensionDirectory = tempDirectory.resolve("custom/sampleextension").createDirectories()
+        extensionDirectory.resolve("extensioninfo.xml").writeText(
+            """
+                <extensioninfo>
+                    <extension name="sampleextension"/>
+                </extensioninfo>
+            """.trimIndent()
+        )
+        configDirectory.resolve("localextensions.xml").writeText(
+            """
+                <hybrisconfig>
+                    <extensions>
+                        <extension dir="${extensionDirectory.pathString}"/>
+                    </extensions>
+                </hybrisconfig>
+            """.trimIndent()
+        )
+
+        val context = kotlin.test.assertNotNull(
+            LocalExtensionsProcessor().getContext(
+                configDirectory = configDirectory,
+                platformDirectory = platformDirectory,
+                foundExtensions = listOf(FoundExtension("sampleextension", extensionDirectory)),
+            )
+        )
+
+        kotlin.test.assertTrue(context.scanTypes.isEmpty())
+        kotlin.test.assertEquals(extensionDirectory, context.extensions["sampleextension"]?.path)
+    }
+
+    fun testSelectsExplicitlyDeclaredExtensionWithoutScanPaths() {
+        val declaredDirectory = tempDirectory.resolve("declared/sampleextension")
+        val duplicateDirectory = tempDirectory.resolve("duplicate/sampleextension")
+        val context = LocalExtensionsContext(
+            extensions = mapOf(
+                "sampleextension" to LocalExtensionsContext.Extension("sampleextension", declaredDirectory),
+            )
+        )
+
+        val extension = LocalExtensionsProcessor().getSuitableExtension(
+            foundExtensions = listOf(
+                FoundExtension("sampleextension", duplicateDirectory),
+                FoundExtension("sampleextension", declaredDirectory),
+            ),
+            context = context,
+        )
+
+        kotlin.test.assertEquals(declaredDirectory, extension?.moduleRootPath)
+    }
+}

--- a/modules/project/localextensions/tests/sap/commerce/toolset/localextensions/LocalExtensionsProcessorTest.kt
+++ b/modules/project/localextensions/tests/sap/commerce/toolset/localextensions/LocalExtensionsProcessorTest.kt
@@ -100,4 +100,28 @@ class LocalExtensionsProcessorTest : BasePlatformTestCase() {
 
         kotlin.test.assertEquals(declaredDirectory, extension?.moduleRootPath)
     }
+
+    fun testRetainsScanPathPriorityForDuplicateExtensions() {
+        val preferredDirectory = tempDirectory.resolve("preferred/sampleextension")
+        val secondaryDirectory = tempDirectory.resolve("secondary/sampleextension")
+        val context = LocalExtensionsContext(
+            scanTypes = linkedMapOf(
+                "preferred" to ScanType("preferred", false, 1, tempDirectory.resolve("preferred")),
+                "secondary" to ScanType("secondary", false, 1, tempDirectory.resolve("secondary")),
+            ),
+            extensions = mapOf(
+                "sampleextension" to LocalExtensionsContext.Extension("sampleextension", secondaryDirectory),
+            ),
+        )
+
+        val extension = LocalExtensionsProcessor().getSuitableExtension(
+            foundExtensions = listOf(
+                FoundExtension("sampleextension", secondaryDirectory),
+                FoundExtension("sampleextension", preferredDirectory),
+            ),
+            context = context,
+        )
+
+        kotlin.test.assertEquals(preferredDirectory, extension?.moduleRootPath)
+    }
 }


### PR DESCRIPTION
Example `localextensions.xml` without ScanType paths:
```xml
<hybrisconfig xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='../bin/platform/resources/schemas/extensions.xsd'>
  <extensions>
<!--    <path dir='${HYBRIS_BIN_DIR}' autoload='false' />-->
    <extension name='someCore' dir="${HYBRIS_BIN_DIR}/custom/some/someCore" />
  </extensions>
</hybrisconfig>
```

Plugin should support the case when dependency on every extension is explicitly defined in the `localextensions.xml` without any scan paths, see more here [Configuration Options in localextensions.xml](https://help.sap.com/docs/SAP_COMMERCE/b490bb4e85bc42a7aa09d513d0bcb18e/cce26d8ef435425fb9e054d91794148c.html?locale=en-US)

---

Signed-off-by: rainer.baun@berner.eu
