### PR TITLE
FlexibleSearch | Execute a query expecting more rows than the console limit via Groovy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Report row count and reached `maxCount` limit in the FlexibleSearch and SQL MCP tool results [#2000](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/2000)
 
 ### `FlexibleSearch` enhancements
-- Execute a query expecting more rows than the HAC console limit on the Service Layer via Groovy
+- Execute a query expecting more rows than the HAC console limit on the Service Layer via Groovy [#2001](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/2001)
 
 ## [2026.2.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## [2026.2.4]
 
 <cite>Release contributors</code>
-- 1 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.4+author%3Aflup-repo+is%3Apr)
+- 2 PR(s) by [Flaviu Lupoian](https://github.com/epam/sap-commerce-intellij-idea-plugin/pulls?q=milestone%3A2026.2.4+author%3Aflup-repo+is%3Apr)
 
 ### `AI` capabilities
 - Report row count and reached `maxCount` limit in the FlexibleSearch and SQL MCP tool results [#2000](https://github.com/epam/sap-commerce-intellij-idea-plugin/pull/2000)
+
+### `FlexibleSearch` enhancements
+- Execute a query expecting more rows than the HAC console limit on the Service Layer via Groovy
 
 ## [2026.2.3]
 

--- a/modules/flexibleSearch/exec/build.gradle.kts
+++ b/modules/flexibleSearch/exec/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(project(":console-core"))
     implementation(project(":console-ui"))
     implementation(project(":flexibleSearch-core"))
+    implementation(project(":groovy-exec"))
     implementation(project(":hac-exec"))
 
     testImplementation(kotlin("test"))

--- a/modules/flexibleSearch/exec/resources/scripts/flexibleSearch-execute.groovy
+++ b/modules/flexibleSearch/exec/resources/scripts/flexibleSearch-execute.groovy
@@ -18,7 +18,7 @@
 
 
 import de.hybris.platform.servicelayer.search.FlexibleSearchQuery
-import de.hybris.platform.servicelayer.search.FlexibleSearchService
+import de.hybris.platform.servicelayer.session.SessionExecutionBody
 import groovy.json.JsonOutput
 
 /*
@@ -29,6 +29,11 @@ The following contract is expected:
  - `placeholder_query` will be used to inject the FlexibleSearch query, it must not contain a triple quote.
  - `placeholder_columnCount` will be used to inject the number of the columns of the query.
  - `placeholder_maxCount` will be used to inject the maximum number of the rows to return.
+ - `placeholder_locale` will be used to inject the language tag of the locale of the query.
+ - `placeholder_user` will be used to inject the UID of the user to execute the query as, empty for the
+   current session user. The query is executed in a local view, therefore the search restrictions of that
+   user apply, exactly as they do for the execution via the HAC console.
+ - services are resolved via the `spring` binding, as not every one of them is bound by the HAC console.
  - script must print the results as a return value of the script.
  - result must be a json array of the rows, each row being a json array of the column values as strings,
    also for a single column query, which is returned by the Service Layer as a flat list of the values.
@@ -39,16 +44,38 @@ The following contract is expected:
 [["8796093054993","MWST"],["8796093087761","ZDVP"]]
  */
 
-def fss = flexibleSearchService as FlexibleSearchService
+def fss = spring.getBean('flexibleSearchService')
+def sessionService = spring.getBean('sessionService')
+def i18nService = spring.getBean('i18nService')
+def userService = spring.getBean('userService')
 
-def query = new FlexibleSearchQuery('''placeholder_query''')
-query.setResultClassList([String.class] * placeholder_columnCount)
-query.setCount(placeholder_maxCount)
+def userUid = '''placeholder_user'''
+def locale = Locale.forLanguageTag('''placeholder_locale''')
 
-def rows = fss.search(query).result
-        .collect { row ->
-            // a single column query is returned as a flat list of the values, not as a list of the rows
-            (row instanceof List ? row : [row]).collect { value -> value?.toString() }
-        }
+def search = {
+    i18nService.setCurrentLocale(locale)
+
+    def query = new FlexibleSearchQuery('''placeholder_query''')
+    query.setResultClassList([String.class] * placeholder_columnCount)
+    query.setCount(placeholder_maxCount)
+    query.setLocale(locale)
+
+    return fss.search(query).result
+            .collect { row ->
+                // a single column query is returned as a flat list of the values, not as a list of the rows
+                (row instanceof List ? row : [row]).collect { value -> value?.toString() }
+            }
+}
+
+def body = new SessionExecutionBody() {
+    Object execute() {
+        return search()
+    }
+}
+
+// a local view keeps the locale of the query and the restrictions of the user out of the current session
+def rows = userUid.isEmpty()
+        ? sessionService.executeInLocalView(body)
+        : sessionService.executeInLocalView(body, userService.getUserForUID(userUid))
 
 return JsonOutput.toJson(rows)

--- a/modules/flexibleSearch/exec/resources/scripts/flexibleSearch-execute.groovy
+++ b/modules/flexibleSearch/exec/resources/scripts/flexibleSearch-execute.groovy
@@ -1,0 +1,54 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+import de.hybris.platform.servicelayer.search.FlexibleSearchQuery
+import de.hybris.platform.servicelayer.search.FlexibleSearchService
+import groovy.json.JsonOutput
+
+/*
+This script is being used by the Plugin to execute a FlexibleSearch query which expects more rows than the
+HAC FlexibleSearch console is willing to return, therefore the query is executed on the Service Layer instead.
+
+The following contract is expected:
+ - `placeholder_query` will be used to inject the FlexibleSearch query, it must not contain a triple quote.
+ - `placeholder_columnCount` will be used to inject the number of the columns of the query.
+ - `placeholder_maxCount` will be used to inject the maximum number of the rows to return.
+ - script must print the results as a return value of the script.
+ - result must be a json array of the rows, each row being a json array of the column values as strings,
+   also for a single column query, which is returned by the Service Layer as a flat list of the values.
+ - `null` column value must be reported as a json `null`.
+
+======= Example =======
+-- Output --
+[["8796093054993","MWST"],["8796093087761","ZDVP"]]
+ */
+
+def fss = flexibleSearchService as FlexibleSearchService
+
+def query = new FlexibleSearchQuery('''placeholder_query''')
+query.setResultClassList([String.class] * placeholder_columnCount)
+query.setCount(placeholder_maxCount)
+
+def rows = fss.search(query).result
+        .collect { row ->
+            // a single column query is returned as a flat list of the values, not as a list of the rows
+            (row instanceof List ? row : [row]).collect { value -> value?.toString() }
+        }
+
+return JsonOutput.toJson(rows)

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
@@ -62,6 +62,9 @@ class FlexibleSearchExecClient(
      *
      * The column names are not reported by the Service Layer result, therefore they are taken from a probing
      * execution of the very same query on the HAC, limited to a single row.
+     *
+     * The script executes the query in a local view of the session, hence the locale and the search restrictions
+     * of the requested user are applied exactly as they are by the HAC console.
      */
     private suspend fun executeOnServiceLayer(context: FlexibleSearchExecContext): FlexibleSearchExecResult {
         val probe = executeOnHac(context.copy(maxCount = 1))
@@ -73,6 +76,8 @@ class FlexibleSearchExecClient(
             .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_QUERY, context.content)
             .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_COLUMN_COUNT, headers.size.toString())
             .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_MAX_COUNT, context.maxCount.toString())
+            .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_LOCALE, context.locale.lowercase())
+            .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_USER, context.user ?: "")
 
         val groovyResult = GroovyExecClient.getInstance(project).execute(
             GroovyExecContext(

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecClient.kt
@@ -31,8 +31,13 @@ import org.apache.http.message.BasicNameValuePair
 import sap.commerce.toolset.exec.ExecClient
 import sap.commerce.toolset.flexibleSearch.exec.context.FlexibleSearchExecContext
 import sap.commerce.toolset.flexibleSearch.exec.context.FlexibleSearchExecResult
+import sap.commerce.toolset.flexibleSearch.exec.context.QueryMode
 import sap.commerce.toolset.flexibleSearch.exec.context.TableBuilder
+import sap.commerce.toolset.groovy.exec.GroovyExecClient
+import sap.commerce.toolset.groovy.exec.context.GroovyExecContext
 import sap.commerce.toolset.hac.exec.http.HacHttpClient
+import sap.commerce.toolset.readResource
+import sap.commerce.toolset.settings.state.TransactionMode
 import java.io.Serial
 
 @Service(Service.Level.PROJECT)
@@ -46,7 +51,60 @@ class FlexibleSearchExecClient(
         errorDetailMessage = exception.stackTraceToString()
     )
 
-    override suspend fun execute(context: FlexibleSearchExecContext): FlexibleSearchExecResult {
+    override suspend fun execute(context: FlexibleSearchExecContext): FlexibleSearchExecResult = when {
+        context.executableOnServiceLayer -> executeOnServiceLayer(context)
+        else -> executeOnHac(context)
+    }
+
+    /**
+     * Executes the query on the Service Layer via Groovy, as the HAC FlexibleSearch console does not return more
+     * than [FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT] rows.
+     *
+     * The column names are not reported by the Service Layer result, therefore they are taken from a probing
+     * execution of the very same query on the HAC, limited to a single row.
+     */
+    private suspend fun executeOnServiceLayer(context: FlexibleSearchExecContext): FlexibleSearchExecResult {
+        val probe = executeOnHac(context.copy(maxCount = 1))
+        val headers = probe.headers
+            ?.takeIf { probe.statusCode == HttpStatus.SC_OK }
+            ?: return probe
+
+        val script = readResource(FlexibleSearchExecConstants.Scripts.EXECUTE)
+            .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_QUERY, context.content)
+            .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_COLUMN_COUNT, headers.size.toString())
+            .replace(FlexibleSearchExecConstants.Scripts.PLACEHOLDER_MAX_COUNT, context.maxCount.toString())
+
+        val groovyResult = GroovyExecClient.getInstance(project).execute(
+            GroovyExecContext(
+                connection = context.connection,
+                executionTitle = context.executionTitle,
+                content = script,
+                transactionMode = TransactionMode.ROLLBACK,
+                timeout = context.timeout,
+            )
+        )
+
+        if (groovyResult.hasError) return FlexibleSearchExecResult(
+            statusCode = HttpStatus.SC_BAD_REQUEST,
+            errorMessage = groovyResult.errorMessage,
+            errorDetailMessage = groovyResult.errorDetailMessage,
+        )
+
+        val rows = groovyResult.result
+            ?.let { parseRows(it) }
+            ?: return FlexibleSearchExecResult(
+                statusCode = HttpStatus.SC_BAD_REQUEST,
+                errorMessage = "Cannot parse rows returned by the Service Layer execution of the query",
+            )
+
+        return FlexibleSearchExecResult(
+            output = buildTableResult(headers, rows),
+            headers = headers,
+            rows = rows,
+        )
+    }
+
+    private suspend fun executeOnHac(context: FlexibleSearchExecContext): FlexibleSearchExecResult {
         val connection = context.connection
         val actionUrl = "${connection.generatedURL}/console/flexsearch/execute"
         val params = context.params()
@@ -94,6 +152,14 @@ class FlexibleSearchExecClient(
             )
         }
     }
+
+    /**
+     * Rows of the Service Layer execution as a json array of the arrays of the nullable column values.
+     */
+    private fun parseRows(json: String): List<List<String>>? = runCatching {
+        Gson().fromJson(json, Array<Array<String?>>::class.java)
+            .map { row -> row.map { value -> value ?: "" } }
+    }.getOrNull()
 
     private fun buildTableResult(headers: List<String>?, rows: List<List<String>>?): String {
         val tableBuilder = TableBuilder()

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecConstants.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecConstants.kt
@@ -44,6 +44,8 @@ object FlexibleSearchExecConstants {
         const val PLACEHOLDER_QUERY = "placeholder_query"
         const val PLACEHOLDER_COLUMN_COUNT = "placeholder_columnCount"
         const val PLACEHOLDER_MAX_COUNT = "placeholder_maxCount"
+        const val PLACEHOLDER_LOCALE = "placeholder_locale"
+        const val PLACEHOLDER_USER = "placeholder_user"
 
         /**
          * The query is injected into a triple quoted Groovy string, therefore it cannot carry one itself.

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecConstants.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/FlexibleSearchExecConstants.kt
@@ -31,6 +31,26 @@ object FlexibleSearchExecConstants {
         const val DATA_SOURCE = "master"
     }
 
+    object Limits {
+        /**
+         * Number of the rows the HAC FlexibleSearch console is expected to return, a query asking for more rows
+         * is executed on the Service Layer via Groovy instead.
+         */
+        const val HAC_MAX_COUNT = 200
+    }
+
+    object Scripts {
+        const val EXECUTE = "scripts/flexibleSearch-execute.groovy"
+        const val PLACEHOLDER_QUERY = "placeholder_query"
+        const val PLACEHOLDER_COLUMN_COUNT = "placeholder_columnCount"
+        const val PLACEHOLDER_MAX_COUNT = "placeholder_maxCount"
+
+        /**
+         * The query is injected into a triple quoted Groovy string, therefore it cannot carry one itself.
+         */
+        const val TRIPLE_QUOTE = "'''"
+    }
+
     object Transform {
         val CONNECTION = Key.create<HacConnectionSettingsState>("flexibleSearch.transform.connection")
         val EXEC_SETTINGS = Key.create<FlexibleSearchExecContext.Settings>("flexibleSearch.transform.execSettings")

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
@@ -62,12 +62,16 @@ data class FlexibleSearchExecContext(
      * Whether the query has to be executed on the Service Layer via Groovy instead of the HAC FlexibleSearch
      * console, which does not return more than [FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT] rows.
      *
+     * The locale and the user of the execution are honoured by the script, the data source is not, therefore a
+     * query against another data source stays on the HAC to never silently report the rows of the wrong one.
+     *
      * Raw SQL is not supported by the Service Layer execution, as is a query carrying a triple quote, which
      * cannot be injected into the Groovy script.
      */
     val executableOnServiceLayer: Boolean
         get() = queryMode == QueryMode.FlexibleSearch
             && maxCount > FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT
+            && dataSource == FlexibleSearchExecConstants.Defaults.DATA_SOURCE
             && !content.contains(FlexibleSearchExecConstants.Scripts.TRIPLE_QUOTE)
 
     fun params(): Map<String, String> = buildMap {

--- a/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
+++ b/modules/flexibleSearch/exec/src/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContext.kt
@@ -27,7 +27,7 @@ import sap.commerce.toolset.settings.state.TransactionMode
 
 data class FlexibleSearchExecContext(
     val connection: HacConnectionSettingsState,
-    private val content: String = "",
+    val content: String = "",
     private val transactionMode: TransactionMode = TransactionMode.ROLLBACK,
     private val queryMode: QueryMode = QueryMode.FlexibleSearch,
     val maxCount: Int,
@@ -57,6 +57,18 @@ data class FlexibleSearchExecContext(
 
     override val executionTitle: String
         get() = "Executing ${queryMode.title} on the remote SAP Commerce instance…"
+
+    /**
+     * Whether the query has to be executed on the Service Layer via Groovy instead of the HAC FlexibleSearch
+     * console, which does not return more than [FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT] rows.
+     *
+     * Raw SQL is not supported by the Service Layer execution, as is a query carrying a triple quote, which
+     * cannot be injected into the Groovy script.
+     */
+    val executableOnServiceLayer: Boolean
+        get() = queryMode == QueryMode.FlexibleSearch
+            && maxCount > FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT
+            && !content.contains(FlexibleSearchExecConstants.Scripts.TRIPLE_QUOTE)
 
     fun params(): Map<String, String> = buildMap {
         put("scriptType", "flexibleSearch")

--- a/modules/flexibleSearch/exec/tests/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContextTest.kt
+++ b/modules/flexibleSearch/exec/tests/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContextTest.kt
@@ -36,11 +36,12 @@ class FlexibleSearchExecContextTest {
         content: String = "SELECT {pk} FROM {Product}",
         maxCount: Int = FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT,
         queryMode: QueryMode = QueryMode.FlexibleSearch,
+        dataSource: String = FlexibleSearchExecConstants.Defaults.DATA_SOURCE,
     ) = FlexibleSearchExecContext(
         connection = HacConnectionSettingsState(),
         content = content,
         queryMode = queryMode,
-        settings = FlexibleSearchExecContext.defaultSettings().copy(maxCount = maxCount),
+        settings = FlexibleSearchExecContext.defaultSettings().copy(maxCount = maxCount, dataSource = dataSource),
     )
 
     @Test
@@ -56,6 +57,16 @@ class FlexibleSearchExecContextTest {
     @Test
     fun `raw SQL is never executed on the service layer`() {
         assertFalse(context(maxCount = 1_000, queryMode = QueryMode.SQL).executableOnServiceLayer)
+    }
+
+    @Test
+    fun `query against another data source is never executed on the service layer`() {
+        assertFalse(context(maxCount = 1_000, dataSource = "junit").executableOnServiceLayer)
+    }
+
+    @Test
+    fun `query against the default data source is executed on the service layer`() {
+        assertTrue(context(maxCount = 1_000, dataSource = FlexibleSearchExecConstants.Defaults.DATA_SOURCE).executableOnServiceLayer)
     }
 
     @Test

--- a/modules/flexibleSearch/exec/tests/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContextTest.kt
+++ b/modules/flexibleSearch/exec/tests/sap/commerce/toolset/flexibleSearch/exec/context/FlexibleSearchExecContextTest.kt
@@ -1,0 +1,65 @@
+/*
+ * This file is part of "SAP Commerce Developers Toolset" plugin for IntelliJ IDEA.
+ * Copyright (C) 2019-2026 EPAM Systems <hybrisideaplugin@epam.com> and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sap.commerce.toolset.flexibleSearch.exec.context
+
+import sap.commerce.toolset.flexibleSearch.exec.FlexibleSearchExecConstants
+import sap.commerce.toolset.hac.exec.settings.state.HacConnectionSettingsState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [FlexibleSearchExecContext.executableOnServiceLayer].
+ *
+ * The HAC FlexibleSearch console does not return more rows than its own limit, therefore a query asking for more
+ * has to be executed on the Service Layer via Groovy instead.
+ */
+class FlexibleSearchExecContextTest {
+
+    private fun context(
+        content: String = "SELECT {pk} FROM {Product}",
+        maxCount: Int = FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT,
+        queryMode: QueryMode = QueryMode.FlexibleSearch,
+    ) = FlexibleSearchExecContext(
+        connection = HacConnectionSettingsState(),
+        content = content,
+        queryMode = queryMode,
+        settings = FlexibleSearchExecContext.defaultSettings().copy(maxCount = maxCount),
+    )
+
+    @Test
+    fun `query within the console limit is executed on the HAC`() {
+        assertFalse(context(maxCount = FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT).executableOnServiceLayer)
+    }
+
+    @Test
+    fun `query asking for more rows than the console limit is executed on the service layer`() {
+        assertTrue(context(maxCount = FlexibleSearchExecConstants.Limits.HAC_MAX_COUNT + 1).executableOnServiceLayer)
+    }
+
+    @Test
+    fun `raw SQL is never executed on the service layer`() {
+        assertFalse(context(maxCount = 1_000, queryMode = QueryMode.SQL).executableOnServiceLayer)
+    }
+
+    @Test
+    fun `query carrying a triple quote is never executed on the service layer`() {
+        assertFalse(context(content = "SELECT {pk} FROM {Product} WHERE {code} = '''x'''", maxCount = 1_000).executableOnServiceLayer)
+    }
+}


### PR DESCRIPTION
Follow up of #2000, which reports the row count and the reached `maxCount` limit, addressing the root cause
suggested there:

> if FlexibleSearch query expects > 200 results, execute it via Groovy. It will be not only for AI, but also
> for execution from the editor.

### Solution

A query asking for more rows than the console limit is executed on the Service Layer via Groovy. The decision
is made by `FlexibleSearchExecClient` itself, therefore it applies to the execution from the editor as well as
to the MCP tools, without a change in either of them.

The Service Layer result carries no column names, hence the very same query is first executed on the HAC
limited to a single row and its headers are reused, also as the number of the columns of the generated script.
The rows are converted back into the ordinary result of the client, keeping the output table and every consumer
unchanged.

The script executes the query in a local view of the session with the locale applied and, when requested, as
the given user, so the search restrictions of that user are respected as they are by the console.

Stays on the HAC:
- raw SQL, which the Service Layer execution does not support;
- a query carrying a triple quote, which cannot be injected into the script;
- a query against a non-default data source, see the open questions below.

### Verification

- `:flexibleSearch-exec:test` — 6 unit tests of the execution routing
- Executed against a remote instance, from the MCP tools and from the editor:

| Case | Result |
|---|---|
| `maxCount` of 200 / 201 / 1000 | 200 / 201 / 338 rows, threshold as expected |
| single and multi column query | rows of both execution paths are identical within the console limit |
| localized attribute, `en` vs `de` | 219 vs 0 rows, identical on both execution paths |
| unknown user | reported as `UnknownIdentifierException` instead of being ignored |
| non-default data source | falls back to the HAC |
| query carrying a triple quote | falls back to the HAC |

### Open questions

1. The console returned all 338 rows of a query with a `maxCount` of 1000 on the instances I have access to,
   so I could not reproduce a hard limit of 200 rows. If the limit is enforced by a configuration I am not
   aware of, the trigger should probably be derived from it instead of the constant of the Plugin.
2. The data source of the execution context is the only setting the script does not honour, as none of the
   instances I have access to defines an alternative data source, hence I could not test activating one.
   Falling back to the HAC keeps the results correct, but a query against another data source is still capped.
3. The console silently ignores an unknown user, the script reports it. I kept the explicit failure, happy to
   align with the console if the lenient behaviour is preferred.

Signed-off-by: Flaviu Lupoian <lupoianflaviu@gmail.com>
