### PR TITLE
Project Import | Exclude Spock specific `resources/META-INF/services` directory from the module library roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,12 @@
 ## [2026.2.3]
 
 <cite>Release contributors</code>
+- 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Aflup-repo+is%3Apr)
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Amlytvyn+is%3Apr)
-
-### Fixes
-- Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
 
 ### `Project Import` enhancements
 - Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
+- Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
 
 ## [2026.2.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 <cite>Release contributors</code>
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Amlytvyn+is%3Apr)
 
+### Fixes
+- Exclude Spock specific `resources/META-INF/services` directory from the module library roots
+
 ### `Project Import` enhancements
 - Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.3+author%3Amlytvyn+is%3Apr)
 
 ### Fixes
-- Exclude Spock specific `resources/META-INF/services` directory from the module library roots
+- Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
 
 ### `Project Import` enhancements
 - Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeCommonsContentRootEntryConfigurator.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/contentEntry/ExcludeCommonsContentRootEntryConfigurator.kt
@@ -47,7 +47,7 @@ class ExcludeCommonsContentRootEntryConfigurator : ModuleContentRootEntryConfigu
         val excludePaths = buildList {
             add(moduleRootPath.resolve(HybrisConstants.EXTERNAL_TOOL_BUILDERS_DIRECTORY))
             add(moduleRootPath.resolve(HybrisConstants.SETTINGS_DIRECTORY))
-            add(moduleRootPath.resolve(HybrisConstants.SPOCK_META_INF_SERVICES_DIRECTORY))
+            add(moduleRootPath.resolve(ProjectConstants.Directory.RESOURCES).resolve(ProjectConstants.Directory.META_INF_SERVICES))
             add(moduleRootPath.resolve(ProjectConstants.Directory.NODE_MODULES))
             add(moduleRootPath.resolve(ProjectConstants.Directory.TEST_CLASSES))
             add(moduleRootPath.resolve(ProjectConstants.Directory.ECLIPSE_BIN))

--- a/modules/java/core/src/sap/commerce/toolset/java/configurator/library/util/LibraryExcludeUtil.kt
+++ b/modules/java/core/src/sap/commerce/toolset/java/configurator/library/util/LibraryExcludeUtil.kt
@@ -27,7 +27,11 @@ import kotlin.io.path.Path
 
 fun ModuleDescriptor.excludedResources(virtualFileUrlManager: VirtualFileUrlManager) = this.moduleRootPath
     .resolve(ProjectConstants.Directory.RESOURCES)
-    .excludedRoots(virtualFileUrlManager, Path(ProjectConstants.Directory.NPM))
+    .excludedRoots(
+        virtualFileUrlManager,
+        Path(ProjectConstants.Directory.NPM),
+        Path(ProjectConstants.Directory.META_INF_SERVICES),
+    )
 
 private fun Path.excludedRoots(virtualFileUrlManager: VirtualFileUrlManager, vararg paths: Path) = paths
     .map { this.resolve(it) }

--- a/modules/project/core/src/sap/commerce/toolset/project/ProjectConstants.kt
+++ b/modules/project/core/src/sap/commerce/toolset/project/ProjectConstants.kt
@@ -76,6 +76,7 @@ object ProjectConstants {
         const val ADDON_TEST_SRC = "addontestsrc"
 
         const val RESOURCES = "resources"
+        const val META_INF_SERVICES = "META-INF/services"
         const val ECLIPSE_BIN = "eclipsebin"
         const val NPM = "npm"
         const val NODE_MODULES = "node_modules"

--- a/modules/shared/core/src/sap/commerce/toolset/HybrisConstants.kt
+++ b/modules/shared/core/src/sap/commerce/toolset/HybrisConstants.kt
@@ -42,7 +42,6 @@ object HybrisConstants {
     const val JAR_MODELS = "models.jar"
     const val SETTINGS_DIRECTORY = ".settings"
     const val EXTERNAL_TOOL_BUILDERS_DIRECTORY = ".externalToolBuilders"
-    const val SPOCK_META_INF_SERVICES_DIRECTORY = "resources/META-INF/services"
 
     const val PLATFORM_HOME_PLACEHOLDER = "\${platformhome}"
 


### PR DESCRIPTION
The import model excludes `resources/META-INF/services` from the module content root, but the same import path adds the module's whole `resources` directory as a compile module library root, and the library exclusion helper covered only `resources/npm`. The generated project model therefore carried both sides of the mismatch, and IntelliJ kept reporting the directory as indexable although it was excluded from the content root filter:

```text
WARN - #c.i.u.i.p.ProjectIndexableFilesFilterHealthCheck - Following files are indexable but they were NOT found in filter. Errors count: 2. Examples:
file id=8998 path=.../hybris/bin/platform/ext/core/resources/META-INF/services
file id=534988 path=.../hybris/bin/platform/ext/core/resources/META-INF/services/org.junit.platform.launcher.PostDiscoveryFilter
```

The exclusion is only effective in write mode, where `resources` is a resource source root. With OOTB modules imported in read-only mode (the default) `resources` reaches the model as a library root instead, which the content root exclusion cannot filter.

The library exclusion helper now excludes `resources/META-INF/services` next to `resources/npm`, so both `Compile` and `Addon` module libraries emit it. Modules without the directory are unaffected — non-existent paths are already dropped while resolving the excluded roots.

Library excluded roots affect IDE indexing and resolution only; the directory stays on the compilation and test classpath.

Signed-off-by: Flaviu Lupoian <lupoianflaviu@gmail.com>
