### PR TITLE
Other | `2026.2.1` backport to `2026.0.16` API adjustment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,29 @@
 ## [2026.0.16]
 
+<cite>Release contributors</code>
+- 1 PR(s) by [Mykhailo Lytvyn](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.0.16+author%3Amlytvyn+is%3Apr)
+
 ### `Project Import` enhancements
-- `2026.2.3` back-port | Rainer Baun | Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
-- `2026.2.3` back-port | Flaviu Lupoian | Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
+- `2026.2.3` backport | Rainer Baun | Skip state validation of the built-in plugins during the import [#1996](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1996)
+- `2026.2.3` backport | Flaviu Lupoian | Exclude Spock specific `resources/META-INF/services` directory from the module library roots [#1997](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1997)
 
 ### `Spring` enhancements
-- `2026.2.1` back-port | Mykhailo Lytvyn | Improved "Simple Spring" and added parent beans resolution in Non-Ultimate edition [#1985](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1985)
+- `2026.2.1` backport | Mykhailo Lytvyn | Improved "Simple Spring" and added parent beans resolution in Non-Ultimate edition [#1985](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1985)
 
 ### `CCv2` enhancements
-- `2026.2.1` back-port | Mykhailo Lytvyn | Show informative message when authentication failed [#1984](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1984)
+- `2026.2.1` backport | Mykhailo Lytvyn | Show informative message when authentication failed [#1984](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1984)
 
 ### `AI` capabilities
-- `2026.2.1` back-port | Mykhailo Lytvyn | Expose the complete TypeSystem as MCP tool [#1987](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1987)
-- `2026.2.1` back-port | Mykhailo Lytvyn | Expose the complete Bean System as MCP tool [#1988](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1988)
-- `2026.2.1` back-port | Mykhailo Lytvyn | Expose CCv2 management operations as MCP tools [#1989](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1989)
-- `2026.2.1` back-port | Mykhailo Lytvyn | Expose business processes via MCP tool [#1990](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1990)
+- `2026.2.1` backport | Mykhailo Lytvyn | Expose the complete TypeSystem as MCP tool [#1987](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1987)
+- `2026.2.1` backport | Mykhailo Lytvyn | Expose the complete Bean System as MCP tool [#1988](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1988)
+- `2026.2.1` backport | Mykhailo Lytvyn | Expose CCv2 management operations as MCP tools [#1989](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1989)
+- `2026.2.1` backport | Mykhailo Lytvyn | Expose business processes via MCP tool [#1990](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1990)
 
 ### Fixes
-- `2026.2.1` back-port | Flaviu Lupoian | Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
+- `2026.2.1` backport | Flaviu Lupoian | Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
+
+### Other
+- `2026.2.1` backport to `2026.0.16` API adjustment [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
 
 ## [2026.0.15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `2026.2.1` backport | Flaviu Lupoian | Keep credentials of the `hAC` and `Solr` connections which were not opened before saving the connection settings [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
 
 ### Other
-- `2026.2.1` backport to `2026.0.16` API adjustment [#1992](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1992)
+- `2026.2.1` backport to `2026.0.16` API adjustment [#1999](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/1999)
 
 ## [2026.0.15]
 

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/Util.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/Util.kt
@@ -48,7 +48,7 @@ fun Row.sUser(project: Project, sUserId: String, icon: Icon, label: String = "Cr
         .comment(label)
         .applyToComponent {
             HelpTooltip()
-                .setPlainTextTitle { "Define an alias for the S-User" }
+                .setTitle { "Define an alias for the S-User" }
                 .installOn(this)
         }
 }

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/view/CCv2EnvironmentDetailsView.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/view/CCv2EnvironmentDetailsView.kt
@@ -761,7 +761,7 @@ class CCv2EnvironmentDetailsView(
                                         .comment("Account key")
                                         .applyToComponent {
                                             HelpTooltip()
-                                                .setPlainTextTitle { "Click to copy to clipboard" }
+                                                .setTitle { "Click to copy to clipboard" }
                                                 .installOn(this)
                                         }
                                         .component

--- a/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/view/CCv2EnvironmentsDataView.kt
+++ b/modules/ccv2/ui/src/sap/commerce/toolset/ccv2/ui/view/CCv2EnvironmentsDataView.kt
@@ -150,7 +150,7 @@ object CCv2EnvironmentsDataView : CCv2DataView<CCv2EnvironmentDto>() {
                         .comment("Build name")
                         .applyToComponent {
                             HelpTooltip()
-                                .setPlainTextTitle { "Show build details" }
+                                .setTitle { "Show build details" }
                                 .installOn(this)
                         }
                 }

--- a/modules/shared/ui/src/sap/commerce/toolset/ui/Dsl.kt
+++ b/modules/shared/ui/src/sap/commerce/toolset/ui/Dsl.kt
@@ -138,7 +138,7 @@ fun Row.copyLink(
         .comment(label)
         .applyToComponent {
             HelpTooltip()
-                .setPlainTextTitle { "Click to copy to clipboard" }
+                .setTitle { "Click to copy to clipboard" }
                 .installOn(this)
         }
 }


### PR DESCRIPTION
All backported to `2026.0.16` release -> https://github.com/epam/sap-commerce-intellij-idea-plugin/issues?q=label%3A%22Backported%20to%202026.0.16%22